### PR TITLE
Add KYC tooltip to the Features page

### DIFF
--- a/src/elm/Page/Community/Settings/Features.elm
+++ b/src/elm/Page/Community/Settings/Features.elm
@@ -139,7 +139,7 @@ toggleView translations labelText isEnabled toggleFunction inputId =
 
         kycTooltip =
             if inputId == "kyc" then
-                span [ class "icon-tooltip inline-block align-center ml-1" ]
+                span [ class "icon-tooltip ml-1" ]
                     [ Icons.question "inline-block"
                     , div
                         [ class "icon-tooltip-content" ]

--- a/src/elm/Page/Community/Settings/Features.elm
+++ b/src/elm/Page/Community/Settings/Features.elm
@@ -9,6 +9,7 @@ import Html exposing (Html, div, input, label, span, text)
 import Html.Attributes exposing (checked, class, for, id, name, style, type_)
 import Html.Events exposing (onCheck)
 import I18Next exposing (Translations, t)
+import Icons
 import Json.Decode exposing (Value)
 import Json.Encode
 import Page
@@ -135,6 +136,19 @@ toggleView translations labelText isEnabled toggleFunction inputId =
 
             else
                 "text-grey"
+
+        kycTooltip =
+            if inputId == "kyc" then
+                span [ class "icon-tooltip inline-block align-center ml-1" ]
+                    [ Icons.question "inline-block"
+                    , div
+                        [ class "icon-tooltip-content" ]
+                        [ text (translate "community.kyc.info")
+                        ]
+                    ]
+
+            else
+                text ""
     in
     div
         [ class "grid w-full py-4"
@@ -142,7 +156,7 @@ toggleView translations labelText isEnabled toggleFunction inputId =
                                 'label status toggle' 40px / auto 80px 50px
                                 """
         ]
-        [ span [ classes, style "grid-area" "label" ] [ text labelText ]
+        [ span [ classes, style "grid-area" "label" ] [ text labelText, kycTooltip ]
         , span [ classes, class ("font-medium lowercase mr-auto " ++ color), style "grid-area" "status" ] [ text statusText ]
         , div [ classes ]
             [ div [ class "form-switch inline-block align-middle" ]

--- a/src/elm/Page/Profile.elm
+++ b/src/elm/Page/Profile.elm
@@ -185,20 +185,23 @@ viewSettings loggedIn model profile =
                             Ignored
 
         viewKycSettings =
+            let
+                kycLabel =
+                    span [ class "flex items-center" ]
+                        [ text (t "community.kyc.dataTitle")
+                        , span [ class "icon-tooltip ml-1" ]
+                            [ Icons.question "inline-block"
+                            , p
+                                [ class "icon-tooltip-content" ]
+                                [ text (t "community.kyc.info")
+                                ]
+                            ]
+                        ]
+            in
             case profile.kyc of
                 Just _ ->
                     viewProfileItem
-                        (span []
-                            [ text (t "community.kyc.dataTitle")
-                            , span [ class "icon-tooltip inline-block align-center ml-1" ]
-                                [ Icons.question "inline-block"
-                                , p
-                                    [ class "icon-tooltip-content" ]
-                                    [ text (t "community.kyc.info")
-                                    ]
-                                ]
-                            ]
-                        )
+                        kycLabel
                         (viewDangerButton (t "community.kyc.delete.label") ToggleDeleteKycModal)
                         Center
                         (Just
@@ -210,17 +213,7 @@ viewSettings loggedIn model profile =
 
                 Nothing ->
                     viewProfileItem
-                        (span []
-                            [ text (t "community.kyc.dataTitle")
-                            , span [ class "icon-tooltip inline-block align-center ml-1" ]
-                                [ Icons.question "inline-block"
-                                , p
-                                    [ class "icon-tooltip-content" ]
-                                    [ text (t "community.kyc.info")
-                                    ]
-                                ]
-                            ]
-                        )
+                        kycLabel
                         (viewButton (t "menu.add") AddKycClicked)
                         Center
                         Nothing

--- a/src/elm/Page/Register.elm
+++ b/src/elm/Page/Register.elm
@@ -18,7 +18,6 @@ import Html.Events exposing (onCheck, onClick, onSubmit)
 import Json.Decode as Decode exposing (Decoder, Value)
 import Json.Decode.Pipeline as Decode
 import Json.Encode as Encode
-import Maybe.Extra
 import Page
 import Page.Register.DefaultForm as DefaultForm
 import Page.Register.JuridicalForm as JuridicalForm

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -128,7 +128,7 @@ textarea.input {
 
 /* Icon Tooltip */
 .icon-tooltip {
-  @apply relative inline-block;
+  @apply relative inline-block align-middle leading-none;
 }
 
 .icon-tooltip .icon-tooltip-content {
@@ -149,7 +149,7 @@ textarea.input {
   content: ' ';
   left: 50%;
   margin-left: -10px;
-  top: 14px;
+  top: 7px;
   border-width: 10px;
   border-style: solid;
   border-color: transparent transparent black transparent;


### PR DESCRIPTION
## What issue does this PR close
Closes N/A. Just a little UI addition to @victorgdev's [KYC read-only toggle](https://github.com/cambiatus/frontend/pull/347).

## Changes Proposed ( a list of new changes introduced by this PR)
Add the tooltip with the description of what KYC is on the Features page:
![image](https://user-images.githubusercontent.com/140053/94437034-e6e60d00-01a5-11eb-9b64-5c9548cd1a00.png)


## How to test ( a list of instructions on how to test this PR)
1. Select the community where you are an admin.
2. Go to the Features page (URI is `community/<SYMBOL>/settings/features`).
3. The KYC setting should have a question mark icon with the tooltip on hover.
