### PR TITLE
Validate sale price field to only include numbers

### DIFF
--- a/src/elm/Page/Shop/Editor.elm
+++ b/src/elm/Page/Shop/Editor.elm
@@ -712,7 +712,7 @@ update msg model loggedIn =
             model
                 |> updateForm
                     (\form ->
-                        { form | price = updateInput value form.price }
+                        { form | price = updateInput (getNumericValues value) form.price }
                     )
                 |> UR.init
 
@@ -1146,6 +1146,15 @@ encodeUpdateForm sale form =
         , ( "track_stock", trackStock )
         , ( "units", units )
         ]
+
+
+getNumericValues : String -> String
+getNumericValues value =
+    value
+        |> String.toList
+        |> List.filter (\x -> Char.isDigit x)
+        |> List.map String.fromChar
+        |> String.join ""
 
 
 encodeDeleteForm : Sale -> Value

--- a/src/elm/Page/Shop/Editor.elm
+++ b/src/elm/Page/Shop/Editor.elm
@@ -1152,7 +1152,7 @@ getNumericValues : String -> String
 getNumericValues value =
     value
         |> String.toList
-        |> List.filter (\x -> Char.isDigit x)
+        |> List.filter Char.isDigit
         |> List.map String.fromChar
         |> String.join ""
 


### PR DESCRIPTION
Closes #137 

Before updating the model we check every character in the sale price and filter out the non-digit ones.