### PR TITLE
Improve Debug.log for dev builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "connect-history-api-fallback": "^1.5.0",
     "cosmiconfig": "^5.0.6",
     "dotenv": "^5.0.0",
+    "elm-debug-transformer": "^1.0.4",
     "elm-hot-webpack-loader": "^1.0.2",
     "elm-review": "^2.0.2",
     "eslint": "5.16.0",

--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,37 @@ pdfMake.fonts = {
 }
 const { Socket: PhoenixSocket } = require('phoenix')
 
+// Transform `Debug.log` output into nice log object with custom formatter
+// (snippet is taken from https://github.com/MattCheely/elm-app-gen/blob/master/generators/app/templates/parcel/app.js)
+if (process.env.NODE_ENV === 'development') {
+  const ElmDebugger = require('elm-debug-transformer')
+
+  const hasFormatterSupport = () => {
+    const originalFormatters = window.devtoolsFormatters
+    let supported = false
+
+    window.devtoolsFormatters = [
+      {
+        header: function (obj, config) {
+          supported = true
+          return null
+        },
+        hasBody: function (obj) {},
+        body: function (obj, config) {}
+      }
+    ]
+    console.log('elm-debug-transformer: checking for formatter support.', {})
+    window.devtoolsFormatters = originalFormatters
+    return supported
+  }
+
+  if (hasFormatterSupport()) {
+    ElmDebugger.register()
+  } else {
+    ElmDebugger.register({ simple_mode: true })
+  }
+}
+
 // =========================================
 // App startup
 // =========================================

--- a/yarn.lock
+++ b/yarn.lock
@@ -829,7 +829,7 @@
     lodash "^4.17.11"
     mini-svg-data-uri "^1.0.3"
     traverse "^0.6.6"
-    
+
 "@types/cacheable-request@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/@types/cacheable-request/-/cacheable-request-6.0.1.tgz#5d22f3dded1fd3a84c0bbeb5039a7419c2c91976"
@@ -3648,6 +3648,11 @@ elm-asset-webpack-loader@1.1.1, elm-asset-webpack-loader@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/elm-asset-webpack-loader/-/elm-asset-webpack-loader-1.1.1.tgz#9e8fc05ea89794006c9f873165200f65c6d8ccc0"
   integrity sha512-J+YKLGNCMLSNhxXfQxaJhQzIiTiKQGo8YlZEntTpZjWy3kTqSF/2qAvnRonM2VvfhbKuhg0cKRKVrt9+cC8bmw==
+
+elm-debug-transformer@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/elm-debug-transformer/-/elm-debug-transformer-1.0.4.tgz#fe5f9918bda808d01919a44403bfa98b60e3127c"
+  integrity sha512-Vhr7if7RggkVsHeJPtDu0TzY1nk+uXOJsWY3Tp9IKN0mviFbXS0vsiVHLEJwXmS/B7I6sCjKVulqe2Gne06rAg==
 
 elm-format@^0.8.1:
   version "0.8.2"
@@ -9571,6 +9576,13 @@ resolve@^1.1.7, resolve@^1.10.0, resolve@^1.3.2, resolve@^1.5.0, resolve@^1.6.0,
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.12.0.tgz#3fc644a35c84a48554609ff26ec52b66fa577df6"
   integrity sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==
+  dependencies:
+    path-parse "^1.0.6"
+
+resolve@^1.14.2:
+  version "1.17.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
+  integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==
   dependencies:
     path-parse "^1.0.6"
 


### PR DESCRIPTION
## What issue does this PR close
There is no issue, just this PR.

## Changes Proposed (a list of new changes introduced by this PR)
Add [elm-debug-transformer](https://github.com/kraklin/elm-debug-transformer) package to improve formatting Elm data structures logged with `Debug.log`.

From this:
![](https://raw.githubusercontent.com/kraklin/elm-debug-transformer/master/img/ugly_output.png)

To this:

![](https://raw.githubusercontent.com/kraklin/elm-debug-transformer/master/img/nice_output.png)

Only dev build changed, no effect for a production build.

## How to test (a list of instructions on how to test this PR)
Run `yarn start` and try to `Debug.log` some data structure like `Model`.

Chrome works just perfectly because it supports custom formatters. This option should be enabled in DevTools:
![image](https://user-images.githubusercontent.com/140053/83571127-dc857080-a52f-11ea-88d6-c2228d80893f.png)


FF and others will produce usual JS objects (which is better than just a string produced by `Debug.log`).