### PR TITLE
Restrict profile bio length (#156)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,8 @@ ideaelm
 jim/
 yarn-error.log
 
+# VSCode files/folders
+.devcontainer*
+
 # Ignore build stylesheet
 src/styles/processed.css

--- a/public/translations/cat-CAT.json
+++ b/public/translations/cat-CAT.json
@@ -37,6 +37,9 @@
     "my_account": "Meu compte",
     "languages": "Idiomes"
   },
+  "edit": {
+    "input_counter": "{{current}} de {{max}}"
+  },
   "error": {
     "validator": {
       "number": {

--- a/public/translations/en-US.json
+++ b/public/translations/en-US.json
@@ -37,6 +37,9 @@
     "my_account": "My account",
     "languages": "Languages"
   },
+  "edit": {
+    "input_counter": "{{current}} of {{max}}"
+  },
   "error": {
     "validator": {
       "number": {

--- a/public/translations/es-ES.json
+++ b/public/translations/es-ES.json
@@ -37,6 +37,9 @@
     "my_account": "Mi cuenta",
     "languages": "Idiomas"
   },
+  "edit": {
+    "input_counter": "{{current}} de {{max}}"
+  },
   "error": {
     "validator": {
       "number": {

--- a/public/translations/pt-BR.json
+++ b/public/translations/pt-BR.json
@@ -37,6 +37,9 @@
     "my_account": "Minha conta",
     "languages": "Linguagens"
   },
+  "edit": {
+    "input_counter": "{{current}} de {{max}}"
+  },
   "error": {
     "validator": {
       "number": {

--- a/src/elm/Page/Profile.elm
+++ b/src/elm/Page/Profile.elm
@@ -279,6 +279,9 @@ viewForm loggedIn isDisabled profile avatarS form =
         text_ s =
             text (t loggedIn.shared.translations s)
 
+        textr_ s m =
+            text (I18Next.tr loggedIn.shared.translations I18Next.Curly s m)
+
         plcH s =
             placeholder (t loggedIn.shared.translations s)
     in
@@ -330,9 +333,18 @@ viewForm loggedIn isDisabled profile avatarS form =
                                 , value form.bio
                                 , disabled isDisabled
                                 , plcH "profile.edit.placeholders.bio"
+                                , maxlength 255
                                 ]
                                 []
                             , viewFieldError "bio" form.errors
+                            ]
+                        , div [ class "input-counter" ]
+                            [ textr_ "edit.input_counter"
+                                [ ( "current"
+                                  , ( String.fromInt (String.length form.bio) )
+                                  )
+                                , ( "max", "255" )
+                                ]
                             ]
                         ]
                     ]

--- a/src/styles/legacy_main.css
+++ b/src/styles/legacy_main.css
@@ -3778,14 +3778,6 @@ textarea.form-input {
     font-size: 20px;
 }
 
-.input-counter {
-    margin-top: 5px;
-    color: #9B4198;
-    font-weight: bold;
-    text-transform: uppercase;
-    text-align: right;
-}
-
 .input-symbol {
     font-size: 20px !important;
     letter-spacing: 5px;

--- a/src/styles/legacy_main.css
+++ b/src/styles/legacy_main.css
@@ -3778,6 +3778,14 @@ textarea.form-input {
     font-size: 20px;
 }
 
+.input-counter {
+    margin-top: 5px;
+    color: #9B4198;
+    font-weight: bold;
+    text-transform: uppercase;
+    text-align: right;
+}
+
 .input-symbol {
     font-size: 20px !important;
     letter-spacing: 5px;

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -105,6 +105,10 @@
     @apply form-input h-12;
 }
 
+.input-counter {
+    @apply text-purple-100 uppercase font-bold float-right mt-1;
+}
+
 .input-label {
     @apply text-green text-caption uppercase font-sans
 }


### PR DESCRIPTION
# Solution performed

- [x] Add a counter below the textarea, according to the guidelines from [design](https://www.figma.com/file/vqHVOvugUksHKlhJvNfaFq/LoginCreateAccount-desk?node-id=1%3A17378).

  - Add a generic translation. Id: `edit.input_counter`
  - Add a generic CSS style. Class: `input-counter`
  - Add `textr_` function helper to translate with non-static data

- [x] Restrict the maximum input length to `255`.

## Screenshots

![cambiatus_frontend_156_input](https://user-images.githubusercontent.com/4184861/75711420-26e32100-5ca5-11ea-8b9f-11a7b9b96746.png)
> Input length: 4

![cambiatus_frontend_156_input_full](https://user-images.githubusercontent.com/4184861/75711423-277bb780-5ca5-11ea-945a-89082d113f4a.png)
> Input length: 255

![cambiatus_frontend_156_window](https://user-images.githubusercontent.com/4184861/75711426-28144e00-5ca5-11ea-84af-867411d8e015.png)
> Profile update page