### PR TITLE
Add translations for the errors on the Product page

### DIFF
--- a/public/translations/cat-CAT.json
+++ b/public/translations/cat-CAT.json
@@ -601,7 +601,15 @@
       "memo_label": "Comentaris (opcional)",
       "default_memo": "Gràcies per la teva ajuda",
       "submit": "Compra ara",
-      "success": "Compra satisfactòria!"
+      "success": "Compra satisfactòria!",
+      "errors": {
+        "unitEmpty": "La unitat no pot estar buida",
+        "unitTooLow": "La unitat és massa baixa, ha de ser com a mínim 1",
+        "unitTooHigh": "No hi ha prou unitats disponibles",
+        "unitNotOnlyNumbers": "Només es permeten números",
+        "memoEmpty": "La nota no pot estar buida",
+        "memoTooLong": "La nota és massa llarga i el màxim de 256 caràcters"
+      }
     },
     "delete": "Eliminar",
     "delete_modal": {

--- a/public/translations/en-US.json
+++ b/public/translations/en-US.json
@@ -599,7 +599,15 @@
       "memo_label": "Comments (optional)",
       "default_memo": "Thanks for the help!",
       "submit": "Buy",
-      "success": "Successful purchase!"
+      "success": "Successful purchase!",
+      "errors": {
+        "unitEmpty": "Unit cannot be empty",
+        "unitTooLow": "Unit is too low, must be at least 1",
+        "unitTooHigh": "Not enough units available",
+        "unitNotOnlyNumbers": "Only numbers are allowed",
+        "memoEmpty": "Memo cannot be empty",
+        "memoTooLong": "Memo is too long, max is 256 characters"
+      }
     },
     "delete": "Delete",
     "delete_modal": {

--- a/public/translations/es-ES.json
+++ b/public/translations/es-ES.json
@@ -601,7 +601,15 @@
       "memo_label": "Comentarios (opcional)",
       "default_memo": "Gracias por tu ayuda",
       "submit": "Comprar",
-      "success": "Compra exitosa!"
+      "success": "Compra exitosa!",
+      "errors": {
+        "unitEmpty": "La unidad no puede estar vacía",
+        "unitTooLow": "La unidad es demasiado baja, debe ser al menos 1",
+        "unitTooHigh": "No hay suficientes unidades disponibles",
+        "unitNotOnlyNumbers": "Solo se permiten números",
+        "memoEmpty": "La nota no puede estar vacía",
+        "memoTooLong": "La nota es demasiado larga, el máximo es de 256 caracteres"
+      }
     },
     "delete": "Eliminar",
     "delete_modal": {

--- a/public/translations/pt-BR.json
+++ b/public/translations/pt-BR.json
@@ -604,7 +604,15 @@
       "memo_label": "Comentários (opcional)",
       "default_memo": "Obrigado pela ajuda!",
       "submit": "Comprar",
-      "success": "Compra bem sucedida!"
+      "success": "Compra bem sucedida!",
+      "errors": {
+        "unitEmpty": "Unidade não pode estar vazia",
+        "unitTooLow": "A unidade é muito baixa, deve ser pelo menos 1",
+        "unitTooHigh": "Unidades insuficientes disponíveis",
+        "unitNotOnlyNumbers": "Somente números são permitidos",
+        "memoEmpty": "O memorando não pode estar vazio",
+        "memoTooLong": "O memorando é muito longo, o máximo é 256 caracteres"
+      }
     },
     "delete": "Excluir",
     "delete_modal": {

--- a/src/elm/Page/Shop/Viewer.elm
+++ b/src/elm/Page/Shop/Viewer.elm
@@ -561,7 +561,7 @@ viewTransferForm { shared } card model =
 
                   else
                     span [ class "field-error" ]
-                        [ text (getValidationMessage form.unitValidation) ]
+                        [ text <| t (getValidationMessage form.unitValidation) ]
                 ]
             , formField
                 [ label [ for fieldId.price ]
@@ -599,7 +599,7 @@ viewTransferForm { shared } card model =
 
                   else
                     span [ class "field-error" ]
-                        [ text (getValidationMessage form.memoValidation) ]
+                        [ text <| t (getValidationMessage form.memoValidation) ]
                 ]
             ]
         ]
@@ -618,22 +618,22 @@ getValidationMessage validation =
         Invalid error ->
             case error of
                 UnitEmpty ->
-                    "Unit cannot be empty"
+                    "shop.transfer.errors.unitEmpty"
 
                 UnitTooLow ->
-                    "Unit is too low, must be at least 1"
+                    "shop.transfer.errors.unitTooLow"
 
                 UnitTooHigh ->
-                    "Not enough units available"
+                    "shop.transfer.errors.unitTooHigh"
 
                 UnitNotOnlyNumbers ->
-                    "Only numbers are allowed"
+                    "shop.transfer.errors.unitNotOnlyNumbers"
 
                 MemoEmpty ->
-                    "Memo cannot be empty"
+                    "shop.transfer.errors.memoEmpty"
 
                 MemoTooLong ->
-                    "Memo is too long, max is 256 characters"
+                    "shop.transfer.errors.memoTooLong"
 
 
 formField : List (Html msg) -> Html msg


### PR DESCRIPTION
## What issue does this PR close
Closes N/A.

Fixes an [issue](https://cambiatus.slack.com/archives/CA83HJAAD/p1602643992139300?thread_ts=1602636902.138800&cid=CA83HJAAD) from @muguika:
> when trying to buy from the shop in Spanish, the warning message "Not enough units available" was showed in English. Should be "No hay suficientes unidades disponibles"
>  ![image](https://user-images.githubusercontent.com/140053/95958292-a0c9b400-0e09-11eb-83cd-111b2ed277d1.png)



## Changes Proposed ( a list of new changes introduced by this PR)
Add translations for the error messages for all languages (now they're only in English).

## How to test ( a list of instructions on how to test this PR)
- Try to buy a product entering `0`in quantity field;
- try to buy a product without entering any values for quantity;
- make sure to check various locales.