### PR TITLE
WIP: Add user quotes to the login screen

### DIFF
--- a/src/elm/Session/Guest.elm
+++ b/src/elm/Session/Guest.elm
@@ -146,7 +146,14 @@ viewLeftCol mdWidth =
         , style "background-size" "auto 80%"
         , style "background-image" "url(images/auth_bg_full.png)"
         ]
-        []
+        [ -- TODO: Replace this placeholder with the actual data
+          viewQuote
+            { photoSrc = "images/woman.png"
+            , name = "Victoria Lane"
+            , occupation = "Founder"
+            , quote = "We are designing for a global user base, we can get feedback not just from drivers we see in San Francisco"
+            }
+        ]
 
 
 viewPageHeader : Model -> Shared -> Html Msg
@@ -213,9 +220,6 @@ type alias Quote =
     }
 
 
-{-| This function will be used later, when actual user quotes will be collected.
-See <https://github.com/cambiatus/frontend/issues/238> for details.
--}
 viewQuote : Quote -> Html msg
 viewQuote { photoSrc, name, occupation, quote } =
     div


### PR DESCRIPTION
## What issue does this PR close
Closes #238 

## Changes Proposed (a list of new changes introduced by this PR)
Add the block with user quotes according to design.

## How to test ( a list of instructions on how to test this PR)
- Make sure you are logged out.
- Make sure you are using the desktop viewport.
- Go to the login page, there should be some user quotes at the left top corner.
