### PR TITLE
Do project wide warning cleanup

### DIFF
--- a/src/elm/Community.elm
+++ b/src/elm/Community.elm
@@ -168,7 +168,7 @@ communitiesQuery =
 
 
 type alias NewCommunity =
-    { title : String }
+    String
 
 
 newCommunitySubscription : Symbol -> SelectionSet NewCommunity RootSubscription
@@ -179,8 +179,7 @@ newCommunitySubscription symbol =
                 |> String.toUpper
 
         selectionSet =
-            SelectionSet.succeed NewCommunity
-                |> with Community.name
+            Community.name
 
         args =
             { input = { symbol = stringSymbol } }
@@ -541,7 +540,7 @@ type alias ActionVerification =
 
 
 type alias ActionVerificationsResponse =
-    { claims : List ClaimResponse }
+    List ClaimResponse
 
 
 type alias ClaimResponse =
@@ -553,8 +552,7 @@ type alias ClaimResponse =
 
 
 type alias CheckResponse =
-    { isVerified : Bool
-    }
+    Bool
 
 
 type alias ActionResponse =
@@ -597,8 +595,7 @@ claimSelectionSet validator =
 
 checkSelectionSet : SelectionSet CheckResponse Cambiatus.Object.Check
 checkSelectionSet =
-    SelectionSet.succeed CheckResponse
-        |> with Check.isVerified
+    Check.isVerified
 
 
 verificationActionSelectionSet : SelectionSet ActionResponse Cambiatus.Object.Action
@@ -632,13 +629,13 @@ toVerifications actionVerificationResponse =
     let
         claimsResponse : List ClaimResponse
         claimsResponse =
-            actionVerificationResponse.claims
+            actionVerificationResponse
 
         toStatus : List CheckResponse -> Tag.TagStatus
         toStatus checks =
             case List.head checks of
                 Just check ->
-                    if check.isVerified == True then
+                    if check then
                         Tag.APPROVED
 
                     else

--- a/src/elm/DateDistance.elm
+++ b/src/elm/DateDistance.elm
@@ -12,30 +12,37 @@ module DateDistance exposing (viewDateDistance)
 import Time exposing (Posix)
 
 
+second : Int
 second =
     1000
 
 
+minute : Int
 minute =
     second * 60
 
 
+hour : Int
 hour =
     minute * 60
 
 
+day : Int
 day =
     hour * 24
 
 
+month : Int
 month =
     day * 30
 
 
+year : Int
 year =
     day * 365
 
 
+toS : Int -> String
 toS =
     String.fromInt
 

--- a/src/elm/Eos.elm
+++ b/src/elm/Eos.elm
@@ -1,6 +1,6 @@
 module Eos exposing (Action, Asset, Authorization, EosBool(..), Network, Symbol, TableQuery, Transaction, bespiralSymbol, boolToEosBool, decodeAmountToFloat, decodeAsset, encodeAction, encodeAsset, encodeAuthorization, encodeEosBool, encodeNetwork, encodeSymbol, encodeTableQuery, encodeTransaction, symbolDecoder, symbolFromString, symbolSelectionSet, symbolToString, symbolUrlParser)
 
-import Eos.Account as Account exposing (Account, PermissionName)
+import Eos.Account as Account exposing (PermissionName)
 import Graphql.SelectionSet as SelectionSet exposing (SelectionSet)
 import Json.Decode as Decode exposing (Decoder)
 import Json.Encode as Encode exposing (Value)
@@ -36,19 +36,14 @@ encodeNetwork network =
 
 
 type alias Transaction =
-    { actions : List Action
-    }
-
-
-
--- TODO: you'll receive one authorization for all the actions, just encode each action with the same authorization
+    List Action
 
 
 encodeTransaction : Transaction -> Value
 encodeTransaction transaction =
     Encode.object
         [ ( "name", Encode.string "eosTransaction" )
-        , ( "actions", Encode.list encodeAction transaction.actions )
+        , ( "actions", Encode.list encodeAction transaction )
         ]
 
 

--- a/src/elm/Eos/Account.elm
+++ b/src/elm/Eos/Account.elm
@@ -1,8 +1,8 @@
 module Eos.Account exposing (Account, Name, Permission, PermissionName, PrivateKey, PublicKey, decoder, encodeName, encodePermissionName, encodePrivateKey, encodePublicKey, nameDecoder, nameMaxChars, nameMinChars, nameQueryUrlParser, nameSelectionSet, nameToString, nameValidationAttrs, permissionDecoder, permissionNameDecoder, privateKeyDecoder, privateKeyToString, publicKeyDecoder, publicKeyToString, samplePermission, stringToName, viewName)
 
-import Graphql.SelectionSet as SelectionSet exposing (SelectionSet, with)
+import Graphql.SelectionSet as SelectionSet exposing (SelectionSet)
 import Html exposing (Html)
-import Html.Attributes exposing (autocomplete, maxlength, minlength, pattern, spellcheck, title, type_)
+import Html.Attributes exposing (autocomplete, maxlength, minlength, pattern, spellcheck, title)
 import Json.Decode as Decode exposing (Decoder)
 import Json.Encode as Encode exposing (Value)
 

--- a/src/elm/Icons.elm
+++ b/src/elm/Icons.elm
@@ -1,4 +1,4 @@
-module Icons exposing (..)
+module Icons exposing (alert, arrowDown, back, close, communities, dashboard, exclamation, flag, heart, languages, notification, profile, remove, search, shop, success, thumbDown, thumbUp, trash)
 
 import Html exposing (Html)
 import Svg exposing (Svg, svg)
@@ -125,6 +125,7 @@ flag class_ =
 exclamation : String -> Svg msg
 exclamation class_ =
     svg [ width "24", height "24", viewBox "0 0 24 24", class class_ ] [ Svg.path [ fillRule "evenodd", clipRule "evenodd", d "M12 1.5C6.20101 1.5 1.5 6.20101 1.5 12C1.5 17.799 6.20101 22.5 12 22.5C17.799 22.5 22.5 17.799 22.5 12C22.5 6.20101 17.799 1.5 12 1.5ZM12 21C7.02944 21 3 16.9706 3 12C3 7.02944 7.02944 3 12 3C16.9706 3 21 7.02944 21 12C21 16.9706 16.9706 21 12 21Z", fill "black" ] [], Svg.path [ fillRule "evenodd", clipRule "evenodd", d "M12.25 5.75C11.8358 5.75 11.5 6.08579 11.5 6.5V13.5C11.5 13.9142 11.8358 14.25 12.25 14.25C12.6642 14.25 13 13.9142 13 13.5V6.5C13 6.08579 12.6642 5.75 12.25 5.75Z", fill "black" ] [], Svg.path [ fillRule "evenodd", clipRule "evenodd", d "M12.25 17C12.6642 17 13 16.6642 13 16.25C13 15.8358 12.6642 15.5 12.25 15.5C11.8358 15.5 11.5 15.8358 11.5 16.25C11.5 16.6642 11.8358 17 12.25 17Z", fill "black" ] [] ]
+
 
 trash : String -> Svg msg
 trash class_ =

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -178,7 +178,6 @@ type Status
 
 type Msg
     = Ignored
-    | ChangedRoute (Maybe Route)
     | ChangedUrl Url
     | ClickedLink Browser.UrlRequest
     | GotJavascriptData Value
@@ -231,9 +230,6 @@ update msg model =
     case ( msg, model.status ) of
         ( Ignored, _ ) ->
             ( model, Cmd.none )
-
-        ( ChangedRoute route, _ ) ->
-            changeRouteTo route model
 
         ( ChangedUrl url, _ ) ->
             changeRouteTo (Route.fromUrl url) model
@@ -868,9 +864,6 @@ msgToString msg =
     case msg of
         Ignored ->
             [ "Ignored" ]
-
-        ChangedRoute _ ->
-            [ "ChangedRoute" ]
 
         ChangedUrl _ ->
             [ "ChangedUrl" ]

--- a/src/elm/Page.elm
+++ b/src/elm/Page.elm
@@ -187,24 +187,22 @@ viewMenuTab buttons =
 
 viewMenuFilterTabButton : Bool -> (a -> msg) -> Decoder a -> String -> Html msg
 viewMenuFilterTabButton isActive toMsg decoder text_ =
-    case isActive of
-        True ->
-            if String.startsWith "All offers" text_ then
-                button [ class "bg-purple-500 border border-purple-500 rounded-l px-12 py-2 text-white", value text_, onClick toMsg decoder ]
-                    [ text text_ ]
+    if isActive then
+        if String.startsWith "All offers" text_ then
+            button [ class "bg-purple-500 border border-purple-500 rounded-l px-12 py-2 text-white", value text_, onClick toMsg decoder ]
+                [ text text_ ]
 
-            else
-                button [ class "bg-purple-500 border border-purple-500 rounded-r px-12 py-2 text-white", value text_, onClick toMsg decoder ]
-                    [ text text_ ]
+        else
+            button [ class "bg-purple-500 border border-purple-500 rounded-r px-12 py-2 text-white", value text_, onClick toMsg decoder ]
+                [ text text_ ]
 
-        False ->
-            if String.startsWith "All offers" text_ then
-                button [ class "border border-purple-500 rounded-l px-16 py-2 text-gray", value text_, onClick toMsg decoder ]
-                    [ text text_ ]
+    else if String.startsWith "All offers" text_ then
+        button [ class "border border-purple-500 rounded-l px-16 py-2 text-gray", value text_, onClick toMsg decoder ]
+            [ text text_ ]
 
-            else
-                button [ class "border border-purple-500 rounded-r px-16 py-2 text-gray", value text_, onClick toMsg decoder ]
-                    [ text text_ ]
+    else
+        button [ class "border border-purple-500 rounded-r px-16 py-2 text-gray", value text_, onClick toMsg decoder ]
+            [ text text_ ]
 
 
 viewCardList : List ( List (Html msg), Posix, Maybe Posix ) -> Html msg
@@ -316,7 +314,7 @@ fullPageLoading =
 
 
 fullPageError : String -> Http.Error -> Html msg
-fullPageError title_ e =
+fullPageError title_ _ =
     div []
         [ viewTitle title_
         , div [ class "card" ] [ text "Something wrong happened." ]
@@ -358,7 +356,7 @@ errorToString errorData =
                 |> List.map graphqlErrorToString
                 |> String.join "\n"
 
-        Graphql.Http.HttpError httpError ->
+        Graphql.Http.HttpError _ ->
             "Http Error"
 
 
@@ -394,7 +392,7 @@ update msg session =
                 |> UR.init
                 |> UR.addCmd (Ports.storeLanguage lang)
 
-        ( CompletedLoadTranslation lang (Err err), _ ) ->
+        ( CompletedLoadTranslation _ (Err err), _ ) ->
             Shared.loadTranslation (Err err)
                 |> updateShared session
                 |> UR.init

--- a/src/elm/Page/Community.elm
+++ b/src/elm/Page/Community.elm
@@ -13,7 +13,7 @@ import Api.Graphql
 import Avatar
 import Cambiatus.Enum.VerificationType as VerificationType
 import Cambiatus.Scalar exposing (DateTime(..))
-import Community exposing (ActionVerification, Model)
+import Community exposing (Model)
 import Eos exposing (Symbol)
 import Eos.Account as Eos
 import Graphql.Http
@@ -28,13 +28,11 @@ import Json.Encode as Encode exposing (Value)
 import Page
 import Route
 import Session.LoggedIn as LoggedIn exposing (External(..), FeedbackStatus(..))
-import Session.Shared exposing (Shared)
 import Strftime
 import Task
 import Time exposing (Posix, posixToMillis)
 import UpdateResult as UR
 import Utils
-import View.Tag as Tag
 
 
 
@@ -96,7 +94,6 @@ type LoadStatus
 
 type EditStatus
     = NoEdit
-    | OpenObjective Int
 
 
 type ModalStatus
@@ -180,8 +177,8 @@ view loggedIn model =
                       else
                         text ""
                     , div [ class "bg-white py-6 sm:py-8 px-3 sm:px-6 rounded-lg mt-4" ]
-                        ([ Page.viewTitle (t "community.objectives.title_plural") ]
-                            ++ List.indexedMap (viewObjective loggedIn model community)
+                        (Page.viewTitle (t "community.objectives.title_plural")
+                            :: List.indexedMap (viewObjective loggedIn model community)
                                 community.objectives
                             ++ [ if canEdit then
                                     viewObjectiveNew loggedIn editStatus community.symbol
@@ -195,80 +192,6 @@ view loggedIn model =
                     --     |> viewSections loggedIn model
                     ]
                 ]
-
-
-
--- VIEW VERIFICATIONS
-
-
-viewVerification : Shared -> ActionVerification -> Html Msg
-viewVerification shared verification =
-    let
-        maybeLogo =
-            if String.isEmpty verification.logo then
-                Nothing
-
-            else
-                Just (shared.endpoints.ipfs ++ "/" ++ verification.logo)
-
-        description =
-            verification.description
-
-        date =
-            Just verification.createdAt
-                |> Utils.posixDateTime
-                |> Strftime.format "%d %b %Y" Time.utc
-
-        status =
-            verification.status
-
-        route =
-            case verification.symbol of
-                Just symbol ->
-                    Route.Claim
-                        symbol
-                        verification.objectiveId
-                        verification.actionId
-                        verification.claimId
-
-                Nothing ->
-                    Route.ComingSoon
-    in
-    a
-        [ class "border-b last:border-b-0 border-gray-500 flex items-start lg:items-center hover:bg-gray-100 first-hover:rounded-t-lg last-hover:rounded-b-lg p-4"
-        , Route.href route
-        ]
-        [ div
-            [ class "flex-none" ]
-            [ case maybeLogo of
-                Just logoUrl ->
-                    img
-                        [ class "w-10 h-10 object-scale-down"
-                        , src logoUrl
-                        ]
-                        []
-
-                Nothing ->
-                    div
-                        [ class "w-10 h-10 object-scale-down" ]
-                        []
-            ]
-        , div
-            [ class "flex-col flex-grow-1 pl-4" ]
-            [ p
-                [ class "font-sans text-black text-sm leading-relaxed" ]
-                [ text description ]
-            , p
-                [ class "font-normal font-sans text-gray-900 text-caption uppercase" ]
-                [ text date ]
-            , div
-                [ class "lg:hidden mt-4" ]
-                [ Tag.view status shared.translations ]
-            ]
-        , div
-            [ class "hidden lg:visible lg:flex lg:flex-none pl-4" ]
-            [ Tag.view status shared.translations ]
-        ]
 
 
 
@@ -738,21 +661,19 @@ update msg model loggedIn =
                         , responseData = Encode.null
                         , data =
                             Eos.encodeTransaction
-                                { actions =
-                                    [ { accountName = "bes.cmm"
-                                      , name = "claimaction"
-                                      , authorization =
-                                            { actor = loggedIn.accountName
-                                            , permissionName = Eos.samplePermission
-                                            }
-                                      , data =
-                                            { actionId = actionId
-                                            , maker = loggedIn.accountName
-                                            }
-                                                |> Community.encodeClaimAction
-                                      }
-                                    ]
-                                }
+                                [ { accountName = "bes.cmm"
+                                  , name = "claimaction"
+                                  , authorization =
+                                        { actor = loggedIn.accountName
+                                        , permissionName = Eos.samplePermission
+                                        }
+                                  , data =
+                                        { actionId = actionId
+                                        , maker = loggedIn.accountName
+                                        }
+                                            |> Community.encodeClaimAction
+                                  }
+                                ]
                         }
 
             else

--- a/src/elm/Page/Community/ActionEditor.elm
+++ b/src/elm/Page/Community/ActionEditor.elm
@@ -417,7 +417,6 @@ type Msg
     | GotInvalidDate
     | SaveAction Int -- Send the date
     | GotSaveAction (Result Value String)
-    | DismissError
     | PressedEnter Bool
 
 
@@ -953,14 +952,6 @@ update msg model loggedIn =
                 |> UR.logImpossible msg []
                 |> UR.addExt (ShowFeedback Failure (t shared.translations "error.unknown"))
 
-        DismissError ->
-            let
-                oldForm =
-                    model.form
-            in
-            { model | form = { oldForm | saveStatus = NotAsked } }
-                |> UR.init
-
         PressedEnter val ->
             if val then
                 UR.init model
@@ -1046,32 +1037,30 @@ upsertAction loggedIn model isoDate =
             , responseData = Encode.null
             , data =
                 Eos.encodeTransaction
-                    { actions =
-                        [ { accountName = "bes.cmm"
-                          , name = "upsertaction"
-                          , authorization =
-                                { actor = loggedIn.accountName
-                                , permissionName = Eos.samplePermission
-                                }
-                          , data =
-                                { actionId = model.actionId |> Maybe.withDefault 0
-                                , objectiveId = model.objectiveId
-                                , description = getInput model.form.description
-                                , reward = getInput model.form.reward ++ " " ++ Eos.symbolToString model.communityId
-                                , verifierReward = verifierReward
-                                , deadline = isoDate
-                                , usages = usages
-                                , usagesLeft = usagesLeft
-                                , verifications = minVotes
-                                , verificationType = verificationType
-                                , validatorsStr = validatorsStr
-                                , isCompleted = isCompleted
-                                , creator = loggedIn.accountName
-                                }
-                                    |> Community.encodeCreateActionAction
-                          }
-                        ]
-                    }
+                    [ { accountName = "bes.cmm"
+                      , name = "upsertaction"
+                      , authorization =
+                            { actor = loggedIn.accountName
+                            , permissionName = Eos.samplePermission
+                            }
+                      , data =
+                            { actionId = model.actionId |> Maybe.withDefault 0
+                            , objectiveId = model.objectiveId
+                            , description = getInput model.form.description
+                            , reward = getInput model.form.reward ++ " " ++ Eos.symbolToString model.communityId
+                            , verifierReward = verifierReward
+                            , deadline = isoDate
+                            , usages = usages
+                            , usagesLeft = usagesLeft
+                            , verifications = minVotes
+                            , verificationType = verificationType
+                            , validatorsStr = validatorsStr
+                            , isCompleted = isCompleted
+                            , creator = loggedIn.accountName
+                            }
+                                |> Community.encodeCreateActionAction
+                      }
+                    ]
             }
 
 
@@ -1657,9 +1646,6 @@ msgToString msg =
 
         GotSaveAction _ ->
             [ "GotSaveAction" ]
-
-        DismissError ->
-            [ "DismissError" ]
 
         PressedEnter _ ->
             [ "PressedEnter" ]

--- a/src/elm/Page/Community/Editor.elm
+++ b/src/elm/Page/Community/Editor.elm
@@ -22,7 +22,7 @@ import File exposing (File)
 import Graphql.Document
 import Graphql.Http
 import Html exposing (Html, br, button, div, input, label, span, text, textarea)
-import Html.Attributes exposing (..)
+import Html.Attributes exposing (accept, class, classList, disabled, for, id, maxlength, minlength, multiple, placeholder, required, type_, value)
 import Html.Events exposing (onClick, onInput, onSubmit)
 import Http
 import I18Next
@@ -35,7 +35,7 @@ import Session.LoggedIn as LoggedIn exposing (External(..), FeedbackStatus(..))
 import Session.Shared exposing (Shared)
 import Task
 import UpdateResult as UR
-import Utils exposing (..)
+import Utils exposing (decodeEnterKeyDown)
 
 
 
@@ -44,16 +44,14 @@ import Utils exposing (..)
 
 initNew : LoggedIn.Model -> ( Model, Cmd Msg )
 initNew _ =
-    ( { status = EditingNew Dict.empty newForm
-      }
+    ( EditingNew Dict.empty newForm
     , Cmd.none
     )
 
 
 initEdit : LoggedIn.Model -> Symbol -> ( Model, Cmd Msg )
 initEdit { shared } symbol =
-    ( { status = Loading symbol
-      }
+    ( Loading symbol
     , Api.Graphql.query shared (Community.communityQuery symbol) CompletedCommunityLoad
     )
 
@@ -72,8 +70,7 @@ subscriptions _ =
 
 
 type alias Model =
-    { status : Status
-    }
+    Status
 
 
 type
@@ -157,12 +154,7 @@ type LogoStatus
 
 
 type FormError
-    = Required
-    | TooShort Int
-    | TooLong Int
-    | InvalidChar Char
-    | AlreadyTaken
-    | ChooseOrUploadLogo
+    = ChooseOrUploadLogo
     | InternalError
     | InvalidSymbol
 
@@ -228,7 +220,7 @@ view loggedIn model =
         t str =
             I18Next.t shared.translations str
     in
-    case model.status of
+    case model of
         Loading _ ->
             Page.fullPageLoading
 
@@ -278,7 +270,7 @@ viewForm shared isEdit isDisabled errors form model =
                 ( t "community.create.title", t "community.create.submit" )
 
         cmd =
-            case model.status of
+            case model of
                 EditingNew _ _ ->
                     NewCommunitySubscription form.symbol
 
@@ -548,26 +540,8 @@ errorToString shared v =
     let
         t s =
             I18Next.t shared.translations s
-
-        tr str values =
-            I18Next.tr shared.translations I18Next.Curly str values
     in
     case v of
-        Required ->
-            t "error.required"
-
-        TooShort i ->
-            tr "error.tooShort" [ ( "minLength", String.fromInt i ) ]
-
-        TooLong i ->
-            tr "error.tooLong" [ ( "maxLength", String.fromInt i ) ]
-
-        InvalidChar c ->
-            tr "error.invalidChar" [ ( "invalidChar", String.fromChar c ) ]
-
-        AlreadyTaken ->
-            t "error.alreadyTaken"
-
         ChooseOrUploadLogo ->
             t "error.chooseOrUploadLogo"
 
@@ -616,19 +590,18 @@ update msg model loggedIn =
                 Just c ->
                     if LoggedIn.isAccount c.creator loggedIn then
                         Editing c Dict.empty (editForm c)
-                            |> updateStatus model
                             |> UR.init
 
                     else
-                        { model | status = Unauthorized c }
+                        Unauthorized c
                             |> UR.init
 
                 Nothing ->
-                    { model | status = NotFound }
+                    NotFound
                         |> UR.init
 
         CompletedCommunityLoad (Err err) ->
-            { model | status = LoadingFailed err }
+            LoadingFailed err
                 |> UR.init
                 |> UR.logGraphqlError msg err
 
@@ -727,7 +700,7 @@ update msg model loggedIn =
                         (UR.init model)
                         |> addHttpError
             in
-            case model.status of
+            case model of
                 WaitingEditLogoUpload _ _ ->
                     save msg loggedIn uResult
 
@@ -738,7 +711,7 @@ update msg model loggedIn =
                     uResult
 
         GotSaveResponse (Ok symbol) ->
-            case model.status of
+            case model of
                 Saving _ _ ->
                     model
                         |> UR.init
@@ -757,15 +730,15 @@ update msg model loggedIn =
                 err =
                     Dict.singleton "form" InternalError
             in
-            case model.status of
+            case model of
                 Saving community form ->
-                    { model | status = Editing community err form }
+                    Editing community err form
                         |> UR.init
                         |> UR.logDebugValue msg val
                         |> UR.addExt (ShowFeedback Failure (t "error.unknown"))
 
                 Creating form ->
-                    { model | status = EditingNew err form }
+                    EditingNew err form
                         |> UR.init
                         |> UR.logDebugValue msg val
                         |> UR.addExt (ShowFeedback Failure (t "error.unknown"))
@@ -777,7 +750,7 @@ update msg model loggedIn =
                         |> UR.addExt (ShowFeedback Failure (t "error.unknown"))
 
         Redirect ->
-            case model.status of
+            case model of
                 Creating form ->
                     let
                         sym =
@@ -814,14 +787,9 @@ update msg model loggedIn =
                 UR.init model
 
 
-updateStatus : Model -> Status -> Model
-updateStatus model status =
-    { model | status = status }
-
-
 updateForm : (Form -> Form) -> UpdateResult -> UpdateResult
 updateForm transform ({ model } as uResult) =
-    case model.status of
+    case model of
         Loading _ ->
             uResult
 
@@ -836,32 +804,26 @@ updateForm transform ({ model } as uResult) =
 
         Editing community errors form ->
             Editing community errors (transform form)
-                |> updateStatus model
                 |> UR.setModel uResult
 
         WaitingEditLogoUpload community form ->
             WaitingEditLogoUpload community (transform form)
-                |> updateStatus model
                 |> UR.setModel uResult
 
         Saving community form ->
             Saving community (transform form)
-                |> updateStatus model
                 |> UR.setModel uResult
 
         EditingNew errors form ->
             EditingNew errors (transform form)
-                |> updateStatus model
                 |> UR.setModel uResult
 
         WaitingNewLogoUpload form ->
             WaitingNewLogoUpload (transform form)
-                |> updateStatus model
                 |> UR.setModel uResult
 
         Creating form ->
             Creating (transform form)
-                |> updateStatus model
                 |> UR.setModel uResult
 
 
@@ -878,7 +840,6 @@ save msg loggedIn ({ model } as uResult) =
                             }
                     in
                     toLoading form
-                        |> updateStatus model
                         |> UR.setModel uResult
                         |> UR.addPort
                             (if isEdit then
@@ -886,22 +847,20 @@ save msg loggedIn ({ model } as uResult) =
                                 , responseData = Encode.string form.symbol
                                 , data =
                                     Eos.encodeTransaction
-                                        { actions =
-                                            [ { accountName = "bes.cmm"
-                                              , name = "update"
-                                              , authorization = authorization
-                                              , data =
-                                                    { asset = createAction.cmmAsset
-                                                    , logo = createAction.logoHash
-                                                    , name = createAction.name
-                                                    , description = createAction.description
-                                                    , inviterReward = createAction.inviterReward
-                                                    , invitedReward = createAction.invitedReward
-                                                    }
-                                                        |> Community.encodeUpdateLogoData
-                                              }
-                                            ]
-                                        }
+                                        [ { accountName = "bes.cmm"
+                                          , name = "update"
+                                          , authorization = authorization
+                                          , data =
+                                                { asset = createAction.cmmAsset
+                                                , logo = createAction.logoHash
+                                                , name = createAction.name
+                                                , description = createAction.description
+                                                , inviterReward = createAction.inviterReward
+                                                , invitedReward = createAction.invitedReward
+                                                }
+                                                    |> Community.encodeUpdateLogoData
+                                          }
+                                        ]
                                 }
 
                              else
@@ -909,41 +868,37 @@ save msg loggedIn ({ model } as uResult) =
                                 , responseData = Encode.string form.symbol
                                 , data =
                                     Eos.encodeTransaction
-                                        { actions =
-                                            [ { accountName = "bes.cmm"
-                                              , name = "create"
-                                              , authorization = authorization
-                                              , data =
-                                                    createAction
-                                                        |> Community.encodeCreateCommunityData
-                                              }
-                                            , { accountName = "bes.token"
-                                              , name = "create"
-                                              , authorization = authorization
-                                              , data =
-                                                    { creator = loggedIn.accountName
-                                                    , maxSupply = { amount = 21000000.0, symbol = createAction.cmmAsset.symbol }
-                                                    , minBalance = { amount = -1000.0, symbol = createAction.cmmAsset.symbol }
-                                                    , tokenType = "mcc"
-                                                    }
-                                                        |> Community.encodeCreateTokenData
-                                              }
-                                            ]
-                                        }
+                                        [ { accountName = "bes.cmm"
+                                          , name = "create"
+                                          , authorization = authorization
+                                          , data =
+                                                createAction
+                                                    |> Community.encodeCreateCommunityData
+                                          }
+                                        , { accountName = "bes.token"
+                                          , name = "create"
+                                          , authorization = authorization
+                                          , data =
+                                                { creator = loggedIn.accountName
+                                                , maxSupply = { amount = 21000000.0, symbol = createAction.cmmAsset.symbol }
+                                                , minBalance = { amount = -1000.0, symbol = createAction.cmmAsset.symbol }
+                                                , tokenType = "mcc"
+                                                }
+                                                    |> Community.encodeCreateTokenData
+                                          }
+                                        ]
                                 }
                             )
 
                 UploadingLogo ->
                     toUploadingLogo form
-                        |> updateStatus model
                         |> UR.setModel uResult
 
                 Invalid problems ->
                     toError problems form
-                        |> updateStatus model
                         |> UR.setModel uResult
     in
-    case model.status of
+    case model of
         Editing community _ form ->
             save_ form (Saving community) (WaitingEditLogoUpload community) (Editing community) True
 

--- a/src/elm/Page/Community/Explore.elm
+++ b/src/elm/Page/Community/Explore.elm
@@ -1,23 +1,16 @@
 module Page.Community.Explore exposing (Model, Msg(..), init, msgToString, update, view)
 
-import Api
 import Api.Graphql
-import Asset.Icon as Icon
 import Community exposing (Metadata)
-import Eos exposing (Symbol)
+import Eos
 import Eos.Account as Eos
 import Graphql.Http
-import Html exposing (..)
-import Html.Attributes exposing (class, src, style)
-import Http
+import Html exposing (Html, a, div, i, img, p, text)
+import Html.Attributes exposing (class, src)
 import I18Next exposing (t)
-import Json.Decode as Decode exposing (Decoder, field, int, list, string)
-import Json.Decode.Pipeline exposing (hardcoded, required)
-import Log
 import Page
 import Route
 import Session.LoggedIn as LoggedIn exposing (External(..))
-import Transfer
 import UpdateResult as UR
 
 
@@ -26,8 +19,8 @@ import UpdateResult as UR
 
 
 init : LoggedIn.Model -> ( Model, Cmd Msg )
-init ({ shared } as loggedIn) =
-    ( initModel loggedIn
+init { shared } =
+    ( initModel
     , Api.Graphql.query shared Community.communitiesQuery CompletedCommunitiesLoad
     )
 
@@ -42,8 +35,8 @@ type alias Model =
     }
 
 
-initModel : LoggedIn.Model -> Model
-initModel loggedIn =
+initModel : Model
+initModel =
     { communities = Loading
     , userMessage = Nothing
     }
@@ -183,7 +176,7 @@ type Msg
 
 
 update : Msg -> Model -> LoggedIn.Model -> UpdateResult
-update msg model loggedIn =
+update msg model _ =
     case msg of
         CompletedCommunitiesLoad (Ok communities) ->
             UR.init { model | communities = Loaded communities }

--- a/src/elm/Page/Community/ObjectiveEditor.elm
+++ b/src/elm/Page/Community/ObjectiveEditor.elm
@@ -311,22 +311,20 @@ update msg model loggedIn =
                                     , responseData = Encode.null
                                     , data =
                                         Eos.encodeTransaction
-                                            { actions =
-                                                [ { accountName = "bes.cmm"
-                                                  , name = "updobjective"
-                                                  , authorization =
-                                                        { actor = loggedIn.accountName
-                                                        , permissionName = Eos.samplePermission
-                                                        }
-                                                  , data =
-                                                        { objectiveId = objectiveId
-                                                        , description = form.description
-                                                        , editor = loggedIn.accountName
-                                                        }
-                                                            |> Community.encodeUpdateObjectiveAction
-                                                  }
-                                                ]
-                                            }
+                                            [ { accountName = "bes.cmm"
+                                              , name = "updobjective"
+                                              , authorization =
+                                                    { actor = loggedIn.accountName
+                                                    , permissionName = Eos.samplePermission
+                                                    }
+                                              , data =
+                                                    { objectiveId = objectiveId
+                                                    , description = form.description
+                                                    , editor = loggedIn.accountName
+                                                    }
+                                                        |> Community.encodeUpdateObjectiveAction
+                                              }
+                                            ]
                                     }
 
                         Nothing ->
@@ -336,22 +334,20 @@ update msg model loggedIn =
                                     , responseData = Encode.null
                                     , data =
                                         Eos.encodeTransaction
-                                            { actions =
-                                                [ { accountName = "bes.cmm"
-                                                  , name = "newobjective"
-                                                  , authorization =
-                                                        { actor = loggedIn.accountName
-                                                        , permissionName = Eos.samplePermission
-                                                        }
-                                                  , data =
-                                                        { symbol = model.community
-                                                        , description = form.description
-                                                        , creator = loggedIn.accountName
-                                                        }
-                                                            |> Community.encodeCreateObjectiveAction
-                                                  }
-                                                ]
-                                            }
+                                            [ { accountName = "bes.cmm"
+                                              , name = "newobjective"
+                                              , authorization =
+                                                    { actor = loggedIn.accountName
+                                                    , permissionName = Eos.samplePermission
+                                                    }
+                                              , data =
+                                                    { symbol = model.community
+                                                    , description = form.description
+                                                    , creator = loggedIn.accountName
+                                                    }
+                                                        |> Community.encodeCreateObjectiveAction
+                                              }
+                                            ]
                                     }
             in
             if LoggedIn.isAuth loggedIn then

--- a/src/elm/Page/Community/Objectives.elm
+++ b/src/elm/Page/Community/Objectives.elm
@@ -1,14 +1,14 @@
 module Page.Community.Objectives exposing (Model, Msg, init, msgToString, update, view)
 
 import Api.Graphql
-import Cambiatus.Enum.VerificationType as VerificationType exposing (VerificationType)
+import Cambiatus.Enum.VerificationType as VerificationType
 import Community exposing (Model, communityQuery)
 import Eos exposing (Symbol)
 import Graphql.Http
-import Html exposing (..)
-import Html.Attributes exposing (class, classList, disabled)
+import Html exposing (Html, a, button, div, p, text)
+import Html.Attributes exposing (class, classList)
 import Html.Events exposing (onClick)
-import I18Next exposing (Delims(..), Translations, t)
+import I18Next exposing (Delims(..), t)
 import Icons
 import Page
 import Profile
@@ -106,10 +106,6 @@ viewNewObjectiveButton ({ shared } as loggedIn) community =
 viewObjective : LoggedIn.Model -> Model -> Community.Model -> Int -> Community.Objective -> Html Msg
 viewObjective ({ shared } as loggedIn) model community index objective =
     let
-        canEdit : Bool
-        canEdit =
-            LoggedIn.isAccount community.creator loggedIn
-
         isOpen : Bool
         isOpen =
             case model.openObjective of
@@ -201,7 +197,7 @@ viewAction ({ shared } as loggedIn) model objectiveId action =
         pastDeadline : Bool
         pastDeadline =
             case action.deadline of
-                Just deadline ->
+                Just _ ->
                     case model.date of
                         Just today ->
                             posixToMillis today > posixToMillis posixDeadline
@@ -271,7 +267,7 @@ viewAction ({ shared } as loggedIn) model objectiveId action =
                           else
                             text ""
                         , case action.deadline of
-                            Just d ->
+                            Just _ ->
                                 p [ classList [ ( "text-red", pastDeadline ) ] ] [ text deadlineStr ]
 
                             Nothing ->

--- a/src/elm/Page/Community/Transfer.elm
+++ b/src/elm/Page/Community/Transfer.elm
@@ -428,28 +428,26 @@ update msg model ({ shared } as loggedIn) =
                             , responseData = Encode.null
                             , data =
                                 Eos.encodeTransaction
-                                    { actions =
-                                        [ { accountName = "bes.token"
-                                          , name = "transfer"
-                                          , authorization =
-                                                { actor = loggedIn.accountName
-                                                , permissionName = Eos.samplePermission
+                                    [ { accountName = "bes.token"
+                                      , name = "transfer"
+                                      , authorization =
+                                            { actor = loggedIn.accountName
+                                            , permissionName = Eos.samplePermission
+                                            }
+                                      , data =
+                                            { from = loggedIn.accountName
+                                            , to = Eos.nameQueryUrlParser (Eos.nameToString account)
+                                            , value =
+                                                { amount =
+                                                    String.toFloat form.amount
+                                                        |> Maybe.withDefault 0.0
+                                                , symbol = model.communityId
                                                 }
-                                          , data =
-                                                { from = loggedIn.accountName
-                                                , to = Eos.nameQueryUrlParser (Eos.nameToString account)
-                                                , value =
-                                                    { amount =
-                                                        String.toFloat form.amount
-                                                            |> Maybe.withDefault 0.0
-                                                    , symbol = model.communityId
-                                                    }
-                                                , memo = form.memo
-                                                }
-                                                    |> Transfer.encodeEosActionData
-                                          }
-                                        ]
-                                    }
+                                            , memo = form.memo
+                                            }
+                                                |> Transfer.encodeEosActionData
+                                      }
+                                    ]
                             }
 
                 ( Loaded _ (CreatingSubscription _), False ) ->

--- a/src/elm/Page/Dashboard.elm
+++ b/src/elm/Page/Dashboard.elm
@@ -662,17 +662,15 @@ update msg model loggedIn =
                                 , responseData = Encode.null
                                 , data =
                                     Eos.encodeTransaction
-                                        { actions =
-                                            [ { accountName = "bes.cmm"
-                                              , name = "verifyclaim"
-                                              , authorization =
-                                                    { actor = loggedIn.accountName
-                                                    , permissionName = Eos.samplePermission
-                                                    }
-                                              , data = Claim.encodeVerification claimId loggedIn.accountName vote
-                                              }
-                                            ]
-                                        }
+                                        [ { accountName = "bes.cmm"
+                                          , name = "verifyclaim"
+                                          , authorization =
+                                                { actor = loggedIn.accountName
+                                                , permissionName = Eos.samplePermission
+                                                }
+                                          , data = Claim.encodeVerification claimId loggedIn.accountName vote
+                                          }
+                                        ]
                                 }
 
                     else

--- a/src/elm/Page/Dashboard/Analysis.elm
+++ b/src/elm/Page/Dashboard/Analysis.elm
@@ -485,17 +485,15 @@ update msg model loggedIn =
                                 , responseData = Encode.null
                                 , data =
                                     Eos.encodeTransaction
-                                        { actions =
-                                            [ { accountName = "bes.cmm"
-                                              , name = "verifyclaim"
-                                              , authorization =
-                                                    { actor = loggedIn.accountName
-                                                    , permissionName = Eos.samplePermission
-                                                    }
-                                              , data = Claim.encodeVerification claimId loggedIn.accountName vote
-                                              }
-                                            ]
-                                        }
+                                        [ { accountName = "bes.cmm"
+                                          , name = "verifyclaim"
+                                          , authorization =
+                                                { actor = loggedIn.accountName
+                                                , permissionName = Eos.samplePermission
+                                                }
+                                          , data = Claim.encodeVerification claimId loggedIn.accountName vote
+                                          }
+                                        ]
                                 }
 
                     else

--- a/src/elm/Page/Dashboard/Claim.elm
+++ b/src/elm/Page/Dashboard/Claim.elm
@@ -100,9 +100,6 @@ viewTitle shared claim =
     let
         text_ s =
             text (I18Next.t shared.translations s)
-
-        negativeChecks =
-            List.filter (\ch -> not ch.isApproved) claim.checks
     in
     div [ class "text-heading font-bold text-center mb-8" ]
         [ case claim.status of

--- a/src/elm/Page/Login.elm
+++ b/src/elm/Page/Login.elm
@@ -1,12 +1,9 @@
 module Page.Login exposing (Model, Msg, init, jsAddressToMsg, msgToString, subscriptions, update, view)
 
 import Auth
-import Graphql.Http
-import Html exposing (..)
-import Html.Attributes exposing (..)
-import I18Next exposing (t)
+import Html exposing (Html, div)
+import Html.Attributes exposing (class)
 import Json.Encode exposing (Value)
-import Page
 import Route
 import Session.Guest as Guest exposing (External(..))
 import UpdateResult as UR
@@ -84,7 +81,7 @@ update : Msg -> Model -> Guest.Model -> UpdateResult
 update msg model guest =
     case msg of
         GotAuthMsg authMsg ->
-            Auth.update authMsg guest.shared model.auth False
+            Auth.update authMsg guest.shared model.auth
                 |> UR.map
                     (\a -> { model | auth = a })
                     GotAuthMsg

--- a/src/elm/Page/Notification.elm
+++ b/src/elm/Page/Notification.elm
@@ -1,4 +1,4 @@
-module Page.Notification exposing (..)
+module Page.Notification exposing (Model, Msg(..), init, msgToString, update, view)
 
 import Api.Graphql
 import Eos
@@ -6,17 +6,17 @@ import Eos.Account as Eos
 import FormatNumber exposing (format)
 import FormatNumber.Locales exposing (usLocale)
 import Graphql.Http
-import Html exposing (..)
+import Html exposing (Html, div, img, p, text)
 import Html.Attributes exposing (class, src)
 import Html.Events exposing (onClick)
-import I18Next exposing (Delims(..), t)
-import Notification exposing (History, NotificationType(..), MintData, SaleHistoryData, TransferData)
+import I18Next exposing (Delims(..))
+import Notification exposing (History, MintData, NotificationType(..), SaleHistoryData, TransferData)
 import Page
-import Route exposing (Route)
+import Route
 import Session.LoggedIn as LoggedIn exposing (External(..))
-import Session.Shared as Shared exposing (Shared)
+import Session.Shared exposing (Shared)
 import Strftime
-import Time exposing (Posix)
+import Time
 import UpdateResult as UR
 import Utils
 
@@ -27,7 +27,7 @@ import Utils
 
 init : LoggedIn.Model -> ( Model, Cmd Msg )
 init ({ shared } as loggedIn) =
-    ( initModel loggedIn
+    ( initModel
     , Api.Graphql.query shared (Notification.notificationHistoryQuery loggedIn.accountName) CompletedLoadNotificationHistory
     )
 
@@ -37,18 +37,16 @@ init ({ shared } as loggedIn) =
 
 
 type alias Model =
-    { status : Status
-    }
+    Status
 
 
-initModel : LoggedIn.Model -> Model
-initModel loggedIn =
-    { status = Loading }
+initModel : Model
+initModel =
+    Loading
 
 
 type Status
     = Loading
-    | LoadingFailed (Graphql.Http.Error (List History))
     | Loaded (List History)
 
 
@@ -68,12 +66,9 @@ view loggedIn model =
         t s =
             I18Next.t loggedIn.shared.translations s
     in
-    case model.status of
+    case model of
         Loading ->
             Page.fullPageLoading
-
-        LoadingFailed e ->
-            Page.fullPageGraphQLError (t "notifications.title") e
 
         Loaded notifications ->
             div [ class "container mx-auto px-4 mb-6" ]
@@ -184,6 +179,7 @@ viewNotificationTransfer shared history notification =
             (viewAmount amount notification.symbol)
         ]
 
+
 viewNotificationMint : Shared -> History -> MintData -> Html Msg
 viewNotificationMint shared history notification =
     let
@@ -200,11 +196,10 @@ viewNotificationMint shared history notification =
                 |> Strftime.format "%d %b %Y" Time.utc
 
         description =
-                [ ( "amount", String.fromFloat notification.quantity)
-                , ( "symbol", notification.community.symbol )
-                ]
-                    |> I18Next.tr shared.translations I18Next.Curly "notifications.issue.receive"
-
+            [ ( "amount", String.fromFloat notification.quantity )
+            , ( "symbol", notification.community.symbol )
+            ]
+                |> I18Next.tr shared.translations I18Next.Curly "notifications.issue.receive"
     in
     div
         [ class "flex items-start lg:items-center p-4"
@@ -237,7 +232,6 @@ viewNotificationMint shared history notification =
         ]
 
 
-
 viewNotificationSaleHistory : LoggedIn.Model -> History -> SaleHistoryData -> Html Msg
 viewNotificationSaleHistory ({ shared } as loggedIn) notification sale =
     let
@@ -257,7 +251,7 @@ viewNotificationSaleHistory ({ shared } as loggedIn) notification sale =
         [ class "flex items-start lg:items-center p-4"
         , onClick (MarkAsRead notification.id (S sale))
         ]
-        ([ div
+        (div
             [ class "flex-none" ]
             [ case maybeLogo of
                 Just logoUrl ->
@@ -272,8 +266,7 @@ viewNotificationSaleHistory ({ shared } as loggedIn) notification sale =
                         [ class "w-10 h-10 object-scale-down" ]
                         []
             ]
-         ]
-            ++ viewNotificationSaleHistoryDetail loggedIn sale date
+            :: viewNotificationSaleHistoryDetail loggedIn sale date
         )
 
 
@@ -295,13 +288,6 @@ viewNotificationSaleHistoryDetail ({ shared } as loggedIn) sale date =
                 , ( "sale", sale.sale.title )
                 ]
                     |> I18Next.tr shared.translations I18Next.Curly "notifications.saleHistory.sell"
-
-        amount =
-            if isBuy then
-                -sale.amount
-
-            else
-                sale.amount
     in
     [ div [ class "flex-col flex-grow-1 pl-4" ]
         [ p
@@ -369,7 +355,7 @@ update : Msg -> Model -> LoggedIn.Model -> UpdateResult
 update msg model loggedIn =
     case msg of
         CompletedLoadNotificationHistory (Ok notifications) ->
-            { model | status = Loaded notifications }
+            Loaded notifications
                 |> UR.init
 
         CompletedLoadNotificationHistory (Err err) ->
@@ -390,9 +376,9 @@ update msg model loggedIn =
                         |> UR.addCmd cmd
 
                 M _ ->
-                  model
-                      |> UR.init
-                      |> UR.addCmd cmd
+                    model
+                        |> UR.init
+                        |> UR.addCmd cmd
 
                 S sale ->
                     model
@@ -404,7 +390,7 @@ update msg model loggedIn =
                             )
 
         CompletedReading (Ok hist) ->
-            case model.status of
+            case model of
                 Loaded histories ->
                     let
                         updatedHistories =
@@ -418,7 +404,7 @@ update msg model loggedIn =
                                 )
                                 histories
                     in
-                    { model | status = Loaded updatedHistories }
+                    Loaded updatedHistories
                         |> UR.init
 
                 _ ->

--- a/src/elm/Page/Profile.elm
+++ b/src/elm/Page/Profile.elm
@@ -1,4 +1,13 @@
-module Page.Profile exposing (Model, Msg, init, jsAddressToMsg, msgToString, update, view)
+module Page.Profile exposing
+    ( Model
+    , Msg
+    , init
+    , jsAddressToMsg
+    , msgToString
+    , subscription
+    , update
+    , view
+    )
 
 import Api
 import Api.Graphql
@@ -6,13 +15,13 @@ import Asset.Icon as Icon
 import Avatar exposing (Avatar)
 import Browser.Events
 import Dict exposing (Dict)
-import Eos as Eos exposing (Symbol)
+import Eos as Eos
 import Eos.Account as Eos
 import File exposing (File)
 import Graphql.Http
-import Html exposing (..)
-import Html.Attributes exposing (..)
-import Html.Events exposing (..)
+import Html exposing (Html, br, button, div, h2, h3, h4, img, input, label, p, span, text, textarea)
+import Html.Attributes exposing (accept, class, classList, disabled, for, id, maxlength, multiple, placeholder, required, src, style, title, type_, value)
+import Html.Events exposing (onClick, onInput, onSubmit, stopPropagationOn)
 import Http
 import I18Next exposing (t)
 import Json.Decode as Decode exposing (Value)
@@ -98,7 +107,7 @@ view loggedIn model =
         Loading ->
             Page.fullPageLoading
 
-        LoadingFailed e ->
+        LoadingFailed _ ->
             Page.fullPageError (t loggedIn.shared.translations "profile.title") Http.Timeout
 
         Loaded profile ->
@@ -188,7 +197,7 @@ view_ loggedIn profile model =
                             )
                     ]
                 ]
-            , viewBadges loggedIn model
+            , viewBadges loggedIn
             , div [ class "notification-settings-card", onClick RequestPush ]
                 [ button [ class "btn btn--primary" ]
                     [ text_ notification_prompt ]
@@ -491,8 +500,8 @@ viewAvatar ipfsUrl profile plchldr avatarS =
         ]
 
 
-viewBadges : LoggedIn.Model -> Model -> Html msg
-viewBadges loggedIn model =
+viewBadges : LoggedIn.Model -> Html msg
+viewBadges loggedIn =
     let
         text_ s =
             text (t loggedIn.shared.translations s)
@@ -614,7 +623,7 @@ update msg model loggedIn =
 
         ClickedEditCancel ->
             case model.status of
-                Editing profile avatarS form ->
+                Editing profile _ _ ->
                     UR.init { model | status = Loaded profile }
 
                 _ ->
@@ -749,10 +758,10 @@ update msg model loggedIn =
                             NotAsked ->
                                 NotAsked
 
-                            SendingFailed file err_ ->
+                            SendingFailed file _ ->
                                 SendingFailed file err
 
-                            Sending file progress ->
+                            Sending file _ ->
                                 SendingFailed file err
                     )
 
@@ -911,7 +920,7 @@ updateAvatarStatus transform ({ model } as uResult) =
         LoadingFailed _ ->
             uResult
 
-        Loaded profile ->
+        Loaded _ ->
             uResult
 
         Editing profile avatarS form ->
@@ -944,7 +953,7 @@ jsAddressToMsg addr val =
                 Ok res ->
                     Just (GotPushSub res)
 
-                Err err ->
+                Err _ ->
                     -- TODO: Handle PushSubscription Decode error
                     Nothing
 

--- a/src/elm/Page/Register.elm
+++ b/src/elm/Page/Register.elm
@@ -5,8 +5,8 @@ import Auth exposing (viewFieldLabel)
 import Browser.Events
 import Char
 import Eos.Account as Eos
-import Html exposing (..)
-import Html.Attributes exposing (..)
+import Html exposing (Attribute, Html, a, button, div, img, input, label, li, p, span, strong, text, ul)
+import Html.Attributes exposing (attribute, checked, class, disabled, id, maxlength, placeholder, src, style, type_, value)
 import Html.Events exposing (onCheck, onClick, onInput, onSubmit)
 import Http
 import I18Next exposing (t)
@@ -19,7 +19,7 @@ import Session.Guest as Guest exposing (External(..))
 import Session.Shared exposing (Shared)
 import Task
 import UpdateResult as UR
-import Utils exposing (..)
+import Utils exposing (decodeEnterKeyDown)
 import Validate exposing (ifBlank, ifFalse, ifInvalidEmail, ifTrue, validate)
 
 
@@ -476,12 +476,10 @@ type alias UpdateResult =
 
 type Msg
     = UpdateForm FormInputMsg
-    | Ignored
     | ValidateForm Form
     | GotAccountAvailabilityResponse Bool
     | AccountGenerated (Result Decode.Error AccountKeys)
     | CompletedCreateProfile AccountKeys (Result Http.Error Profile)
-    | CompletedLoadProfile AccountKeys (Result Http.Error Profile)
     | AgreedToSave12Words Bool
     | DownloadPdf String
     | PdfDownloaded
@@ -503,10 +501,6 @@ update maybeInvitation msg model guest =
             I18Next.tr shared.translations I18Next.Curly str values
     in
     case msg of
-        Ignored ->
-            model
-                |> UR.init
-
         UpdateForm subMsg ->
             updateForm subMsg model
                 |> UR.init
@@ -651,16 +645,6 @@ update maybeInvitation msg model guest =
                 |> UR.init
                 |> UR.logHttpError msg err
 
-        CompletedLoadProfile _ (Ok profile) ->
-            UR.init model
-                |> UR.addCmd (Route.replaceUrl guest.shared.navKey Route.Dashboard)
-                |> UR.addExt (UpdatedGuest { guest | profile = Just profile })
-
-        CompletedLoadProfile _ (Err err) ->
-            { model | problems = ServerError "Auth failed" :: model.problems }
-                |> UR.init
-                |> UR.logHttpError msg err
-
         AgreedToSave12Words val ->
             { model | hasAgreedToSavePassphrase = val }
                 |> UR.init
@@ -780,9 +764,6 @@ jsAddressToMsg addr val =
 msgToString : Msg -> List String
 msgToString msg =
     case msg of
-        Ignored ->
-            [ "Ignored" ]
-
         UpdateForm _ ->
             [ "UpdateForm" ]
 
@@ -797,9 +778,6 @@ msgToString msg =
 
         CompletedCreateProfile _ r ->
             [ "CompletedCreateProfile", UR.resultToString r ]
-
-        CompletedLoadProfile _ r ->
-            [ "CompletedLoadProfile", UR.resultToString r ]
 
         AgreedToSave12Words _ ->
             [ "AgreedToSave12Words" ]

--- a/src/elm/Page/Shop/Editor.elm
+++ b/src/elm/Page/Shop/Editor.elm
@@ -10,7 +10,7 @@ import Eos exposing (Symbol)
 import Eos.Account as Eos
 import File exposing (File)
 import Graphql.Http
-import Html exposing (Attribute, Html, button, div, h2, h3, input, label, option, p, select, span, text, textarea)
+import Html exposing (Attribute, Html, button, div, input, label, option, p, select, span, text, textarea)
 import Html.Attributes exposing (accept, attribute, class, disabled, for, hidden, id, maxlength, multiple, required, selected, style, type_, value)
 import Html.Events exposing (keyCode, on, onClick, onInput)
 import Http
@@ -35,16 +35,14 @@ import Utils exposing (decodeEnterKeyDown)
 
 initCreate : LoggedIn.Model -> ( Model, Cmd Msg )
 initCreate loggedIn =
-    ( { status = LoadingBalancesCreate
-      }
+    ( LoadingBalancesCreate
     , Api.getBalances loggedIn.shared loggedIn.accountName CompletedBalancesLoad
     )
 
 
 initUpdate : SaleId -> LoggedIn.Model -> ( Model, Cmd Msg )
 initUpdate saleId loggedIn =
-    ( { status = LoadingBalancesUpdate saleId
-      }
+    ( LoadingBalancesUpdate saleId
     , Api.getBalances loggedIn.shared loggedIn.accountName CompletedBalancesLoad
     )
 
@@ -63,8 +61,7 @@ subscriptions _ =
 
 
 type alias Model =
-    { status : Status
-    }
+    Status
 
 
 type
@@ -180,7 +177,7 @@ view loggedIn model =
         t =
             I18Next.t shared.translations
     in
-    case model.status of
+    case model of
         LoadingBalancesCreate ->
             Page.fullPageLoading
 
@@ -266,17 +263,16 @@ viewForm shared balances imageStatus isEdit isDisabled deleteModal form =
             [ class "bg-white rounded-lg" ]
             [ div [ class "px-4 py-6 border-b border-gray-500" ]
                 [ div [ class "text-heading font-medium" ] [ text pageTitle ]
-                , case isEdit of
-                    True ->
-                        button
-                            [ class "btn delete-button"
-                            , disabled isDisabled
-                            , onClick ClickedDelete
-                            ]
-                            [ text (t "shop.delete") ]
+                , if isEdit then
+                    button
+                        [ class "btn delete-button"
+                        , disabled isDisabled
+                        , onClick ClickedDelete
+                        ]
+                        [ text (t "shop.delete") ]
 
-                    False ->
-                        text ""
+                  else
+                    text ""
                 , if isEdit && deleteModal == Open then
                     viewConfirmDeleteModal t
 
@@ -559,7 +555,7 @@ update msg model loggedIn =
     in
     case msg of
         CompletedBalancesLoad (Ok balances) ->
-            case model.status of
+            case model of
                 LoadingBalancesCreate ->
                     let
                         balanceOptions =
@@ -569,8 +565,7 @@ update msg model loggedIn =
                                 )
                                 balances
                     in
-                    model
-                        |> updateStatus (EditingCreate balances NoImage (initForm balanceOptions))
+                    EditingCreate balances NoImage (initForm balanceOptions)
                         |> UR.init
 
                 LoadingBalancesUpdate saleId ->
@@ -583,8 +578,7 @@ update msg model loggedIn =
                                 Just id ->
                                     Api.Graphql.query loggedIn.shared (Shop.saleQuery id) CompletedSaleLoad
                     in
-                    model
-                        |> updateStatus (LoadingSaleUpdate balances saleId)
+                    LoadingSaleUpdate balances saleId
                         |> UR.init
                         |> UR.addCmd saleFetch
 
@@ -594,13 +588,12 @@ update msg model loggedIn =
                         |> UR.logImpossible msg []
 
         CompletedBalancesLoad (Err error) ->
-            model
-                |> updateStatus (LoadBalancesFailed error)
+            LoadBalancesFailed error
                 |> UR.init
                 |> UR.logHttpError msg error
 
         CompletedSaleLoad (Ok maybeSale) ->
-            case ( model.status, maybeSale ) of
+            case ( model, maybeSale ) of
                 ( LoadingSaleUpdate balances _, Just sale ) ->
                     let
                         balanceOptions =
@@ -617,8 +610,7 @@ update msg model loggedIn =
                             else
                                 trackNo
                     in
-                    model
-                        |> updateStatus (EditingUpdate balances sale NoImage Closed (initForm balanceOptions))
+                    EditingUpdate balances sale NoImage Closed (initForm balanceOptions)
                         |> updateForm
                             (\form ->
                                 { form
@@ -639,16 +631,14 @@ update msg model loggedIn =
                         |> UR.logImpossible msg []
 
         CompletedSaleLoad (Err error) ->
-            model
-                |> updateStatus (LoadSaleFailed error)
+            LoadSaleFailed error
                 |> UR.init
                 |> UR.logGraphqlError msg error
 
         CompletedImageUpload (Ok hash) ->
-            case model.status of
+            case model of
                 EditingCreate balances _ form ->
-                    model
-                        |> updateStatus (EditingCreate balances (Uploaded hash) form)
+                    EditingCreate balances (Uploaded hash) form
                         |> updateForm
                             (\form_ ->
                                 { form_ | image = updateInput (Just hash) form_.image }
@@ -656,8 +646,7 @@ update msg model loggedIn =
                         |> UR.init
 
                 EditingUpdate balances sale _ _ form ->
-                    model
-                        |> updateStatus (EditingUpdate balances sale (Uploaded hash) Closed form)
+                    EditingUpdate balances sale (Uploaded hash) Closed form
                         |> updateForm
                             (\form_ ->
                                 { form_ | image = updateInput (Just hash) form_.image }
@@ -670,16 +659,14 @@ update msg model loggedIn =
                         |> UR.logImpossible msg []
 
         CompletedImageUpload (Err error) ->
-            case model.status of
+            case model of
                 EditingCreate balances _ form ->
-                    model
-                        |> updateStatus (EditingCreate balances (UploadFailed error) form)
+                    EditingCreate balances (UploadFailed error) form
                         |> UR.init
                         |> UR.logHttpError msg error
 
                 EditingUpdate balances sale _ _ form ->
-                    model
-                        |> updateStatus (EditingUpdate balances sale (UploadFailed error) Closed form)
+                    EditingUpdate balances sale (UploadFailed error) Closed form
                         |> UR.init
                         |> UR.logHttpError msg error
 
@@ -693,16 +680,14 @@ update msg model loggedIn =
                 uploadImage =
                     Api.uploadImage loggedIn.shared file CompletedImageUpload
             in
-            case model.status of
+            case model of
                 EditingCreate balances _ form ->
-                    model
-                        |> updateStatus (EditingCreate balances Uploading form)
+                    EditingCreate balances Uploading form
                         |> UR.init
                         |> UR.addCmd uploadImage
 
                 EditingUpdate balances sale _ _ form ->
-                    model
-                        |> updateStatus (EditingUpdate balances sale Uploading Closed form)
+                    EditingUpdate balances sale Uploading Closed form
                         |> UR.init
                         |> UR.addCmd uploadImage
 
@@ -776,12 +761,11 @@ update msg model loggedIn =
                         model
                             |> updateForm validateForm
                 in
-                case validatedModel.status of
+                case validatedModel of
                     EditingCreate balances (Uploaded hash) form ->
                         if isValidForm form then
                             performRequest
                                 ClickedSave
-                                validatedModel
                                 (Creating balances (Uploaded hash) form)
                                 loggedIn.accountName
                                 "createsale"
@@ -795,7 +779,6 @@ update msg model loggedIn =
                         if isValidForm form then
                             performRequest
                                 ClickedSave
-                                validatedModel
                                 (Creating balances (UploadFailed error) form)
                                 loggedIn.accountName
                                 "createsale"
@@ -809,7 +792,6 @@ update msg model loggedIn =
                         if isValidForm form then
                             performRequest
                                 ClickedSave
-                                validatedModel
                                 (Creating balances NoImage form)
                                 loggedIn.accountName
                                 "createsale"
@@ -823,7 +805,6 @@ update msg model loggedIn =
                         if isValidForm form then
                             performRequest
                                 ClickedSave
-                                validatedModel
                                 (Saving balances sale (Uploaded hash) form)
                                 loggedIn.accountName
                                 "updatesale"
@@ -837,7 +818,6 @@ update msg model loggedIn =
                         if isValidForm form then
                             performRequest
                                 ClickedSave
-                                validatedModel
                                 (Saving balances sale (UploadFailed error) form)
                                 loggedIn.accountName
                                 "updatesale"
@@ -851,7 +831,6 @@ update msg model loggedIn =
                         if isValidForm form then
                             performRequest
                                 ClickedSave
-                                validatedModel
                                 (Saving balances sale NoImage form)
                                 loggedIn.accountName
                                 "updatesale"
@@ -872,20 +851,18 @@ update msg model loggedIn =
                     |> UR.addExt (RequiredAuthentication (Just ClickedSave))
 
         ClickedDelete ->
-            case model.status of
+            case model of
                 EditingUpdate balances sale imageStatus _ form ->
-                    model
-                        |> updateStatus (EditingUpdate balances sale imageStatus Open form)
+                    EditingUpdate balances sale imageStatus Open form
                         |> UR.init
 
                 _ ->
                     UR.init model
 
         ClickedDeleteCancel ->
-            case model.status of
+            case model of
                 EditingUpdate balances sale imageStatus _ form ->
-                    model
-                        |> updateStatus (EditingUpdate balances sale imageStatus Closed form)
+                    EditingUpdate balances sale imageStatus Closed form
                         |> UR.init
 
                 _ ->
@@ -893,11 +870,10 @@ update msg model loggedIn =
 
         ClickedDeleteConfirm ->
             if LoggedIn.isAuth loggedIn then
-                case model.status of
+                case model of
                     EditingUpdate balances sale (Uploaded hash) _ form ->
                         performRequest
                             ClickedDeleteConfirm
-                            model
                             (Deleting balances sale (Uploaded hash) form)
                             loggedIn.accountName
                             "deletesale"
@@ -906,7 +882,6 @@ update msg model loggedIn =
                     EditingUpdate balances sale (UploadFailed error) _ form ->
                         performRequest
                             ClickedDeleteConfirm
-                            model
                             (Deleting balances sale (UploadFailed error) form)
                             loggedIn.accountName
                             "deletesale"
@@ -915,7 +890,6 @@ update msg model loggedIn =
                     EditingUpdate balances sale NoImage _ form ->
                         performRequest
                             ClickedDeleteConfirm
-                            model
                             (Deleting balances sale NoImage form)
                             loggedIn.accountName
                             "deletesale"
@@ -942,10 +916,9 @@ update msg model loggedIn =
                 internalError =
                     I18Next.t loggedIn.shared.translations "error.unknown"
             in
-            case model.status of
+            case model of
                 Creating balances imageStatus form ->
-                    model
-                        |> updateStatus (EditingCreate balances imageStatus form)
+                    EditingCreate balances imageStatus form
                         |> updateForm
                             (\form_ ->
                                 { form_
@@ -956,8 +929,7 @@ update msg model loggedIn =
                         |> UR.logDebugValue msg error
 
                 Saving balances sale imageStatus form ->
-                    model
-                        |> updateStatus (EditingUpdate balances sale imageStatus Closed form)
+                    EditingUpdate balances sale imageStatus Closed form
                         |> updateForm
                             (\form_ ->
                                 { form_
@@ -984,10 +956,9 @@ update msg model loggedIn =
                 internalError =
                     I18Next.t loggedIn.shared.translations "error.unknown"
             in
-            case model.status of
+            case model of
                 Deleting balances sale imageStatus form ->
-                    model
-                        |> updateStatus (EditingUpdate balances sale imageStatus Closed form)
+                    EditingUpdate balances sale imageStatus Closed form
                         |> updateForm
                             (\form_ ->
                                 { form_
@@ -1014,71 +985,47 @@ update msg model loggedIn =
                 UR.init model
 
 
-performRequest : Msg -> Model -> Status -> Eos.Name -> String -> Value -> UpdateResult
-performRequest msg model status account action data =
-    model
-        |> updateStatus status
+performRequest : Msg -> Status -> Eos.Name -> String -> Value -> UpdateResult
+performRequest msg status account action data =
+    status
         |> UR.init
         |> UR.addPort
             { responseAddress = msg
             , responseData = Encode.null
             , data =
                 Eos.encodeTransaction
-                    { actions =
-                        [ { accountName = "bes.cmm"
-                          , name = action
-                          , authorization =
-                                { actor = account
-                                , permissionName = Eos.samplePermission
-                                }
-                          , data = data
-                          }
-                        ]
-                    }
+                    [ { accountName = "bes.cmm"
+                      , name = action
+                      , authorization =
+                            { actor = account
+                            , permissionName = Eos.samplePermission
+                            }
+                      , data = data
+                      }
+                    ]
             }
 
 
 updateForm : (Form -> Form) -> Model -> Model
 updateForm transform model =
-    let
-        status =
-            case model.status of
-                LoadingBalancesCreate ->
-                    model.status
+    case model of
+        EditingCreate balances imageStatus form ->
+            EditingCreate balances imageStatus (transform form)
 
-                LoadingBalancesUpdate _ ->
-                    model.status
+        Creating balances imageStatus form ->
+            Creating balances imageStatus (transform form)
 
-                LoadingSaleUpdate _ _ ->
-                    model.status
+        EditingUpdate balances sale imageStatus confirmDelete form ->
+            EditingUpdate balances sale imageStatus confirmDelete (transform form)
 
-                LoadBalancesFailed _ ->
-                    model.status
+        Saving balances sale imageStatus form ->
+            Saving balances sale imageStatus (transform form)
 
-                LoadSaleFailed _ ->
-                    model.status
+        Deleting balances sale imageStatus form ->
+            Deleting balances sale imageStatus (transform form)
 
-                EditingCreate balances imageStatus form ->
-                    EditingCreate balances imageStatus (transform form)
-
-                Creating balances imageStatus form ->
-                    Creating balances imageStatus (transform form)
-
-                EditingUpdate balances sale imageStatus confirmDelete form ->
-                    EditingUpdate balances sale imageStatus confirmDelete (transform form)
-
-                Saving balances sale imageStatus form ->
-                    Saving balances sale imageStatus (transform form)
-
-                Deleting balances sale imageStatus form ->
-                    Deleting balances sale imageStatus (transform form)
-    in
-    { model | status = status }
-
-
-updateStatus : Status -> Model -> Model
-updateStatus status model =
-    { model | status = status }
+        _ ->
+            model
 
 
 validateForm : Form -> Form

--- a/src/elm/Ports.elm
+++ b/src/elm/Ports.elm
@@ -8,10 +8,6 @@ port module Ports exposing
     , storeLanguage
     )
 
-import Eos exposing (Symbol)
-import Eos.Account as Eos
-import Json.Decode as Decode
-import Json.Decode.Pipeline as Decode exposing (optional, required)
 import Json.Encode as Encode exposing (Value)
 
 
@@ -63,25 +59,3 @@ port javascriptInPort : (Value -> msg) -> Sub msg
 
 
 port storeLanguage : String -> Cmd msg
-
-
-
---
--- Callbacks
---
--- Helpers
-
-
-decodeAccountNameOrStringError : Value -> Result String ( Eos.Name, Maybe String )
-decodeAccountNameOrStringError value =
-    Decode.decodeValue
-        (Decode.succeed (\accountName maybePrivateKey -> ( accountName, maybePrivateKey ))
-            |> Decode.required "accountName" Eos.nameDecoder
-            |> Decode.optional "privateKey" (Decode.nullable Decode.string) Nothing
-        )
-        value
-        |> Result.mapError
-            (\s ->
-                Decode.decodeValue Decode.string value
-                    |> Result.withDefault "Failed to decode"
-            )

--- a/src/elm/PushSubscription.elm
+++ b/src/elm/PushSubscription.elm
@@ -2,11 +2,11 @@ module PushSubscription exposing (Keys, PushSubscription, activatePushMutation, 
 
 import Cambiatus.Mutation as Mutation
 import Eos.Account as Eos
-import Graphql.Operation exposing (RootMutation, RootQuery)
+import Graphql.Operation exposing (RootMutation)
 import Graphql.OptionalArgument exposing (OptionalArgument(..))
-import Graphql.SelectionSet as SelectionSet exposing (SelectionSet, with)
+import Graphql.SelectionSet as SelectionSet exposing (SelectionSet)
 import Json.Decode as Decode exposing (Decoder, string)
-import Json.Decode.Pipeline exposing (custom, required)
+import Json.Decode.Pipeline exposing (required)
 
 
 type alias Keys =

--- a/src/elm/Select.elm
+++ b/src/elm/Select.elm
@@ -104,7 +104,7 @@ This is the element that wraps the selected item(s) and the input
 
 -}
 
-import Html exposing (..)
+import Html exposing (Html)
 import Select.Config as Config
 import Select.Messages as Messages
 import Select.Models as Models

--- a/src/elm/Select/Events.elm
+++ b/src/elm/Select/Events.elm
@@ -1,16 +1,16 @@
 module Select.Events exposing (onBlurAttribute)
 
-import Html exposing (..)
-import Html.Events exposing (keyCode, on)
+import Html exposing (Attribute)
+import Html.Events exposing (on)
 import Json.Decode as Decode
 import Select.Config exposing (Config)
-import Select.Messages exposing (..)
+import Select.Messages exposing (Msg(..))
 import Select.Models exposing (State)
 import Select.Utils exposing (referenceDataName)
 
 
 onBlurAttribute : Config msg item -> State -> Attribute (Msg item)
-onBlurAttribute config state =
+onBlurAttribute _ state =
     let
         dataDecoder =
             Decode.at [ "relatedTarget", "attributes", referenceDataName, "value" ] Decode.string

--- a/src/elm/Select/Search.elm
+++ b/src/elm/Select/Search.elm
@@ -10,9 +10,6 @@ then no search has been done and we shouldn't show the menu.
 matchedItemsWithCutoff : Config msg item -> Maybe String -> List item -> List item -> Maybe (List item)
 matchedItemsWithCutoff config maybeQuery availableItems selectedItems =
     case maybeQuery of
-        Nothing ->
-            Nothing
-
         {- When emptySearch is On, onBlur will set query to Just "" -}
         Just "" ->
             if config.emptySearch then
@@ -27,6 +24,9 @@ matchedItemsWithCutoff config maybeQuery availableItems selectedItems =
             filterItems config availableItems selectedItems
                 |> config.filter query
                 |> Maybe.map (maybeCuttoff config)
+
+        _ ->
+            Nothing
 
 
 {-| If this is a multi select, then we don't want to display the selected items

--- a/src/elm/Select/Select.elm
+++ b/src/elm/Select/Select.elm
@@ -1,9 +1,9 @@
 module Select.Select exposing (view)
 
-import Html exposing (..)
+import Html exposing (Html, div)
 import Html.Attributes exposing (class, id, style)
 import Select.Config exposing (Config)
-import Select.Messages exposing (..)
+import Select.Messages exposing (Msg)
 import Select.Models exposing (State)
 import Select.Select.Input
 import Select.Select.Menu

--- a/src/elm/Select/Select/Clear.elm
+++ b/src/elm/Select/Select/Clear.elm
@@ -1,7 +1,7 @@
 module Select.Select.Clear exposing (svgPath, view)
 
 import Select.Config exposing (Config)
-import Svg exposing (..)
+import Svg exposing (Svg, g, path, svg)
 import Svg.Attributes as Attrs
 
 

--- a/src/elm/Select/Select/Input.elm
+++ b/src/elm/Select/Select/Input.elm
@@ -18,7 +18,7 @@ import Json.Decode as Decode
 import Select.Config exposing (Config)
 import Select.Events exposing (onBlurAttribute)
 import Select.Messages as Msg exposing (Msg)
-import Select.Models as Models exposing (State)
+import Select.Models exposing (State)
 import Select.Search as Search
 import Select.Select.Clear as Clear
 import Select.Select.RemoveItem as RemoveItem
@@ -177,9 +177,9 @@ view config model availableItems selectedItems =
                     maybeMatchedItems
     in
     Html.div
-        ([ class inputControlClass ] ++ inputControlStylesAttrs)
+        (class inputControlClass :: inputControlStylesAttrs)
         [ Html.div
-            ([ class inputWrapperClass ] ++ inputWrapperStylesAttrs)
+            (class inputWrapperClass :: inputWrapperStylesAttrs)
             input
         , underline
         , clear
@@ -284,7 +284,7 @@ singleInput config model availableItems selectedItems maybeMatchedItems =
 
 
 inputAttributes : Config msg item -> State -> List item -> List item -> Maybe (List item) -> List (Html.Attribute (Msg item))
-inputAttributes config model availableItems selectedItems maybeMatchedItems =
+inputAttributes config model _ selectedItems maybeMatchedItems =
     let
         inputClasses : String
         inputClasses =
@@ -316,9 +316,6 @@ inputAttributes config model availableItems selectedItems maybeMatchedItems =
         preselectedItem : Maybe item
         preselectedItem =
             case maybeMatchedItems of
-                Nothing ->
-                    Nothing
-
                 Just matchedItems ->
                     if config.isMultiSelect then
                         case model.highlightedItem of
@@ -331,6 +328,9 @@ inputAttributes config model availableItems selectedItems maybeMatchedItems =
 
                     else
                         List.head matchedItems
+
+                _ ->
+                    Nothing
     in
     [ autocomplete False
     , attribute "autocorrect" "off" -- for mobile Safari

--- a/src/elm/Select/Select/Input.elm
+++ b/src/elm/Select/Select/Input.elm
@@ -249,8 +249,8 @@ multiInput config model availableItems selected maybeMatchedItems =
     in
     [ viewMultiItems selected
     , Html.input
-        (inputAttributes config model availableItems selected maybeMatchedItems
-            ++ [ value val ]
+        (value val
+            :: inputAttributes config model availableItems selected maybeMatchedItems
             ++ (if List.isEmpty selected then
                     [ placeholder config.prompt ]
 

--- a/src/elm/Select/Select/Item.elm
+++ b/src/elm/Select/Select/Item.elm
@@ -1,10 +1,10 @@
 module Select.Select.Item exposing (baseItemClasses, baseItemStyles, view, viewNotFound)
 
-import Html exposing (..)
-import Html.Attributes exposing (attribute, class, style)
+import Html exposing (Html, div, text)
+import Html.Attributes exposing (class, style)
 import Html.Events exposing (onMouseDown)
 import Select.Config exposing (Config)
-import Select.Messages exposing (..)
+import Select.Messages exposing (Msg(..))
 import Select.Models exposing (State)
 import Select.Styles as Styles
 import Select.Utils exposing (referenceAttr)

--- a/src/elm/Select/Select/Menu.elm
+++ b/src/elm/Select/Select/Menu.elm
@@ -1,14 +1,13 @@
 module Select.Select.Menu exposing (menu, view, viewClassAttr, viewStyles)
 
-import Html exposing (..)
+import Html exposing (Attribute, Html, div, text)
 import Html.Attributes exposing (class, style)
 import Select.Config exposing (Config)
-import Select.Messages exposing (..)
-import Select.Models as Models exposing (State)
+import Select.Messages exposing (Msg(..))
+import Select.Models exposing (State)
 import Select.Search as Search
 import Select.Select.Item as Item
 import Select.Styles as Styles
-import Select.Utils as Utils
 
 
 view : Config msg item -> State -> List item -> List item -> Html (Msg item)

--- a/src/elm/Select/Select/RemoveItem.elm
+++ b/src/elm/Select/Select/RemoveItem.elm
@@ -3,7 +3,7 @@ module Select.Select.RemoveItem exposing (svgPath, view)
 import Html.Attributes as HtmlAttrs
 import Select.Config exposing (Config)
 import Select.Styles as Styles
-import Svg exposing (..)
+import Svg exposing (Svg, path, svg)
 import Svg.Attributes as Attrs
 
 

--- a/src/elm/Select/Update.elm
+++ b/src/elm/Select/Update.elm
@@ -1,7 +1,7 @@
 module Select.Update exposing (update)
 
 import Select.Config exposing (Config)
-import Select.Messages exposing (..)
+import Select.Messages exposing (Msg(..))
 import Select.Models exposing (State)
 import Task
 
@@ -61,23 +61,22 @@ update config msg model =
 
                         Just focusMessage ->
                             Task.succeed Nothing
-                                |> Task.perform (\x -> focusMessage)
+                                |> Task.perform (\_ -> focusMessage)
             in
-            case config.emptySearch of
-                True ->
-                    ( { model | query = Just "" }
-                    , Cmd.batch
-                        [ cmd
-                        , if config.emptySearch then
-                            queryChangeCmd ""
+            if config.emptySearch then
+                ( { model | query = Just "" }
+                , Cmd.batch
+                    [ cmd
+                    , if config.emptySearch then
+                        queryChangeCmd ""
 
-                          else
-                            Cmd.none
-                        ]
-                    )
+                      else
+                        Cmd.none
+                    ]
+                )
 
-                False ->
-                    ( model, cmd )
+            else
+                ( model, cmd )
 
         OnBlur ->
             ( { model | query = Nothing }, Cmd.none )

--- a/src/elm/Select/Utils.elm
+++ b/src/elm/Select/Utils.elm
@@ -8,7 +8,7 @@ module Select.Utils exposing
 import Html exposing (Attribute)
 import Html.Attributes exposing (attribute, style)
 import Select.Config exposing (Config)
-import Select.Models as Models exposing (State)
+import Select.Models exposing (State)
 
 
 referenceDataName : String
@@ -17,7 +17,7 @@ referenceDataName =
 
 
 referenceAttr : Config msg item -> State -> Attribute msg2
-referenceAttr config model =
+referenceAttr _ model =
     attribute referenceDataName model.id
 
 

--- a/src/elm/Session/Guest.elm
+++ b/src/elm/Session/Guest.elm
@@ -1,21 +1,17 @@
 module Session.Guest exposing (External(..), Model, Msg(..), Page(..), addAfterLoginRedirect, init, initModel, msgToString, subscriptions, update, view)
 
-import Api
-import Asset.Icon as Icon
 import Browser.Events
-import Html exposing (..)
-import Html.Attributes exposing (..)
-import Html.Events exposing (onClick, onFocus, onInput, onMouseEnter, onSubmit)
+import Html exposing (Html, button, div, header, img, p, span, text)
+import Html.Attributes exposing (alt, class, classList, src, style, tabindex, type_)
+import Html.Events exposing (onClick, onMouseEnter)
 import Http
-import I18Next exposing (Delims(..), Translations, t, tr)
+import I18Next exposing (Delims(..), Translations)
 import Icons
 import Json.Decode as Decode
-import Log
 import Ports
 import Profile exposing (Profile)
 import Route exposing (Route)
 import Session.Shared as Shared exposing (Shared)
-import Time
 import Translation
 import UpdateResult as UR
 
@@ -31,8 +27,8 @@ init shared =
     )
 
 
-fetchTranslations : String -> Shared -> Cmd Msg
-fetchTranslations language shared =
+fetchTranslations : String -> Cmd Msg
+fetchTranslations language =
     CompletedLoadTranslation language
         |> Translation.get language
 
@@ -63,7 +59,7 @@ initModel shared =
 
 
 subscriptions : Model -> Sub Msg
-subscriptions model =
+subscriptions _ =
     Sub.map KeyDown (Browser.Events.onKeyDown (Decode.field "key" Decode.string))
 
 
@@ -81,7 +77,7 @@ type Page
 
 
 view : (Msg -> msg) -> Page -> Model -> Html msg -> Html msg
-view thisMsg page ({ shared } as model) content =
+view thisMsg _ ({ shared } as model) content =
     case Shared.translationStatus shared of
         Shared.LoadingTranslation ->
             Shared.viewFullLoading
@@ -233,7 +229,7 @@ update msg ({ shared } as model) =
                 |> UR.init
                 |> UR.addCmd (Ports.storeLanguage lang)
 
-        CompletedLoadTranslation lang (Err err) ->
+        CompletedLoadTranslation _ (Err err) ->
             { model | shared = Shared.loadTranslation (Err err) shared }
                 |> UR.init
                 |> UR.logHttpError msg err
@@ -241,7 +237,7 @@ update msg ({ shared } as model) =
         ClickedTryAgainTranslation ->
             { model | shared = Shared.toLoadingTranslation shared }
                 |> UR.init
-                |> UR.addCmd (fetchTranslations (Shared.language shared) shared)
+                |> UR.addCmd (fetchTranslations (Shared.language shared))
 
         ShowLanguageNav b ->
             UR.init { model | showLanguageNav = b }
@@ -252,7 +248,7 @@ update msg ({ shared } as model) =
                 , showLanguageNav = False
             }
                 |> UR.init
-                |> UR.addCmd (fetchTranslations lang shared)
+                |> UR.addCmd (fetchTranslations lang)
 
         KeyDown key ->
             if key == "Esc" || key == "Escape" then

--- a/src/elm/Session/LoggedIn.elm
+++ b/src/elm/Session/LoggedIn.elm
@@ -40,7 +40,7 @@ import Flags exposing (Flags)
 import Graphql.Document
 import Graphql.Http
 import Graphql.Operation exposing (RootSubscription)
-import Graphql.SelectionSet as SelectionSet exposing (SelectionSet, with)
+import Graphql.SelectionSet exposing (SelectionSet)
 import Html exposing (Html, a, button, div, footer, img, input, nav, p, span, text)
 import Html.Attributes exposing (class, classList, placeholder, required, src, style, type_, value)
 import Html.Events exposing (onClick, onFocus, onInput, onMouseEnter, onSubmit, stopPropagationOn)
@@ -838,7 +838,7 @@ update msg model =
             UR.init closeAllModals
 
         GotAuthMsg authMsg ->
-            Auth.update authMsg shared model.auth model.showAuthModal
+            Auth.update authMsg shared model.auth
                 |> UR.map
                     (\a -> { model | auth = a })
                     GotAuthMsg
@@ -861,7 +861,7 @@ update msg model =
         CompletedLoadUnread payload ->
             case Decode.decodeValue (unreadCountSubscription model.accountName |> Graphql.Document.decoder) payload of
                 Ok res ->
-                    { model | unreadCount = res.unreads }
+                    { model | unreadCount = res }
                         |> UR.init
 
                 Err _ ->
@@ -967,13 +967,16 @@ isAccount accountName model =
 
 
 type alias UnreadMeta =
-    { unreads : Int }
+    Int
+
+
+
+-- { unreads : Int }
 
 
 unreadSelection : SelectionSet UnreadMeta Cambiatus.Object.UnreadNotifications
 unreadSelection =
-    SelectionSet.succeed UnreadMeta
-        |> with Cambiatus.Object.UnreadNotifications.unreads
+    Cambiatus.Object.UnreadNotifications.unreads
 
 
 unreadCountSubscription : Eos.Name -> SelectionSet UnreadMeta RootSubscription

--- a/src/elm/Session/LoggedIn.elm
+++ b/src/elm/Session/LoggedIn.elm
@@ -970,10 +970,6 @@ type alias UnreadMeta =
     Int
 
 
-
--- { unreads : Int }
-
-
 unreadSelection : SelectionSet UnreadMeta Cambiatus.Object.UnreadNotifications
 unreadSelection =
     Cambiatus.Object.UnreadNotifications.unreads

--- a/src/elm/Session/Shared.elm
+++ b/src/elm/Session/Shared.elm
@@ -14,12 +14,12 @@ module Session.Shared exposing
     )
 
 import Browser.Navigation as Nav
-import Eos exposing (Symbol)
+import Eos
 import Eos.Account as Eos
-import Flags exposing (Endpoints, Environment, Flags, defaultEndpoints)
+import Flags exposing (Endpoints, Environment, Flags)
 import Graphql.Http
-import Html exposing (..)
-import Html.Attributes exposing (..)
+import Html exposing (Html, button, div, img, p, text)
+import Html.Attributes exposing (class, src)
 import Html.Events exposing (onClick)
 import Http
 import I18Next exposing (Translations, initialTranslations, t)
@@ -178,7 +178,7 @@ viewFullLoading =
 
 
 viewFullError : Shared -> Http.Error -> msg -> String -> Html msg
-viewFullError shared err msg msgText =
+viewFullError shared _ msg msgText =
     div [ class "full-page-loading full-spinner-container" ]
         [ p [] [ text msgText ]
         , button [ onClick msg ] [ text (t shared.translations "menu.try_again") ]
@@ -186,7 +186,7 @@ viewFullError shared err msg msgText =
 
 
 viewFullGraphqlError : Shared -> Graphql.Http.Error e -> msg -> String -> Html msg
-viewFullGraphqlError shared err msg msgText =
+viewFullGraphqlError shared _ msg msgText =
     div [ class "full-page-loading full-spinner-container" ]
         [ p [] [ text msgText ]
         , button [ onClick msg ] [ text (t shared.translations "menu.try_again") ]

--- a/src/elm/Shop.elm
+++ b/src/elm/Shop.elm
@@ -8,11 +8,8 @@ module Shop exposing
     , salesQuery
     )
 
-import Avatar exposing (Avatar)
 import Cambiatus.Object
-import Cambiatus.Object.Profile as Creator
 import Cambiatus.Object.Sale
-import Cambiatus.Object.SaleHistory
 import Cambiatus.Query
 import Eos exposing (Symbol)
 import Eos.Account as Eos
@@ -43,10 +40,6 @@ type alias Sale =
     , trackStock : Bool
     , creator : Profile
     }
-
-
-type alias SaleAvatar =
-    { avatar : Avatar }
 
 
 type alias SaleId =

--- a/src/elm/Transfer.elm
+++ b/src/elm/Transfer.elm
@@ -62,8 +62,7 @@ type alias Transfer =
 
 
 type alias Cmm =
-    { name : String
-    }
+    String
 
 
 type alias EdgeTransfer =
@@ -112,9 +111,7 @@ transferItemSelectionSet =
         |> with (Eos.symbolSelectionSet Cambiatus.Object.Transfer.communityId)
         |> with
             (Cambiatus.Object.Transfer.community
-                (SelectionSet.succeed Cmm
-                    |> with Cambiatus.Object.Community.name
-                )
+                Cambiatus.Object.Community.name
             )
         |> with Cambiatus.Object.Transfer.createdAt
 

--- a/src/elm/Translation.elm
+++ b/src/elm/Translation.elm
@@ -1,10 +1,8 @@
 module Translation exposing (get)
 
-import Api
-import Flags exposing (Endpoints)
 import Http
 import I18Next exposing (Translations)
-import Url.Builder exposing (QueryParameter)
+import Url.Builder
 
 
 get : String -> (Result Http.Error Translations -> msg) -> Cmd msg

--- a/src/elm/UpdateResult.elm
+++ b/src/elm/UpdateResult.elm
@@ -36,7 +36,7 @@ module UpdateResult exposing
 import Graphql.Http
 import Http
 import Json.Decode as Decode
-import Json.Encode as Encode exposing (Value)
+import Json.Encode exposing (Value)
 import Log exposing (Log)
 import Ports
 


### PR DESCRIPTION
## What issue does this PR close
No issue is related to this PR

## Changes Proposed ( a list of new changes introduced by this PR)
Do a cleanup to the project warning, since we moved it from the private repository we had lots of old warnings, refactors that still used some of the old pages structure, etc

This intend do to a clean up of several warnings, but not all, some of them are still there:

- A few from our auto generated Graphql types, those will be automatically generated/updated as we add stuff to the backend api, so no point in fixing them
- A query from transfer, that may be more useful to remove after we added the Timeline feature
- a few TODOs that are still relevant somehow

## How to test ( a list of instructions on how to test this PR)
The test is just to make sure the project compiles properly, no behaviours were changed
