### PR TITLE
Adjust dashboard to show "empty analisys screen"

### DIFF
--- a/src/elm/Cambiatus/InputObject.elm
+++ b/src/elm/Cambiatus/InputObject.elm
@@ -368,15 +368,16 @@ buildSalesInput fillOptionals =
     let
         optionals =
             fillOptionals
-                { account = Absent, all = Absent, communities = Absent }
+                { account = Absent, all = Absent, communities = Absent, communityId = Absent }
     in
-    { account = optionals.account, all = optionals.all, communities = optionals.communities }
+    { account = optionals.account, all = optionals.all, communities = optionals.communities, communityId = optionals.communityId }
 
 
 type alias SalesInputOptionalFields =
     { account : OptionalArgument String
     , all : OptionalArgument String
     , communities : OptionalArgument String
+    , communityId : OptionalArgument String
     }
 
 
@@ -386,6 +387,7 @@ type alias SalesInput =
     { account : OptionalArgument String
     , all : OptionalArgument String
     , communities : OptionalArgument String
+    , communityId : OptionalArgument String
     }
 
 
@@ -394,7 +396,7 @@ type alias SalesInput =
 encodeSalesInput : SalesInput -> Value
 encodeSalesInput input =
     Encode.maybeObject
-        [ ( "account", Encode.string |> Encode.optional input.account ), ( "all", Encode.string |> Encode.optional input.all ), ( "communities", Encode.string |> Encode.optional input.communities ) ]
+        [ ( "account", Encode.string |> Encode.optional input.account ), ( "all", Encode.string |> Encode.optional input.all ), ( "communities", Encode.string |> Encode.optional input.communities ), ( "communityId", Encode.string |> Encode.optional input.communityId ) ]
 
 
 buildTransferInput : TransferInputRequiredFields -> TransferInput

--- a/src/elm/Cambiatus/Object/Profile.elm
+++ b/src/elm/Cambiatus/Object/Profile.elm
@@ -24,6 +24,11 @@ account =
     Object.selectionForField "String" "account" [] Decode.string
 
 
+analysisCount : SelectionSet Int Cambiatus.Object.Profile
+analysisCount =
+    Object.selectionForField "Int" "analysisCount" [] Decode.int
+
+
 avatar : SelectionSet (Maybe String) Cambiatus.Object.Profile
 avatar =
     Object.selectionForField "(Maybe String)" "avatar" [] (Decode.string |> Decode.nullable)

--- a/src/elm/Page/Dashboard.elm
+++ b/src/elm/Page/Dashboard.elm
@@ -159,7 +159,7 @@ view loggedIn model =
                         ]
                     ]
                 , viewBalance loggedIn model balance
-                , viewAnalysisList loggedIn model
+                , viewAnalysisList loggedIn profile model
                 , viewTransfers loggedIn model
                 , viewAnalysisModal loggedIn model
                 , viewInvitationModal loggedIn model
@@ -305,8 +305,8 @@ viewInvitationModal { shared } model =
                 ]
 
 
-viewAnalysisList : LoggedIn.Model -> Model -> Html Msg
-viewAnalysisList loggedIn model =
+viewAnalysisList : LoggedIn.Model -> Profile.Profile -> Model -> Html Msg
+viewAnalysisList loggedIn profile model =
     let
         text_ s =
             text (I18Next.t loggedIn.shared.translations s)
@@ -329,34 +329,30 @@ viewAnalysisList loggedIn model =
             Page.fullPageLoading
 
         LoadedGraphql claims ->
-            if not (List.isEmpty claims) then
-                div [ class "w-full flex" ]
-                    [ div
-                        [ class "w-full" ]
-                        [ div [ class "text-gray-600 text-2xl font-light flex mt-4 mb-4" ]
-                            [ div [ class "text-indigo-500 mr-2 font-medium" ]
-                                [ text_ "dashboard.analysis.title.1"
-                                ]
-                            , text_ "dashboard.analysis.title.2"
+            div [ class "w-full flex" ]
+                [ div
+                    [ class "w-full" ]
+                    [ div [ class "text-gray-600 text-2xl font-light flex mt-4 mb-4" ]
+                        [ div [ class "text-indigo-500 mr-2 font-medium" ]
+                            [ text_ "dashboard.analysis.title.1"
                             ]
-                        , if isVoted claims then
-                            div [ class "flex flex-col w-full h-64 items-center justify-center px-3 py-12 my-2 rounded-lg bg-white" ]
-                                [ img [ src "/images/not_found.svg", class "object-contain h-32 mb-3" ] []
-                                , p [ class "flex text-body text-gray" ]
-                                    [ p [ class "font-bold" ] [ text_ "dashboard.analysis.empty.1" ]
-                                    , text_ "dashboard.analysis.empty.2"
-                                    ]
-                                , p [ class "text-body text-gray" ] [ text_ "dashboard.analysis.empty.3" ]
-                                ]
-
-                          else
-                            div [ class "flex flex-wrap -mx-2" ]
-                                (List.map (viewAnalysis loggedIn) claims)
+                        , text_ "dashboard.analysis.title.2"
                         ]
-                    ]
+                    , if isVoted claims || profile.analysisCount < 0 then
+                        div [ class "flex flex-col w-full items-center justify-center px-3 py-12 my-2 rounded-lg bg-white" ]
+                            [ img [ src "/images/not_found.svg", class "object-contain h-32 mb-3" ] []
+                            , p [ class "flex text-body text-gray" ]
+                                [ p [ class "font-bold" ] [ text_ "dashboard.analysis.empty.1" ]
+                                , text_ "dashboard.analysis.empty.2"
+                                ]
+                            , p [ class "text-body text-gray" ] [ text_ "dashboard.analysis.empty.3" ]
+                            ]
 
-            else
-                text ""
+                      else
+                        div [ class "flex flex-wrap -mx-2" ]
+                            (List.map (viewAnalysis loggedIn) claims)
+                    ]
+                ]
 
         FailedGraphql err ->
             div [] [ Page.fullPageGraphQLError "Failed load" err ]

--- a/src/elm/Page/Shop.elm
+++ b/src/elm/Page/Shop.elm
@@ -55,7 +55,7 @@ init loggedIn filter =
     ( model
     , Cmd.batch
         [ Api.Graphql.query loggedIn.shared
-            (Shop.salesQuery filter loggedIn.accountName)
+            (Shop.salesQuery filter loggedIn.accountName loggedIn.selectedCommunity)
             CompletedSalesLoad
         , Api.getBalances loggedIn.shared loggedIn.accountName CompletedLoadBalances
         , Task.perform GotTime Time.now
@@ -145,8 +145,6 @@ type ValidationError
     | UnitNotOnlyNumbers
     | MemoEmpty
     | MemoTooLong
-
-
 
 
 
@@ -471,7 +469,7 @@ update msg model loggedIn =
                 UR.init model
 
         TransferSuccess index ->
-            updateCard msg index (\card -> (  card   , [] )) (UR.init model)
+            updateCard msg index (\card -> ( card, [] )) (UR.init model)
 
         ClickedMessages cardIndex creatorId ->
             UR.init model

--- a/src/elm/Profile.elm
+++ b/src/elm/Profile.elm
@@ -42,7 +42,7 @@ import Graphql.SelectionSet as SelectionSet exposing (SelectionSet, with)
 import Html exposing (Html, div, p, span, text)
 import Html.Attributes exposing (class, maxlength, minlength, pattern, title, type_)
 import I18Next exposing (Translations, t)
-import Json.Decode as Decode exposing (Decoder, list, nullable, string)
+import Json.Decode as Decode exposing (Decoder, int, list, nullable, string)
 import Json.Decode.Pipeline as Decode exposing (optional, required)
 import Json.Encode as Encode
 import Select
@@ -67,6 +67,7 @@ type alias Profile =
     , chatToken : Maybe String
     , createdAt : Posix
     , communities : List CommunityInfo
+    , analysisCount : Int
     }
 
 
@@ -100,6 +101,7 @@ selectionSet =
         |> with User.chatToken
         |> SelectionSet.hardcoded (Time.millisToPosix 0)
         |> with (User.communities communityInfoSelectionSet)
+        |> with User.analysisCount
 
 
 communityInfoSelectionSet : SelectionSet CommunityInfo Cambiatus.Object.Community
@@ -125,6 +127,7 @@ decode =
         |> Decode.hardcoded (Time.millisToPosix 0)
         |> Decode.at [ "data", "user" ]
         |> Decode.hardcoded []
+        |> optional "analysisCount" int 0
 
 
 decodeInterests : Decoder (List String)

--- a/src/elm/Shop.elm
+++ b/src/elm/Shop.elm
@@ -130,8 +130,8 @@ saleQuery saleId =
         salesSelection
 
 
-salesQuery : Filter -> Eos.Name -> SelectionSet (List Sale) RootQuery
-salesQuery filter accName =
+salesQuery : Filter -> Eos.Name -> Symbol -> SelectionSet (List Sale) RootQuery
+salesQuery filter accName communityId =
     case filter of
         UserSales ->
             let
@@ -139,7 +139,13 @@ salesQuery filter accName =
                     Eos.nameToString accName
 
                 args =
-                    { input = { account = Present accString, all = Absent, communities = Absent } }
+                    { input =
+                        { account = Present accString
+                        , all = Absent
+                        , communities = Absent
+                        , communityId = Present (Eos.symbolToString communityId)
+                        }
+                    }
             in
             Cambiatus.Query.sales
                 args
@@ -151,7 +157,13 @@ salesQuery filter accName =
                     Eos.nameToString accName
 
                 args =
-                    { input = { account = Absent, all = Present accString, communities = Absent } }
+                    { input =
+                        { account = Absent
+                        , all = Present accString
+                        , communities = Absent
+                        , communityId = Present (Eos.symbolToString communityId)
+                        }
+                    }
             in
             Cambiatus.Query.sales
                 args


### PR DESCRIPTION
## What issue does this PR close
Closes #227

## Changes Proposed ( a list of new changes introduced by this PR)
Show the "girl card" -- the empty state for when a user has analysed at least one claim in the entire user's history

## How to test ( a list of instructions on how to test this PR)
Just open the dashboard with a user that has already analysed a claim. If you want to test how it works for a user that never analysed any claim, just open the dashboard with one of those users

## Additional

Since I had to update graphql schema, one change of the shop GraphQL API was adapted as well, so the project would compile
