### PR TITLE
Added confirmation modal before deleting product (#132)

### DIFF
--- a/public/translations/cat-CAT.json
+++ b/public/translations/cat-CAT.json
@@ -448,6 +448,13 @@
       "memo_label": "Comentaris (opcional)",
       "default_memo": "Gràcies per la teva ajuda",
       "submit": "Compra ara"
+    },
+    "delete": "Eliminar",
+    "delete_modal": {
+      "title": "Eliminar",
+      "body": "Estàs segur de que vols eliminar aquest ítem?",
+      "confirm": "Si",
+      "cancel": "No"
     }
   },
   "dashboard": {

--- a/public/translations/en-US.json
+++ b/public/translations/en-US.json
@@ -446,6 +446,13 @@
       "memo_label": "Comments (optional)",
       "default_memo": "Thanks for the help!",
       "submit": "Buy"
+    },
+    "delete": "Delete",
+    "delete_modal": {
+      "title": "Delete",
+      "body": "Are you sure you want to delete this item?",
+      "confirm": "Yes",
+      "cancel": "No"
     }
   },
   "dashboard": {

--- a/public/translations/es-ES.json
+++ b/public/translations/es-ES.json
@@ -279,8 +279,8 @@
       "action_count": "{{actions}} acciones",
       "editor": {
         "not_found": "No encontrado",
-        "error": "Huy! Algo salió mal",
-        "description_label": "Cual es tu objetivo?",
+        "error": "¡Huy! Algo salió mal",
+        "description_label": "¿Cual es tu objetivo?",
         "description_placeholder": "Define un objetivo que atienda el problema que enfrenta tu comunidad.",
         "submit": "Salvar"
       }
@@ -420,7 +420,7 @@
     "rate_sale": "Clasificación",
     "messages": "Mensajes",
     "no_answer_yet": "Sin respuesta aun",
-    "message_placeholder": "Escribe tu mensaje aqui o envia un mensaje directo usando Whatsapp o chat.",
+    "message_placeholder": "Escribe tu mensaje aqui o envía un mensaje directo usando Whatsapp o chat.",
     "create_offer": "Crear oferta",
     "edit_offer": "Editar oferta",
     "unauthorized": "No tienes autorización para editar esta venta",
@@ -447,6 +447,13 @@
       "memo_label": "Comentarios (opcional)",
       "default_memo": "Gracias por tu ayuda",
       "submit": "Comprar"
+    },
+    "delete": "Eliminar",
+    "delete_modal": {
+      "title": "Eliminar",
+      "body": "¿Estás seguro de que quieres eliminar este item?",
+      "confirm": "Sí",
+      "cancel": "No"
     }
   },
   "dashboard": {
@@ -507,8 +514,8 @@
   },
   "transfer_result": {
     "title": "Transferida",
-    "transfer_success": "Transferencia exitosa!",
-    "receive_success": "Recibido con éxito!",
+    "transfer_success": "¡Transferencia exitosa!",
+    "receive_success": "¡Recibido con éxito!",
     "date": "Fecha",
     "message": "Mensaje",
     "community": "Comunidad",

--- a/public/translations/pt-BR.json
+++ b/public/translations/pt-BR.json
@@ -450,6 +450,13 @@
       "memo_label": "Comentários (opcional)",
       "default_memo": "Obrigado pela ajuda!",
       "submit": "Comprar"
+    },
+    "delete": "Excluir",
+    "delete_modal": {
+      "title": "Excluir",
+      "body": "Tem certeza de que deseja excluir este item?",
+      "confirm": "Sim",
+      "cancel": "No"
     }
   },
   "dashboard": {

--- a/public/translations/pt-BR.json
+++ b/public/translations/pt-BR.json
@@ -456,7 +456,7 @@
       "title": "Excluir",
       "body": "Tem certeza de que deseja excluir este item?",
       "confirm": "Sim",
-      "cancel": "No"
+      "cancel": "Não"
     }
   },
   "dashboard": {

--- a/src/elm/Page/Shop/Editor.elm
+++ b/src/elm/Page/Shop/Editor.elm
@@ -478,7 +478,7 @@ viewConfirmDeleteModal t =
                     [ text (t "shop.delete_modal.body") ]
                 ]
             , div [ class "w-full md:bg-gray-100 md:flex md:absolute rounded-b-lg md:inset-x-0 md:bottom-0 md:p-4 justify-center" ]
-                [ div [ class "flex" ]
+                [ div [ class "md:flex" ]
                     [ button
                         [ class "flex-1 block button button-secondary mb-4 button-lg w-full md:w-40 md:mb-0"
                         , onClick ClickedDeleteCancel

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -165,12 +165,12 @@
 }
 
 .modal-content {
-    @apply bg-white bottom-0 right-0 left-0 fixed rounded-lg p-4;
+    @apply bg-white bottom-0 right-0 left-0 fixed rounded-t-lg p-4;
 }
 
 @screen md {
     .modal-content {
-        @apply max-w-3xl fixed top-modal mx-auto h-64;
+        @apply max-w-3xl fixed top-modal mx-auto h-64 rounded-lg;
     }
 }
 


### PR DESCRIPTION
## What issue does this PR close
Closes #132

## Changes Proposed ( a list of new changes introduced by this PR)

Adds a confirmation modal before deleting a product as proposed by the feature request.

Code-wise...

 - Used the same modal markup from the invitations.
 - Added 2 new Msg, ClickedDeleteConfirm (which replaced the old ClickedDelete, which nows just opens the modal), and ClickedDeleteCancel.
 - Added an additional type on EditingUpdate status to handle the deletion modal being opened or not.

## How to test ( a list of instructions on how to test this PR)

1. Open dashboard
2. Click on "SHOP" tab
3. Click "My offers"
4. If no offer is available create an offer first by clicking on "Create offer"
5. Click the offer you want to delete
6. Click on "Edit my offer"
7. Click "Delete"

Modal should show up.

- Clicking "No", the "X" on the corner, or outside the modal, should close the modal and cancel the deletion.
- Clicking "Yes" should go ahead with the deletion
  - If you aren't logged in, it should show you another modal to input your PIN, and then go ahead with the deletion
  - After deleted it should redirect you back to the shop

@lucca65 

