### PR TITLE
Add hotfix for the bug with 404 for assets on the home page

### DIFF
--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,7 +1,8 @@
-var CACHE_NAME = 'bes-site-cache-v1'
-var urlsToCache = [
-  '/'
-]
+var CACHE_NAME = 'bes-site-cache-v1-hotfix'
+
+// See https://github.com/cambiatus/frontend/issues/252 for the details
+var urlsToCache = []
+self.caches.delete('bes-site-cache-v1')
 
 // install event handler here setup our local landscape
 self.addEventListener('install', function (event) {


### PR DESCRIPTION
## What issue does this PR close
Closes #252.

## Changes Proposed ( a list of new changes introduced by this PR)
- Remove old cache which caused errors.
- Create a new empty cache just to make sure all other code still works.

This PR just removes broken cache for one (and only) cached endpoint — Home Page. This is really dumb solution and the caching with service worker needs further investigation. But I think since our users have the problem with the Home Page we should fix it somehow quickly and then create a more robust solution in the separate issue.

## How to test ( a list of instructions on how to test this PR)
After building the website home page should work fine, all JS files should be available.
