### PR TITLE
Normalize account name into a lowercase string for registration

### DIFF
--- a/src/elm/Page/Register.elm
+++ b/src/elm/Page/Register.elm
@@ -962,7 +962,7 @@ updateForm msg shared ({ form } as model) =
                     fieldProbs accountValidator str
 
                 newForm =
-                    { form | account = str }
+                    { form | account = str |> String.toLower }
             in
             { model
                 | form = newForm


### PR DESCRIPTION
## What issue does this PR close
Closes #107 

## Changes Proposed ( a list of new changes introduced by this PR)
- [x] Account names are normalized to lower case characters 


## How to test ( a list of instructions on how to test this PR)
- Open the application 
- Try to register a new account ( make sure to include some upper case characters in your account name)
- When your registration is done, check that the account name is in all lower case 
