### PR TITLE
Upgrade node to 14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #================
 # Build Stage
 #================
-FROM node:12.0-alpine as builder
+FROM node:14-alpine as builder
 
 ENV NODE_ENV=production
 
@@ -12,8 +12,6 @@ COPY . .
 
 # Remove host stuff
 RUN rm -Rf node_modules build elm-stuff
-
-RUN npm install yarn --global
 
 RUN yarn install --production
 RUN yarn run build

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.7.3",
   "private": true,
   "engines": {
-    "node": "14.8.0"
+    "node": "14"
   },
   "scripts": {
     "build": "yarn bundle",


### PR DESCRIPTION
Docker doesn't provide an image for Node 14.8.0, so we remove the minor
version specification from package.json

We also remove the installation of yarn as `node:14` already comes with
it installed

----

## What issue does this PR close
Closes #338

## Changes Proposed ( a list of new changes introduced by this PR)
1. Upgrades node version to 14

## How to test ( a list of instructions on how to test this PR)
1. Run `docker build .`