### PR TITLE
Put back the objectives that were removed

### DIFF
--- a/src/elm/Page/Community.elm
+++ b/src/elm/Page/Community.elm
@@ -157,7 +157,7 @@ view loggedIn model =
                                 ]
                             , p [ class "text-grey-200 text-sm" ] [ text community.description ]
                             ]
-                        , if canEdit && community.hasObjectives then
+                        , if community.hasObjectives then
                             div [ class "container mx-auto px-4" ]
                                 [ div [ class "bg-white py-6 sm:py-8 px-3 sm:px-6 rounded-lg mt-4" ]
                                     (Page.viewTitle (t "community.objectives.title_plural")
@@ -173,17 +173,7 @@ view loggedIn model =
                                 ]
 
                           else
-                              div [ class "bg-white py-6 sm:py-8 px-3 sm:px-6 rounded-lg mt-4" ]
-                                 (Page.viewTitle (t "community.objectives.title_plural")
-                                     :: List.indexedMap (viewObjective loggedIn model community)
-                                         community.objectives
-                                     ++ [ if canEdit then
-                                             viewObjectiveNew loggedIn editStatus community.symbol
-
-                                           else
-                                             text ""
-                                        ]
-                                 )
+                            text ""
                         ]
     in
     { title = title

--- a/src/elm/Page/Community.elm
+++ b/src/elm/Page/Community.elm
@@ -173,7 +173,17 @@ view loggedIn model =
                                 ]
 
                           else
-                            text ""
+                              div [ class "bg-white py-6 sm:py-8 px-3 sm:px-6 rounded-lg mt-4" ]
+                                 (Page.viewTitle (t "community.objectives.title_plural")
+                                     :: List.indexedMap (viewObjective loggedIn model community)
+                                         community.objectives
+                                     ++ [ if canEdit then
+                                             viewObjectiveNew loggedIn editStatus community.symbol
+
+                                           else
+                                             text ""
+                                        ]
+                                 )
                         ]
     in
     { title = title

--- a/yarn.lock
+++ b/yarn.lock
@@ -8214,7 +8214,7 @@ pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
-pkg-up@2.0.0:
+pkg-up@2.0.0, pkg-up@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/pkg-up/-/pkg-up-2.0.0.tgz#c819ac728059a461cab1c3889a2be3c49a004d7f"
   integrity sha1-yBmscoBZpGHKscOImivjxJoATX8=


### PR DESCRIPTION
## What issue does this PR close
N/A

## Changes Proposed ( a list of new changes introduced by this PR)
Put back the objectives section that was removed by accident. It caused a lot of trouble to MUDA, where no user was able to open new claims. We should be more careful on next reviews and don't remove nothing that we are not sure that needs to be removed or not

## How to test ( a list of instructions on how to test this PR)
Open a community that has objectives enabled and filled in, and you should see something like this:
<img width="1432" alt="Screen Shot 2020-07-25 at 22 39 33" src="https://user-images.githubusercontent.com/1082127/88469397-b80e9a80-cec7-11ea-8b76-88a4c044d78f.png">

