### PR TITLE
Fix loading spinner and document type/number matching on the registration page with KYC

### DIFF
--- a/src/elm/Page/Register.elm
+++ b/src/elm/Page/Register.elm
@@ -301,16 +301,16 @@ viewCreateAccount translators model =
                 defaultForm
 
             Loading ->
-                Session.Shared.viewFullLoading
+                viewLoading
 
             Generated keys ->
                 viewAccountGenerated translators model keys
 
             LoadedInvite _ ->
-                Session.Shared.viewFullLoading
+                viewLoading
 
             LoadedCountry _ ->
-                Session.Shared.viewFullLoading
+                viewLoading
 
             FailedInvite _ ->
                 Page.fullPageNotFound (translators.t "error.unknown") ""
@@ -382,13 +382,13 @@ viewKycRegister translators model =
                             selectedForm
 
                         LoadedInvite _ ->
-                            [ Session.Shared.viewFullLoading ]
+                            [ viewLoading ]
 
                         LoadedCountry _ ->
-                            [ Session.Shared.viewFullLoading ]
+                            [ viewLoading ]
 
                         Loading ->
-                            [ Session.Shared.viewFullLoading ]
+                            [ viewLoading ]
 
                         FailedCountry _ ->
                             [ Page.fullPageNotFound (translators.t "error.unknown") "" ]
@@ -506,6 +506,15 @@ viewFormTypeRadio options =
         [ label [ class "cursor-pointer", for id ] [ text options.label ]
         , input [ class "hidden", type_ "radio", checked options.isSelected, onClick (options.onClick options.type_) ] []
         ]
+
+
+{-| Loading screen on this page differs from `Session.Shared.viewFullLoading`
+since we don't need full width here.
+-}
+viewLoading : Html msg
+viewLoading =
+    div [ class "h-full full-spinner-container" ]
+        [ div [ class "spinner" ] [] ]
 
 
 viewTitleForStep : Translators -> Int -> Html msg

--- a/src/elm/Page/Register/JuridicalForm.elm
+++ b/src/elm/Page/Register/JuridicalForm.elm
@@ -124,8 +124,12 @@ view translators model =
             (companyTypeToString model.companyType)
             True
             EnteredType
-            [ { value = "mipyme", label = translators.t "register.form.company.mipyme.label" }
-            , { value = "corporation", label = translators.t "register.form.company.gran_empresa.label" }
+            [ { value = companyTypeToString MIPYME
+              , label = translators.t "register.form.company.mipyme.label"
+              }
+            , { value = companyTypeToString Corporation
+              , label = translators.t "register.form.company.gran_empresa.label"
+              }
             ]
             (fieldProblems CompanyType model.problems)
         , View.Form.Input.init
@@ -268,9 +272,6 @@ update msg form translators =
             { form
                 | companyType =
                     case type_ of
-                        "corporation" ->
-                            Corporation
-
                         "mipyme" ->
                             MIPYME
 

--- a/src/elm/Page/Register/NaturalForm.elm
+++ b/src/elm/Page/Register/NaturalForm.elm
@@ -102,9 +102,15 @@ view translators model =
             (documentTypeToString model.documentType)
             True
             EnteredDocumentType
-            [ { value = "ssn", label = translators.t "register.form.document.cedula_de_identidad.label" }
-            , { value = "dimex", label = translators.t "register.form.document.dimex.label" }
-            , { value = "nite", label = translators.t "register.form.document.nite.label" }
+            [ { value = documentTypeToString SSN
+              , label = translators.t "register.form.document.cedula_de_identidad.label"
+              }
+            , { value = documentTypeToString DIMEX
+              , label = translators.t "register.form.document.dimex.label"
+              }
+            , { value = documentTypeToString NITE
+              , label = translators.t "register.form.document.nite.label"
+              }
             ]
             (fieldProblems DocumentType model.problems)
         , View.Form.Input.init
@@ -192,9 +198,6 @@ update msg model =
             { model
                 | documentType =
                     case documentType of
-                        "ssn" ->
-                            SSN
-
                         "dimex" ->
                             DIMEX
 


### PR DESCRIPTION
## What issue does this PR close
Closes N/A.

**Describe the bug**
Found a couple of issues:
- Loading spinner becomes misplaced from the middle screens and above.
- There's a wrong corresponding document number for the document type after the page is loaded.

Here's a little demo (click to see the video):
[![](https://img.youtube.com/vi/x1JC2AQo9z0/0.jpg)](https://www.youtube.com/watch?v=x1JC2AQo9z0)

**To Reproduce**
1. Go to `http://staging.cambiatus.io/register/7wmLW4` or use another link with an invitation to the KYC-enabled community.
2. Make sure your screen is wide enough to see the picture from the left. See misplaced loading spinner.
3. Check the document type for the Natural person. It's not matched properly with the document number field.

**Expected behavior**
- Loading spinner should be placed in the middle of the white area.
- Document type should have the correct corresponding document number field.