### PR TITLE
Fix logo corners on invite page

### DIFF
--- a/src/elm/Page/Community/Invite.elm
+++ b/src/elm/Page/Community/Invite.elm
@@ -227,7 +227,7 @@ viewContent { t } { creator, community } innerContent =
     in
     div [ class "bg-white pb-20" ]
         [ div [ class "flex flex-wrap content-end" ]
-            [ div [ class "flex items-center justify-center h-24 w-24 rounded-full mx-auto -mt-12 bg-white" ]
+            [ div [ class "flex overflow-hidden items-center justify-center h-24 w-24 rounded-full mx-auto -mt-12 bg-white" ]
                 [ img
                     [ src community.logo
                     , class "object-scale-down h-20 w-20"


### PR DESCRIPTION
## What issue does this PR close
Closes N/A. Fixes corners of the logo inside circle shape on the invitation page.

Before:
![image](https://user-images.githubusercontent.com/140053/94919107-8fed7a00-04bc-11eb-8187-bef49fae6fd7.png)

After this fix:
![image](https://user-images.githubusercontent.com/140053/94919123-9976e200-04bc-11eb-89cf-7d5484d3c4cf.png)

## How to test
- Make sure the community has a logo with a non-transparent background.
- Open the invitation link to this community, the logo should be inside the circle share with cropped corners.