### PR TITLE
Fix Incorrect message when PIN is incorrect

### DIFF
--- a/public/translations/cat-CAT.json
+++ b/public/translations/cat-CAT.json
@@ -79,7 +79,8 @@
     "chooseOrUploadLogo": "Escull o puja el teu propi logotip.",
     "invalidSymbol": "Símbol invàlid.",
     "unknown": "Oh oh. Alguna cosa ha anat malament.",
-    "accountNotFound": "Compte no trobat. Esteu segur que heu creat el vostre compte?"
+    "accountNotFound": "Compte no trobat. Esteu segur que heu creat el vostre compte?",
+    "invalidPin": "PIN invàlid."
   },
   "auth": {
     "title": "Utilitzeu la vostra clau privada i el PIN o connecteu-vos per",

--- a/public/translations/en-US.json
+++ b/public/translations/en-US.json
@@ -79,7 +79,8 @@
     "chooseOrUploadLogo": "Choose or upload a logo.",
     "invalidSymbol": "Invalid symbol.",
     "unknown": "Uoh. Something wrong happened.",
-    "accountNotFound": "Account not found. Are you sure you created your account?"
+    "accountNotFound": "Account not found. Are you sure you created your account?",
+    "invalidPin": "Invalid PIN."
   },
   "auth": {
     "title": "Use your private key and PIN or log in by",

--- a/public/translations/es-ES.json
+++ b/public/translations/es-ES.json
@@ -79,7 +79,8 @@
     "chooseOrUploadLogo": "Escoje o sube tu propio logo.",
     "invalidSymbol": "Simbolo invalido.",
     "unknown": "Oh oh. Algo salió mal.",
-    "accountNotFound": "Cuenta no encontrada. ¿Estás seguro de haber creado tu cuenta?"
+    "accountNotFound": "Cuenta no encontrada. ¿Estás seguro de haber creado tu cuenta?",
+    "invalidPin": "PIN invalido."
   },
   "auth": {
     "title": "Use su clave privada y PIN o inicie sesión por",

--- a/public/translations/pt-BR.json
+++ b/public/translations/pt-BR.json
@@ -79,7 +79,8 @@
     "chooseOrUploadLogo": "Escolha ou envie um logo.",
     "invalidSymbol": "Simbolo inválido.",
     "unknown": "Opa. Algo de errado aconteceu =(.",
-    "accountNotFound": "Conta não encontrada. Tem certeza que criou uma conta com essa chave?"
+    "accountNotFound": "Conta não encontrada. Tem certeza que criou uma conta com essa chave?",
+    "invalidPin": "PIN inválido."
   },
   "auth": {
     "title": "Use sua chave privada e PIN ou faça o login",

--- a/src/elm/Auth.elm
+++ b/src/elm/Auth.elm
@@ -381,7 +381,7 @@ viewAuthError shared maybeLoginError =
 
         Just error ->
             div [ class "bg-red border-lg rounded p-4 mt-2" ]
-                [ p [ class "text-white" ] [ text (t shared.translations "error.accountNotFound") ]
+                [ p [ class "text-white" ] [ text (t shared.translations "error.invalidPin") ]
                 ]
 
 


### PR DESCRIPTION
## What issue does this PR close
Closes #210 

## Changes Proposed ( a list of new changes introduced by this PR)
  - Creates a new string: "invalidPin"
  - Adds this string to all supported languages 
  - Replaces the wrong string (accountNotFound) for the new one, on the Auth.elm file

## How to test ( a list of instructions on how to test this PR)
  - Go to Transfer
  - Fill in all the fields
  - When the app ask for your PIN, use a wrong one
  - It should show the message: Incorrect PIN
