### PR TITLE
Fixes edit offer button styling

### DIFF
--- a/src/elm/Page/Shop/Viewer.elm
+++ b/src/elm/Page/Shop/Viewer.elm
@@ -448,11 +448,11 @@ viewCard ({ shared } as loggedIn) card model =
                             [ text (tr "account.my_wallet.your_current_balance" [ ( "balance", currBalance ) ]) ]
                         ]
                     ]
-                , div [ class " mt-6 md:mt-0" ]
+                , div [ class " mt-6 md:mt-0 w-full md:w-40 lg:w-40" ]
                     [ if card.sale.creatorId == loggedIn.accountName then
                         div [ class "flex md:justify-end" ]
                             [ button
-                                [ class "button button-primary w-full"
+                                [ class "button button-primary w-full px-4"
                                 , onClick (ClickedEdit card.sale)
                                 ]
                                 [ text_ "shop.edit" ]

--- a/src/elm/Page/Shop/Viewer.elm
+++ b/src/elm/Page/Shop/Viewer.elm
@@ -448,7 +448,7 @@ viewCard ({ shared } as loggedIn) card model =
                             [ text (tr "account.my_wallet.your_current_balance" [ ( "balance", currBalance ) ]) ]
                         ]
                     ]
-                , div [ class " mt-6 md:mt-0 w-full md:w-40 lg:w-40" ]
+                , div [ class "mt-6 md:mt-0 w-full sm:w-40" ]
                     [ if card.sale.creatorId == loggedIn.accountName then
                         div [ class "flex md:justify-end" ]
                             [ button
@@ -479,7 +479,7 @@ viewCard ({ shared } as loggedIn) card model =
                       else
                         div [ class "flex -mx-2 md:justify-end" ]
                             [ button
-                                [ class "button button-primary mx-auto"
+                                [ class "button button-primary w-full sm:w-40 mx-auto"
                                 , onClick (ClickedBuy card.sale)
                                 ]
                                 [ text_ "shop.buy" ]


### PR DESCRIPTION
## What issue does this PR close
Closes #131 

## Changes Proposed ( a list of new changes introduced by this PR)
Fixes the following styles of the edit-offer-button:
- Padding (left and right = 16px)
- Sizing (responsive - mobile = full width / desktop = regular size)

## How to test ( a list of instructions on how to test this PR)
1. Go to Shop
2. Click on My Offers tab
3. Click on Your offer
4. Change the viewport size 

## Screenshots of the testing

Mobile
![image](https://user-images.githubusercontent.com/53874965/87117674-2526fc80-c247-11ea-88e9-2957dee1139a.png)

Desktop
![image](https://user-images.githubusercontent.com/53874965/87117687-2b1cdd80-c247-11ea-994a-8d57da6d3e42.png)
