### PR TITLE
Improve invitation process for inviter and invitee

### DIFF
--- a/public/translations/cat-CAT.json
+++ b/public/translations/cat-CAT.json
@@ -300,6 +300,8 @@
       "subtitle": "Voleu unir-vos a",
       "yes": "Sí, uniu-vos",
       "no": "No gràcies",
+      "already_member": "Ja ets membre d'aquesta comunitat!",
+      "choose_community_tip": "Sempre podeu triar {{communityTitle}} des del menú desplegable que hi ha al cantó superior esquerre del lloc web.",
       "modal": {
         "title": "Atenció",
         "body": "De debò no vols unir-te a la comunitat?",

--- a/public/translations/en-US.json
+++ b/public/translations/en-US.json
@@ -296,6 +296,8 @@
       "subtitle": "Would you like to join",
       "yes": "Yes, join",
       "no": "No, thanks",
+      "already_member": "You are already a member of this community!",
+      "choose_community_tip": "You can always choose {{communityTitle}} from the dropdown in the left upper corner of the website.",
       "modal": {
         "title": "Attention",
         "body": "Don't you really want to join the community?",

--- a/public/translations/es-ES.json
+++ b/public/translations/es-ES.json
@@ -300,6 +300,8 @@
       "subtitle": "Te gustaría unirte",
       "yes": "Si, únete",
       "no": "No, gracias",
+      "already_member": "¡Ya eres miembro de esta comunidad!",
+      "choose_community_tip": "Siempre puede elegir {{communityTitle}} del menú desplegable en la esquina superior izquierda del sitio web.",
       "modal": {
         "title": "Atención",
         "body": "¿Realmente no quieres unirte a la comunidad?",

--- a/public/translations/pt-BR.json
+++ b/public/translations/pt-BR.json
@@ -304,6 +304,8 @@
       "subtitle": "Gostaria de se juntar a",
       "yes": "Sim, participar",
       "no": "Não, obrigado",
+      "already_member": "Você já é membro desta comunidade!",
+      "choose_community_tip": "Você sempre pode escolher {{communityTitle}} no menu suspenso no canto superior esquerdo do site.",
       "modal": {
         "title": "Atenção",
         "body": "Você realmente não deseja participar da comunidade?",

--- a/src/elm/Page/Community/Invite.elm
+++ b/src/elm/Page/Community/Invite.elm
@@ -16,42 +16,24 @@ import Html exposing (Html, button, div, img, span, text)
 import Html.Attributes exposing (class, src)
 import Html.Events exposing (onClick)
 import Http
-import I18Next exposing (t)
 import Page exposing (Session(..), toShared)
 import Profile exposing (Profile)
 import Route
 import Session.LoggedIn as LoggedIn exposing (External)
-import Session.Shared exposing (Shared)
+import Session.Shared exposing (Translators)
 import UpdateResult as UR
 import View.Modal as Modal
 
 
-init : Session -> String -> ( Model, Cmd Msg )
-init session invitationId =
-    ( initModel invitationId
-    , Api.Graphql.query
-        (toShared session)
-        (Community.inviteQuery invitationId)
-        CompletedLoad
-    )
+
+-- TYPES
 
 
-initModel : String -> Model
-initModel invitationId =
-    { status = Loading
-    , confirmationModal = Closed
-    , invitationId = invitationId
-    }
+type alias InvitationId =
+    String
 
 
-type alias Model =
-    { status : Status
-    , confirmationModal : ModalStatus
-    , invitationId : String
-    }
-
-
-type Status
+type PageStatus
     = Loading
     | NotFound
     | Failed (Graphql.Http.Error (Maybe Invite))
@@ -64,14 +46,54 @@ type ModalStatus
     | Open
 
 
+
+-- MODEL
+
+
+type alias Model =
+    { pageStatus : PageStatus
+    , confirmationModalStatus : ModalStatus
+    , invitationId : InvitationId
+    }
+
+
+
+-- INIT
+
+
+initModel : String -> Model
+initModel invitationId =
+    { pageStatus = Loading
+    , confirmationModalStatus = Closed
+    , invitationId = invitationId
+    }
+
+
+init : Session -> String -> ( Model, Cmd Msg )
+init session invitationId =
+    ( initModel invitationId
+    , Api.Graphql.query
+        (toShared session)
+        (Community.inviteQuery invitationId)
+        CompletedLoad
+    )
+
+
+
+-- VIEW
+
+
 view : Session -> Model -> { title : String, content : Html Msg }
 view session model =
     let
         shared =
             toShared session
 
+        { t } =
+            shared.translators
+
         title =
-            case model.status of
+            case model.pageStatus of
                 Loaded invite ->
                     let
                         inviter =
@@ -80,7 +102,7 @@ view session model =
                     in
                     inviter
                         ++ " "
-                        ++ t shared.translations "community.invitation.title"
+                        ++ t "community.invitation.title"
                         ++ " "
                         ++ invite.community.title
 
@@ -88,30 +110,25 @@ view session model =
                     ""
 
         content =
-            div [ class "flex flex-col min-h-screen" ]
-                [ div [ class "flex-grow" ]
-                    [ case model.status of
-                        Loading ->
-                            div [] []
+            case model.pageStatus of
+                Loading ->
+                    div [] []
 
-                        NotFound ->
-                            div [] []
+                NotFound ->
+                    div [] []
 
-                        Failed e ->
-                            Page.fullPageGraphQLError (t shared.translations "") e
+                Failed e ->
+                    Page.fullPageGraphQLError (t "") e
 
-                        Loaded invite ->
-                            div []
-                                [ viewHeader
-                                , viewContent shared invite model.invitationId
-                                , viewModal shared model model.invitationId
-                                ]
+                Loaded invite ->
+                    div []
+                        [ viewHeader
+                        , viewContent shared.translators invite model.invitationId
+                        , viewModal shared.translators model.confirmationModalStatus model.invitationId
+                        ]
 
-                        Error e ->
-                            Page.fullPageError (t shared.translations "") e
-                    ]
-                , viewFooter session
-                ]
+                Error e ->
+                    Page.fullPageError (t "") e
     in
     { title = title
     , content = content
@@ -124,49 +141,52 @@ viewHeader =
         []
 
 
-viewContent : Shared -> Invite -> String -> Html Msg
-viewContent shared invite invitationId =
+viewContent : Translators -> Invite -> InvitationId -> Html Msg
+viewContent { t, tr } { creator, community } invitationId =
     let
         text_ s =
-            text (I18Next.t shared.translations s)
+            text (t s)
 
         inviter =
-            invite.creator.userName
-                |> Maybe.withDefault (Eos.nameToString invite.creator.account)
+            creator.userName
+                |> Maybe.withDefault (Eos.nameToString creator.account)
     in
     div [ class "bg-white pb-20" ]
         [ div [ class "flex flex-wrap content-end" ]
             [ div [ class "flex items-center justify-center h-24 w-24 rounded-full mx-auto -mt-12 bg-white" ]
                 [ img
-                    [ src invite.community.logo
+                    [ src community.logo
                     , class "object-scale-down h-20 w-20"
                     ]
                     []
                 ]
             ]
-        , div [ class " px-4" ]
-            [ div [ class "flex mx-auto justify-center justify-center mt-6" ]
-                [ div [ class "inline-block text-center text-heading font" ]
-                    [ span [ class "mr-1 font-medium" ] [ text inviter ]
+        , div [ class "px-4 text-center" ]
+            [ div [ class "mt-6" ]
+                [ div [ class "text-heading font" ]
+                    [ span [ class "font-medium" ]
+                        [ text inviter
+                        ]
+                    , text " "
                     , text_ "community.invitation.title"
-                    , span [ class "ml-1 font-medium" ] [ text invite.community.title ]
+                    , text " "
+                    , span [ class "font-medium" ]
+                        [ text community.title ]
                     ]
                 ]
-            , div [ class "flex mx-auto justify-center mt-6 px-4" ]
-                [ div [ class "inline-block text-center text-heading" ]
-                    [ span [ class "mr-1" ] [ text_ "community.invitation.subtitle" ]
-                    , text invite.community.title
-                    , text "?"
-                    ]
+            , div [ class "mt-6 px-4 text-heading" ]
+                [ span [ class "mr-1" ] [ text_ "community.invitation.subtitle" ]
+                , text community.title
+                , text "?"
                 ]
             , div [ class "flex flex-wrap justify-center w-full mt-6" ]
                 [ button
-                    [ class "button button-sm button-secondary w-full md:w-48 uppercase mb-4 md:mr-8"
+                    [ class "button button-secondary w-full md:w-48 uppercase mb-4 md:mr-8"
                     , onClick OpenConfirmationModal
                     ]
                     [ text_ "community.invitation.no" ]
                 , button
-                    [ class "button button-sm button-primary w-full md:w-48 uppercase"
+                    [ class "button button-primary w-full md:w-48 uppercase"
                     , onClick (AcceptInvitation invitationId)
                     ]
                     [ text_ "community.invitation.yes" ]
@@ -175,17 +195,14 @@ viewContent shared invite invitationId =
         ]
 
 
-viewModal : Shared -> Model -> String -> Html Msg
-viewModal shared model invitationId =
+viewModal : Translators -> ModalStatus -> InvitationId -> Html Msg
+viewModal { t } modalStatus invitationId =
     let
-        t s =
-            I18Next.t shared.translations s
-
         text_ s =
             text (t s)
 
         isModalVisible =
-            case model.confirmationModal of
+            case modalStatus of
                 Closed ->
                     False
 
@@ -215,20 +232,6 @@ viewModal shared model invitationId =
         |> Modal.toHtml
 
 
-viewFooter : Session -> Html msg
-viewFooter session =
-    let
-        shared =
-            case session of
-                LoggedIn loggedIn ->
-                    loggedIn.shared
-
-                Guest guest ->
-                    guest.shared
-    in
-    LoggedIn.viewFooter shared
-
-
 
 -- UPDATE
 
@@ -250,22 +253,22 @@ update : Session -> Msg -> Model -> UpdateResult
 update session msg model =
     case msg of
         CompletedLoad (Ok (Just invitation)) ->
-            UR.init { model | status = Loaded invitation }
+            UR.init { model | pageStatus = Loaded invitation }
 
         CompletedLoad (Ok Nothing) ->
-            UR.init { model | status = NotFound }
+            UR.init { model | pageStatus = NotFound }
 
         CompletedLoad (Err error) ->
-            { model | status = Failed error }
+            { model | pageStatus = Failed error }
                 |> UR.init
                 |> UR.logGraphqlError msg error
 
         OpenConfirmationModal ->
-            { model | confirmationModal = Open }
+            { model | confirmationModalStatus = Open }
                 |> UR.init
 
         CloseConfirmationModal ->
-            { model | confirmationModal = Closed }
+            { model | confirmationModalStatus = Closed }
                 |> UR.init
 
         RejectInvitation ->
@@ -313,8 +316,12 @@ update session msg model =
                     )
 
         CompletedSignIn _ (Err err) ->
-            { model | status = Error err }
+            { model | pageStatus = Error err }
                 |> UR.init
+
+
+
+-- INTEROP
 
 
 msgToString : Msg -> List String

--- a/src/elm/Page/Community/Invite.elm
+++ b/src/elm/Page/Community/Invite.elm
@@ -113,10 +113,10 @@ view session model =
         content =
             case model.pageStatus of
                 Loading ->
-                    div [] []
+                    text ""
 
                 NotFound ->
-                    div [] []
+                    text ""
 
                 Failed e ->
                     Page.fullPageGraphQLError (t "") e

--- a/src/elm/Page/Dashboard.elm
+++ b/src/elm/Page/Dashboard.elm
@@ -265,7 +265,16 @@ viewInvitationModal { shared } model =
                     "https://"
 
         url invitationId =
-            protocol ++ shared.url.host ++ "/invite/" ++ invitationId
+            let
+                portStr =
+                    case shared.url.port_ of
+                        Just p ->
+                            ":" ++ String.fromInt p
+
+                        Nothing ->
+                            ""
+            in
+            protocol ++ shared.url.host ++ portStr ++ "/invite/" ++ invitationId
 
         isInviteModalVisible =
             case model.inviteModalStatus of


### PR DESCRIPTION
## What issue does this PR close
Closes N/A. Contains handy changes for the invitation process; related to #312 and #311.

## Changes Proposed (a list of new changes introduced by this PR)
- Show notice if the invitee is already a member of the inviter's community;
- Fix the invite link that it may contain a port number like `:3000` (we are doing a lot of tests on localhost so it will help to save time);
- Improve code readability.

![image](https://user-images.githubusercontent.com/140053/90623467-2b819e80-e21f-11ea-8350-965ddbb5ebd3.png)


## How to test ( a list of instructions on how to test this PR)
- Go to Dashboard and press "Invite your friends" on your localhost. There should be a link with a port `:3000`.
- Pretend you are an invitee and open the link. There should be a notice that you are already a member of this community.
- Open the link logged-out and see the usual accept the invitation page.
- Open the link from the user account which is not a member of this community, see the confirmation page (same as for logged-out user).
