### PR TITLE
Add validation for manual verification

### DIFF
--- a/public/translations/cat-CAT.json
+++ b/public/translations/cat-CAT.json
@@ -47,6 +47,7 @@
         "negative": "El nombre ha de ser negatiu",
         "greater_than": "El nombre ha de ser superior a {{base}}",
         "greater_than_or_equal": "El nombre ha de ser major o igual a {{base}}",
+        "length_greater_than_or_equal": "Trieu almenys {{count}} elements",
         "lower_than": "El nombre ha de ser inferior a {{base}}",
         "lower_than_or_equal": "El nombre ha de ser inferior o igual a {{base}}"
       },
@@ -325,6 +326,7 @@
         "validation_on_detail": "l'acció estarà disponible fins a una data, quantitat o totes dues coses",
         "verification_label": "Necessita verificació?",
         "verifiers_label": "Trieu els verificadors",
+        "verifiers_label_count": "Trieu almenys {{count}} verificadors",
         "remove_verifier": "Elimina",
         "verifiers_reward_label": "Recompensa per als verificadors",
         "votes_label": "Nombre mínim de vots",

--- a/public/translations/en-US.json
+++ b/public/translations/en-US.json
@@ -47,6 +47,7 @@
         "negative": "The number must be negative",
         "greater_than": "The number must be greater than {{base}}",
         "greater_than_or_equal": "The number must be greater than or equal to {{base}}",
+        "length_greater_than_or_equal": "Choose at least {{count}} items",
         "lower_than": "The number must be lower than {{base}}",
         "lower_than_or_equal": "The number must be lower than or equal to {{base}}"
       },
@@ -323,6 +324,7 @@
         "validation_on_detail": "the action will be available until a date, quantity or both",
         "verification_label": "Does it need verification?",
         "verifiers_label": "Choose the verifiers",
+        "verifiers_label_count": "Choose at least {{count}} verifiers",
         "remove_verifier": "Remove",
         "verifiers_reward_label": "Reward for verifiers",
         "votes_label": "Minimum number of votes",

--- a/public/translations/es-ES.json
+++ b/public/translations/es-ES.json
@@ -47,6 +47,7 @@
         "negative": "El número debe ser negativo",
         "greater_than": "El número debe ser mayor que {{base}}",
         "greater_than_or_equal": "El número debe ser mayor o igual que {{base}}",
+        "length_greater_than_or_equal": "Elige al menos {{count}} artículos",
         "lower_than": "El número debe ser inferior a {{base}}",
         "lower_than_or_equal": "El número debe ser inferior o igual a {{base}}"
       },
@@ -324,6 +325,7 @@
         "validation_on_detail": "la acción estará disponible hasta una fecha, cantidad o ambas",
         "verification_label": "¿Necesita verificación?",
         "verifiers_label": "Elige los verificadores",
+        "verifiers_label_count": "Elija al menos {{count}} verificadores",
         "remove_verifier": "retirar",
         "verifiers_reward_label": "Recompensa por verificadores",
         "votes_label": "Numero minimo de votos",

--- a/public/translations/pt-BR.json
+++ b/public/translations/pt-BR.json
@@ -47,6 +47,7 @@
         "negative": "O número deve ser negativo",
         "greater_than": "O número deve ser maior do que {{base}}",
         "greater_than_or_equal": "O número deve ser maior ou igual a {{base}}",
+        "length_greater_than_or_equal": "Escolha ao menos {{count}} itens",
         "lower_than": "O número deve ser menor do que {{base}}",
         "lower_than_or_equal": "O número deve ser menor ou igual a {{base}}"
       },
@@ -327,6 +328,7 @@
         "validation_on_detail": "a ação estará disponível até uma data, quantidade ou ambos",
         "verification_label": "Precisa de verificação?",
         "verifiers_label": "Escolha os verificadores",
+        "verifiers_label_count": "Escolha ao menos {{count}} verificadores",
         "remove_verifier": "Remover",
         "verifiers_reward_label": "Recompensa para verificadores",
         "votes_label": "Número mínimo de votos",

--- a/src/elm/DataValidator.elm
+++ b/src/elm/DataValidator.elm
@@ -7,6 +7,7 @@ module DataValidator exposing
     , greaterThan
     , greaterThanOrEqual
     , hasErrors
+    , lengthGreaterThanOrEqual
     , listErrors
     , longerThan
     , lowerThan
@@ -216,6 +217,18 @@ greaterThanOrEqual base constraints =
     , defaultError =
         \translations ->
             I18Next.tr translations I18Next.Curly (numTranslation "greater_than_or_equal") [ ( "base", String.fromFloat base ) ]
+    }
+        :: constraints
+
+
+lengthGreaterThanOrEqual : Int -> List Constraint -> List Constraint
+lengthGreaterThanOrEqual count constraints =
+    { test =
+        \v ->
+            Maybe.withDefault 0 (String.toInt v) >= count
+    , defaultError =
+        \translations ->
+            I18Next.tr translations I18Next.Curly (numTranslation "length_greater_than_or_equal") [ ( "count", String.fromInt count ) ]
     }
         :: constraints
 

--- a/src/elm/Page/Community/ActionEditor.elm
+++ b/src/elm/Page/Community/ActionEditor.elm
@@ -22,6 +22,7 @@ import DataValidator
         , greaterThan
         , greaterThanOrEqual
         , hasErrors
+        , lengthGreaterThanOrEqual
         , listErrors
         , longerThan
         , newValidator
@@ -115,7 +116,7 @@ type ActionValidation
 
 type Verification
     = Automatic
-    | Manual (List Profile) (Validator String) (Validator String) -- Manual: users list, verification reward and min votes
+    | Manual (Validator (List Profile)) (Validator String) (Validator String) -- Manual: users list, verification reward and min votes
 
 
 type SaveStatus
@@ -195,9 +196,14 @@ editForm form action =
                 Automatic
 
             else
-                Manual verificators
+                let
+                    newVerifications =
+                        defaultMinVotes |> updateInput (String.fromInt action.verifications)
+                in
+                Manual
+                    (defaultVerifiersValidator verificators (getInput newVerifications) |> updateInput verificators)
                     (defaultVerificationReward |> updateInput (String.fromFloat action.verificationReward))
-                    (defaultMinVotes |> updateInput (String.fromInt action.verifications))
+                    newVerifications
     in
     { form
         | description = updateInput action.description form.description
@@ -236,6 +242,26 @@ defaultUsagesValidator =
         |> newValidator "" (\s -> Just s) True
 
 
+defaultVerifiersValidator : List Profile -> String -> Validator (List Profile)
+defaultVerifiersValidator verifiers minVerifiersQty =
+    let
+        limit =
+            case String.toInt minVerifiersQty of
+                Just m ->
+                    if m < minVotesLimit then
+                        minVotesLimit
+
+                    else
+                        m
+
+                Nothing ->
+                    minVotesLimit
+    in
+    []
+        |> lengthGreaterThanOrEqual limit
+        |> newValidator verifiers (\s -> Just (String.fromInt (List.length s))) True
+
+
 defaultUsagesLeftValidator : Validator String
 defaultUsagesLeftValidator =
     []
@@ -250,11 +276,16 @@ defaultVerificationReward =
         |> newValidator "0" (\s -> Just s) True
 
 
+minVotesLimit : Int
+minVotesLimit =
+    2
+
+
 defaultMinVotes : Validator String
 defaultMinVotes =
     []
-        |> greaterThanOrEqual 2
-        |> newValidator "2" (\s -> Just s) True
+        |> greaterThanOrEqual (toFloat minVotesLimit)
+        |> newValidator (String.fromInt minVotesLimit) (\s -> Just s) True
 
 
 validateForm : Form -> Form
@@ -283,7 +314,7 @@ validateForm form =
                     Automatic
 
                 Manual profiles verificationReward minVotes ->
-                    Manual profiles (validate verificationReward) (validate minVotes)
+                    Manual (validate profiles) (validate verificationReward) (validate minVotes)
     in
     { form
         | description = validate form.description
@@ -295,8 +326,21 @@ validateForm form =
 
 isFormValid : Form -> Bool
 isFormValid form =
+    let
+        verificationHasErrors =
+            case form.verification of
+                Manual profiles verificationReward minVotes ->
+                    hasErrors minVotes
+                        || hasErrors profiles
+                        || hasErrors verificationReward
+
+                Automatic ->
+                    -- Automatic verification never has validation errors
+                    False
+    in
     hasErrors form.description
         || hasErrors form.reward
+        || verificationHasErrors
         |> not
 
 
@@ -472,11 +516,14 @@ update msg model loggedIn =
                         | form =
                             { oldForm
                                 | verification =
+                                    let
+                                        newVerifiers =
+                                            maybeProfile
+                                                |> Maybe.map (List.singleton >> List.append (getInput selectedVerifiers))
+                                                |> Maybe.withDefault (getInput selectedVerifiers)
+                                    in
                                     Manual
-                                        (maybeProfile
-                                            |> Maybe.map (List.singleton >> List.append selectedVerifiers)
-                                            |> Maybe.withDefault selectedVerifiers
-                                        )
+                                        (updateInput newVerifiers selectedVerifiers)
                                         verificationReward
                                         minVotes
                             }
@@ -494,11 +541,14 @@ update msg model loggedIn =
                             model.form.verification
 
                         Manual selectedVerifiers a b ->
+                            let
+                                newVerifiers =
+                                    List.filter
+                                        (\currVerifier -> currVerifier.account /= profile.account)
+                                        (getInput selectedVerifiers)
+                            in
                             Manual
-                                (List.filter
-                                    (\currVerifier -> currVerifier.account /= profile.account)
-                                    selectedVerifiers
-                                )
+                                (updateInput newVerifiers selectedVerifiers)
                                 a
                                 b
             in
@@ -625,7 +675,15 @@ update msg model loggedIn =
                         |> UR.logImpossible msg []
 
                 Manual listProfile verifierReward minVotes ->
-                    { model | form = { oldForm | verification = Manual listProfile verifierReward (updateInput val minVotes) } }
+                    let
+                        newMinVotes =
+                            updateInput val minVotes
+
+                        newVerifiers =
+                            -- Update min. verifiers quantity
+                            defaultVerifiersValidator (getInput listProfile) val
+                    in
+                    { model | form = { oldForm | verification = Manual newVerifiers verifierReward newMinVotes } }
                         |> UR.init
 
         ValidateForm ->
@@ -788,7 +846,7 @@ update msg model loggedIn =
                                 Automatic
 
                             else
-                                Manual [] defaultVerificationReward defaultMinVotes
+                                Manual (defaultVerifiersValidator [] (getInput defaultMinVotes)) defaultVerificationReward defaultMinVotes
                     }
             }
                 |> UR.init
@@ -956,7 +1014,7 @@ upsertAction loggedIn model isoDate =
                     []
 
                 Manual list _ _ ->
-                    list
+                    getInput list
 
         validatorsStr =
             validators
@@ -1367,6 +1425,9 @@ viewManualVerificationForm ({ shared } as loggedIn) model community =
     let
         text_ s =
             text (t shared.translations s)
+
+        tr r_id replaces =
+            I18Next.tr shared.translations I18Next.Curly r_id replaces
     in
     case model.form.verification of
         Automatic ->
@@ -1375,10 +1436,11 @@ viewManualVerificationForm ({ shared } as loggedIn) model community =
         Manual selectedVerifiers verificationReward minVotes ->
             div [ class "w-2/5" ]
                 [ span [ class "input-label" ]
-                    [ text_ "community.actions.form.verifiers_label" ]
+                    [ text (tr "community.actions.form.verifiers_label_count" [ ( "count", getInput minVotes ) ]) ]
                 , div []
                     [ viewVerifierSelect shared model False
-                    , viewSelectedVerifiers loggedIn selectedVerifiers
+                    , viewFieldErrors (listErrors shared.translations selectedVerifiers)
+                    , viewSelectedVerifiers loggedIn (getInput selectedVerifiers)
                     ]
                 , span [ class "input-label" ]
                     [ text_ "community.actions.form.verifiers_reward_label" ]
@@ -1529,7 +1591,7 @@ viewVerifierSelect shared model isDisabled =
                     (Select.view (selectConfig shared isDisabled)
                         model.multiSelectState
                         users
-                        selectedUsers
+                        (getInput selectedUsers)
                     )
                 ]
 


### PR DESCRIPTION
## What issue does this PR close
Closes #85 

## Changes Proposed ( a list of new changes introduced by this PR)
- add validation function for the list length (>= a given value);
- wrap `List Profile` (verifiers) in `Validation` type and check that length of this list is >= than min. number of votes.

## How to test ( a list of instructions on how to test this PR)
1. Create new or edit existing Action.
2. Select "Manual" verification.
3. Press "Create"/"Edit" button with no verifiers selected of with number of verifiers less than min. number of votes.
4. There should be an error like this:
    ![image](https://user-images.githubusercontent.com/140053/78260507-b5e29380-7506-11ea-8dda-0365c6542ac4.png)


Also works for other min. numbers of votes:
![image](https://user-images.githubusercontent.com/140053/78260713-f0e4c700-7506-11ea-8ef8-b64e25718d70.png)


