### PR TITLE
Finalize invite form for an existing user: add the actual saving of KYC data

### DIFF
--- a/src/elm/Cambiatus/InputObject.elm
+++ b/src/elm/Cambiatus/InputObject.elm
@@ -54,6 +54,53 @@ encodeActionsInput input =
         [ ( "creator", Encode.string |> Encode.optional input.creator ), ( "isCompleted", Encode.bool |> Encode.optional input.isCompleted ), ( "validator", Encode.string |> Encode.optional input.validator ), ( "verificationType", Encode.enum Cambiatus.Enum.VerificationType.toString |> Encode.optional input.verificationType ) ]
 
 
+buildAddressUpdateInput : AddressUpdateInputRequiredFields -> (AddressUpdateInputOptionalFields -> AddressUpdateInputOptionalFields) -> AddressUpdateInput
+buildAddressUpdateInput required fillOptionals =
+    let
+        optionals =
+            fillOptionals
+                { number = Absent }
+    in
+    { accountId = required.accountId, cityId = required.cityId, countryId = required.countryId, neighborhoodId = required.neighborhoodId, number = optionals.number, stateId = required.stateId, street = required.street, zip = required.zip }
+
+
+type alias AddressUpdateInputRequiredFields =
+    { accountId : String
+    , cityId : String
+    , countryId : String
+    , neighborhoodId : String
+    , stateId : String
+    , street : String
+    , zip : String
+    }
+
+
+type alias AddressUpdateInputOptionalFields =
+    { number : OptionalArgument String }
+
+
+{-| Type for the AddressUpdateInput input object.
+-}
+type alias AddressUpdateInput =
+    { accountId : String
+    , cityId : String
+    , countryId : String
+    , neighborhoodId : String
+    , number : OptionalArgument String
+    , stateId : String
+    , street : String
+    , zip : String
+    }
+
+
+{-| Encode a AddressUpdateInput into a value that can be used as an argument.
+-}
+encodeAddressUpdateInput : AddressUpdateInput -> Value
+encodeAddressUpdateInput input =
+    Encode.maybeObject
+        [ ( "accountId", Encode.string input.accountId |> Just ), ( "cityId", Encode.string input.cityId |> Just ), ( "countryId", Encode.string input.countryId |> Just ), ( "neighborhoodId", Encode.string input.neighborhoodId |> Just ), ( "number", Encode.string |> Encode.optional input.number ), ( "stateId", Encode.string input.stateId |> Just ), ( "street", Encode.string input.street |> Just ), ( "zip", Encode.string input.zip |> Just ) ]
+
+
 buildChecksInput : (ChecksInputOptionalFields -> ChecksInputOptionalFields) -> ChecksInput
 buildChecksInput fillOptionals =
     let
@@ -250,6 +297,41 @@ encodeInviteInput : InviteInput -> Value
 encodeInviteInput input =
     Encode.maybeObject
         [ ( "id", Encode.string |> Encode.optional input.id ) ]
+
+
+buildKycDataUpdateInput : KycDataUpdateInputRequiredFields -> KycDataUpdateInput
+buildKycDataUpdateInput required =
+    { accountId = required.accountId, countryId = required.countryId, document = required.document, documentType = required.documentType, phone = required.phone, userType = required.userType }
+
+
+type alias KycDataUpdateInputRequiredFields =
+    { accountId : String
+    , countryId : String
+    , document : String
+    , documentType : String
+    , phone : String
+    , userType : String
+    }
+
+
+{-| Type for the KycDataUpdateInput input object.
+-}
+type alias KycDataUpdateInput =
+    { accountId : String
+    , countryId : String
+    , document : String
+    , documentType : String
+    , phone : String
+    , userType : String
+    }
+
+
+{-| Encode a KycDataUpdateInput into a value that can be used as an argument.
+-}
+encodeKycDataUpdateInput : KycDataUpdateInput -> Value
+encodeKycDataUpdateInput input =
+    Encode.maybeObject
+        [ ( "accountId", Encode.string input.accountId |> Just ), ( "countryId", Encode.string input.countryId |> Just ), ( "document", Encode.string input.document |> Just ), ( "documentType", Encode.string input.documentType |> Just ), ( "phone", Encode.string input.phone |> Just ), ( "userType", Encode.string input.userType |> Just ) ]
 
 
 buildNewCommunityInput : NewCommunityInputRequiredFields -> NewCommunityInput

--- a/src/elm/Cambiatus/InputObject.elm
+++ b/src/elm/Cambiatus/InputObject.elm
@@ -66,10 +66,10 @@ buildAddressUpdateInput required fillOptionals =
 
 type alias AddressUpdateInputRequiredFields =
     { accountId : String
-    , cityId : String
-    , countryId : String
-    , neighborhoodId : String
-    , stateId : String
+    , cityId : Cambiatus.ScalarCodecs.Id
+    , countryId : Cambiatus.ScalarCodecs.Id
+    , neighborhoodId : Cambiatus.ScalarCodecs.Id
+    , stateId : Cambiatus.ScalarCodecs.Id
     , street : String
     , zip : String
     }
@@ -83,11 +83,11 @@ type alias AddressUpdateInputOptionalFields =
 -}
 type alias AddressUpdateInput =
     { accountId : String
-    , cityId : String
-    , countryId : String
-    , neighborhoodId : String
+    , cityId : Cambiatus.ScalarCodecs.Id
+    , countryId : Cambiatus.ScalarCodecs.Id
+    , neighborhoodId : Cambiatus.ScalarCodecs.Id
     , number : OptionalArgument String
-    , stateId : String
+    , stateId : Cambiatus.ScalarCodecs.Id
     , street : String
     , zip : String
     }
@@ -98,7 +98,7 @@ type alias AddressUpdateInput =
 encodeAddressUpdateInput : AddressUpdateInput -> Value
 encodeAddressUpdateInput input =
     Encode.maybeObject
-        [ ( "accountId", Encode.string input.accountId |> Just ), ( "cityId", Encode.string input.cityId |> Just ), ( "countryId", Encode.string input.countryId |> Just ), ( "neighborhoodId", Encode.string input.neighborhoodId |> Just ), ( "number", Encode.string |> Encode.optional input.number ), ( "stateId", Encode.string input.stateId |> Just ), ( "street", Encode.string input.street |> Just ), ( "zip", Encode.string input.zip |> Just ) ]
+        [ ( "accountId", Encode.string input.accountId |> Just ), ( "cityId", (Cambiatus.ScalarCodecs.codecs |> Cambiatus.Scalar.unwrapEncoder .codecId) input.cityId |> Just ), ( "countryId", (Cambiatus.ScalarCodecs.codecs |> Cambiatus.Scalar.unwrapEncoder .codecId) input.countryId |> Just ), ( "neighborhoodId", (Cambiatus.ScalarCodecs.codecs |> Cambiatus.Scalar.unwrapEncoder .codecId) input.neighborhoodId |> Just ), ( "number", Encode.string |> Encode.optional input.number ), ( "stateId", (Cambiatus.ScalarCodecs.codecs |> Cambiatus.Scalar.unwrapEncoder .codecId) input.stateId |> Just ), ( "street", Encode.string input.street |> Just ), ( "zip", Encode.string input.zip |> Just ) ]
 
 
 buildChecksInput : (ChecksInputOptionalFields -> ChecksInputOptionalFields) -> ChecksInput
@@ -306,7 +306,7 @@ buildKycDataUpdateInput required =
 
 type alias KycDataUpdateInputRequiredFields =
     { accountId : String
-    , countryId : String
+    , countryId : Cambiatus.ScalarCodecs.Id
     , document : String
     , documentType : String
     , phone : String
@@ -318,7 +318,7 @@ type alias KycDataUpdateInputRequiredFields =
 -}
 type alias KycDataUpdateInput =
     { accountId : String
-    , countryId : String
+    , countryId : Cambiatus.ScalarCodecs.Id
     , document : String
     , documentType : String
     , phone : String
@@ -331,7 +331,7 @@ type alias KycDataUpdateInput =
 encodeKycDataUpdateInput : KycDataUpdateInput -> Value
 encodeKycDataUpdateInput input =
     Encode.maybeObject
-        [ ( "accountId", Encode.string input.accountId |> Just ), ( "countryId", Encode.string input.countryId |> Just ), ( "document", Encode.string input.document |> Just ), ( "documentType", Encode.string input.documentType |> Just ), ( "phone", Encode.string input.phone |> Just ), ( "userType", Encode.string input.userType |> Just ) ]
+        [ ( "accountId", Encode.string input.accountId |> Just ), ( "countryId", (Cambiatus.ScalarCodecs.codecs |> Cambiatus.Scalar.unwrapEncoder .codecId) input.countryId |> Just ), ( "document", Encode.string input.document |> Just ), ( "documentType", Encode.string input.documentType |> Just ), ( "phone", Encode.string input.phone |> Just ), ( "userType", Encode.string input.userType |> Just ) ]
 
 
 buildNewCommunityInput : NewCommunityInputRequiredFields -> NewCommunityInput

--- a/src/elm/Cambiatus/Mutation.elm
+++ b/src/elm/Cambiatus/Mutation.elm
@@ -61,3 +61,25 @@ type alias UpdateProfileRequiredArguments =
 updateProfile : UpdateProfileRequiredArguments -> SelectionSet decodesTo Cambiatus.Object.Profile -> SelectionSet (Maybe decodesTo) RootMutation
 updateProfile requiredArgs object_ =
     Object.selectionForCompositeField "updateProfile" [ Argument.required "input" requiredArgs.input Cambiatus.InputObject.encodeProfileUpdateInput ] object_ (identity >> Decode.nullable)
+
+
+type alias UpsertAddressRequiredArguments =
+    { input : Cambiatus.InputObject.AddressUpdateInput }
+
+
+{-| Updates user's address if it already exists or inserts a new one if user hasn't it yet.
+-}
+upsertAddress : UpsertAddressRequiredArguments -> SelectionSet decodesTo Cambiatus.Object.Address -> SelectionSet (Maybe decodesTo) RootMutation
+upsertAddress requiredArgs object_ =
+    Object.selectionForCompositeField "upsertAddress" [ Argument.required "input" requiredArgs.input Cambiatus.InputObject.encodeAddressUpdateInput ] object_ (identity >> Decode.nullable)
+
+
+type alias UpsertKycRequiredArguments =
+    { input : Cambiatus.InputObject.KycDataUpdateInput }
+
+
+{-| Updates user's KYC info if it already exists or inserts a new one if user hasn't it yet.
+-}
+upsertKyc : UpsertKycRequiredArguments -> SelectionSet decodesTo Cambiatus.Object.KycData -> SelectionSet (Maybe decodesTo) RootMutation
+upsertKyc requiredArgs object_ =
+    Object.selectionForCompositeField "upsertKyc" [ Argument.required "input" requiredArgs.input Cambiatus.InputObject.encodeKycDataUpdateInput ] object_ (identity >> Decode.nullable)

--- a/src/elm/Cambiatus/Object/City.elm
+++ b/src/elm/Cambiatus/Object/City.elm
@@ -19,6 +19,11 @@ import Graphql.SelectionSet exposing (SelectionSet)
 import Json.Decode as Decode
 
 
+id : SelectionSet Cambiatus.ScalarCodecs.Id Cambiatus.Object.City
+id =
+    Object.selectionForField "ScalarCodecs.Id" "id" [] (Cambiatus.ScalarCodecs.codecs |> Cambiatus.Scalar.unwrapCodecs |> .codecId |> .decoder)
+
+
 name : SelectionSet String Cambiatus.Object.City
 name =
     Object.selectionForField "String" "name" [] Decode.string

--- a/src/elm/Cambiatus/Object/Country.elm
+++ b/src/elm/Cambiatus/Object/Country.elm
@@ -19,6 +19,11 @@ import Graphql.SelectionSet exposing (SelectionSet)
 import Json.Decode as Decode
 
 
+id : SelectionSet Cambiatus.ScalarCodecs.Id Cambiatus.Object.Country
+id =
+    Object.selectionForField "ScalarCodecs.Id" "id" [] (Cambiatus.ScalarCodecs.codecs |> Cambiatus.Scalar.unwrapCodecs |> .codecId |> .decoder)
+
+
 name : SelectionSet String Cambiatus.Object.Country
 name =
     Object.selectionForField "String" "name" [] Decode.string

--- a/src/elm/Cambiatus/Object/Neighborhood.elm
+++ b/src/elm/Cambiatus/Object/Neighborhood.elm
@@ -19,6 +19,11 @@ import Graphql.SelectionSet exposing (SelectionSet)
 import Json.Decode as Decode
 
 
+id : SelectionSet Cambiatus.ScalarCodecs.Id Cambiatus.Object.Neighborhood
+id =
+    Object.selectionForField "ScalarCodecs.Id" "id" [] (Cambiatus.ScalarCodecs.codecs |> Cambiatus.Scalar.unwrapCodecs |> .codecId |> .decoder)
+
+
 name : SelectionSet String Cambiatus.Object.Neighborhood
 name =
     Object.selectionForField "String" "name" [] Decode.string

--- a/src/elm/Cambiatus/Object/State.elm
+++ b/src/elm/Cambiatus/Object/State.elm
@@ -24,6 +24,11 @@ cities object_ =
     Object.selectionForCompositeField "cities" [] object_ (identity >> Decode.list)
 
 
+id : SelectionSet Cambiatus.ScalarCodecs.Id Cambiatus.Object.State
+id =
+    Object.selectionForField "ScalarCodecs.Id" "id" [] (Cambiatus.ScalarCodecs.codecs |> Cambiatus.Scalar.unwrapCodecs |> .codecId |> .decoder)
+
+
 name : SelectionSet String Cambiatus.Object.State
 name =
     Object.selectionForField "String" "name" [] Decode.string

--- a/src/elm/Profile.elm
+++ b/src/elm/Profile.elm
@@ -19,6 +19,7 @@ module Profile exposing
     , selectConfig
     , selectFilter
     , selectionSet
+    , upsertKycMutation
     , username
     , view
     , viewEmpty
@@ -33,6 +34,7 @@ import Cambiatus.Object
 import Cambiatus.Object.Community as Community
 import Cambiatus.Object.Profile as User
 import Cambiatus.Query
+import Cambiatus.Scalar exposing (Id(..))
 import Dict exposing (Dict)
 import Eos exposing (Symbol)
 import Eos.Account as Eos
@@ -193,6 +195,29 @@ mutation account form =
             }
         }
         selectionSet
+
+
+
+-- KYC
+
+
+upsertKycMutation : Eos.Name -> ProfileKyc -> SelectionSet (Maybe ProfileKyc) RootMutation
+upsertKycMutation account data =
+    let
+        nameString =
+            Eos.nameToString account
+    in
+    Cambiatus.Mutation.upsertKyc
+        { input =
+            { accountId = nameString
+            , countryId = Id "1"
+            , documentType = data.documentType
+            , document = data.document
+            , phone = data.phone
+            , userType = "natural"
+            }
+        }
+        Kyc.selectionSet
 
 
 


### PR DESCRIPTION
## What issue does this PR close
Closes #312

## Changes Proposed (a list of new changes introduced by this PR)
Use the mutation for saving KYC data from the form shown to the existing user during the invitation process.

## How to test (a list of instructions on how to test this PR)
- Invite an existing user to the community with KYC enabled.
- Make sure the user hasn't KYC data filled.
- Open an invitation link, press the "Yes, Join" button and see the form to fill KYC data.
- Fill in the form, press the "Save and Join" button, and join the community having KYC data filled.
