### PR TITLE
Change the default to show shop

### DIFF
--- a/src/elm/Session/LoggedIn.elm
+++ b/src/elm/Session/LoggedIn.elm
@@ -160,7 +160,7 @@ initModel shared authModel accountName selectedCommunity =
     , auth = authModel
     , feedback = Hidden
     , showCommunitySelector = False
-    , hasShop = False
+    , hasShop = True
     , hasObjectives = False
     }
 


### PR DESCRIPTION
## What issue does this PR close
Change default feature enable for shop as True.

This is certainly a **gambiarra** I know. It will solve the issue for the community users for now. The definitive solution should be addressed on #329 where we need to discuss and find a solution for this problem

## Changes Proposed ( a list of new changes introduced by this PR)
- Change the default value for the `hasShop` flag on the `initModel` function. All inside `LoggedIn.elm`

## How to test ( a list of instructions on how to test this PR)
- Login as a user with a community that `hasShop` is set to `true`
- Check if the shop link is available on the main menu
