### PR TITLE
Fix routes restriction based on hasShop and hasObjecitveves community features

### DIFF
--- a/public/translations/cat-CAT.json
+++ b/public/translations/cat-CAT.json
@@ -400,6 +400,9 @@
         "description_label": "Quin és el teu objectiu?",
         "description_placeholder": "Defineix un objectiu que resolgui el problema al que s’enfronta la teva comunitat.",
         "submit": "Guardar"
+      },
+      "disabled": {
+        "description": "Les reclamacions, les accions i els objectius estan desactivats en aquesta comunitat."
       }
     },
     "actions": {

--- a/public/translations/cat-CAT.json
+++ b/public/translations/cat-CAT.json
@@ -621,6 +621,9 @@
       "body": "Estàs segur de que vols eliminar aquest ítem?",
       "confirm": "Si",
       "cancel": "No"
+    },
+    "disabled": {
+      "description": "La botiga està desactivada en aquesta comunitat."
     }
   },
   "dashboard": {

--- a/public/translations/en-US.json
+++ b/public/translations/en-US.json
@@ -396,6 +396,9 @@
         "description_label": "What is your objective?",
         "description_placeholder": "Set a goal that helps resolve the community problem.",
         "submit": "Save"
+      },
+      "disabled": {
+        "description": "Claims, Actions, and Objectives are disabled in this community."
       }
     },
     "actions": {

--- a/public/translations/en-US.json
+++ b/public/translations/en-US.json
@@ -619,6 +619,9 @@
       "body": "Are you sure you want to delete this item?",
       "confirm": "Yes",
       "cancel": "No"
+    },
+    "disabled": {
+      "description": "Shop is disabled in this community."
     }
   },
   "dashboard": {

--- a/public/translations/es-ES.json
+++ b/public/translations/es-ES.json
@@ -621,6 +621,9 @@
       "body": "¿Estás seguro de que quieres eliminar este item?",
       "confirm": "Sí",
       "cancel": "No"
+    },
+    "disabled": {
+      "description": "La tienda está deshabilitada en esta comunidad."
     }
   },
   "dashboard": {

--- a/public/translations/es-ES.json
+++ b/public/translations/es-ES.json
@@ -400,6 +400,9 @@
         "description_label": "¿Cual es tu objetivo?",
         "description_placeholder": "Define un objetivo que atienda el problema que enfrenta tu comunidad.",
         "submit": "Salvar"
+      },
+      "disabled": {
+        "description": "Las reclamaciones, las acciones y los objetivos están deshabilitados en esta comunidad."
       }
     },
     "actions": {

--- a/public/translations/pt-BR.json
+++ b/public/translations/pt-BR.json
@@ -624,6 +624,9 @@
       "body": "Tem certeza de que deseja excluir este item?",
       "confirm": "Sim",
       "cancel": "Não"
+    },
+    "disabled": {
+      "description": "A loja está desativada nesta comunidade."
     }
   },
   "dashboard": {

--- a/public/translations/pt-BR.json
+++ b/public/translations/pt-BR.json
@@ -404,6 +404,9 @@
         "description_label": "Qual o seu objetivo?",
         "description_placeholder": "Defina uma meta que ajude a resolver o problema da comunidade.",
         "submit": "Salvar"
+      },
+      "disabled": {
+        "description": "Reivindicações, ações e objetivos estão desativados nesta comunidade."
       }
     },
     "actions": {

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -623,7 +623,7 @@ changeRouteTo maybeRoute model =
                     , Route.replaceUrl shared.navKey redirect
                     )
 
-        withFeature : (LoggedIn.Model -> Bool) -> ( Model, Cmd msg ) -> ( Model, Cmd msg )
+        withFeature : (LoggedIn.Model -> LoggedIn.FeatureStatus) -> ( Model, Cmd msg ) -> ( Model, Cmd msg )
         withFeature feature fn =
             case session of
                 Page.Guest guest ->
@@ -632,13 +632,14 @@ changeRouteTo maybeRoute model =
                         |> noCmd
 
                 Page.LoggedIn loggedIn ->
-                    if feature loggedIn then
-                        fn
+                    case feature loggedIn of
+                        LoggedIn.FeatureLoaded True ->
+                            fn
 
-                    else
-                        NotFound
-                            |> updateStatus model
-                            |> noCmd
+                        _ ->
+                            NotFound
+                                |> updateStatus model
+                                |> noCmd
 
         withLoggedIn route fn =
             case session of

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -623,6 +623,7 @@ changeRouteTo maybeRoute model =
                     , Route.replaceUrl shared.navKey redirect
                     )
 
+        withFeature : (LoggedIn.Model -> Bool) -> ( Model, Cmd msg ) -> ( Model, Cmd msg )
         withFeature feature fn =
             case session of
                 Page.Guest guest ->

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -623,24 +623,6 @@ changeRouteTo maybeRoute model =
                     , Route.replaceUrl shared.navKey redirect
                     )
 
-        withFeature : (LoggedIn.Model -> LoggedIn.FeatureStatus) -> ( Model, Cmd msg ) -> ( Model, Cmd msg )
-        withFeature feature fn =
-            case session of
-                Page.Guest _ ->
-                    NotFound
-                        |> updateStatus model
-                        |> noCmd
-
-                Page.LoggedIn loggedIn ->
-                    case feature loggedIn of
-                        LoggedIn.FeatureLoaded True ->
-                            fn
-
-                        _ ->
-                            NotFound
-                                |> updateStatus model
-                                |> noCmd
-
         withLoggedIn route fn =
             case session of
                 Page.LoggedIn loggedIn ->
@@ -831,25 +813,21 @@ changeRouteTo maybeRoute model =
             (\l -> Shop.init l maybeFilter)
                 >> updateStatusWith (Shop maybeFilter) GotShopMsg model
                 |> withLoggedIn (Route.Shop maybeFilter)
-                |> withFeature .hasShop
 
         Just Route.NewSale ->
             ShopEditor.initCreate
                 >> updateStatusWith (ShopEditor Nothing) GotShopEditorMsg model
                 |> withLoggedIn Route.NewSale
-                |> withFeature .hasShop
 
         Just (Route.EditSale saleId) ->
             (\l -> ShopEditor.initUpdate saleId l)
                 >> updateStatusWith (ShopEditor (Just saleId)) GotShopEditorMsg model
                 |> withLoggedIn (Route.EditSale saleId)
-                |> withFeature .hasShop
 
         Just (Route.ViewSale saleId) ->
             (\l -> ShopViewer.init l saleId)
                 >> updateStatusWith (ShopViewer saleId) GotShopViewerMsg model
                 |> withLoggedIn (Route.ViewSale saleId)
-                |> withFeature .hasShop
 
         Just (Route.ViewTransfer transferId) ->
             (\l -> ViewTransfer.init l transferId)

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -626,7 +626,7 @@ changeRouteTo maybeRoute model =
         withFeature : (LoggedIn.Model -> LoggedIn.FeatureStatus) -> ( Model, Cmd msg ) -> ( Model, Cmd msg )
         withFeature feature fn =
             case session of
-                Page.Guest guest ->
+                Page.Guest _ ->
                     NotFound
                         |> updateStatus model
                         |> noCmd
@@ -816,19 +816,16 @@ changeRouteTo maybeRoute model =
             (\l -> ActionEditor.initNew l symbol objectiveId)
                 >> updateStatusWith ActionEditor GotActionEditorMsg model
                 |> withLoggedIn (Route.NewAction symbol objectiveId)
-                |> withFeature .hasObjectives
 
         Just (Route.EditAction symbol objectiveId actionId) ->
             (\l -> ActionEditor.initEdit l symbol objectiveId actionId)
                 >> updateStatusWith ActionEditor GotActionEditorMsg model
                 |> withLoggedIn (Route.EditAction symbol objectiveId actionId)
-                |> withFeature .hasObjectives
 
         Just (Route.Claim communityId objectiveId actionId claimId) ->
             (\l -> Claim.init l communityId claimId)
                 >> updateStatusWith Claim GotVerifyClaimMsg model
                 |> withLoggedIn (Route.Claim communityId objectiveId actionId claimId)
-                |> withFeature .hasObjectives
 
         Just (Route.Shop maybeFilter) ->
             (\l -> Shop.init l maybeFilter)

--- a/src/elm/Page/Community/ActionEditor.elm
+++ b/src/elm/Page/Community/ActionEditor.elm
@@ -1108,7 +1108,18 @@ view ({ shared } as loggedIn) model =
                     Page.fullPageNotFound "not authorized" ""
     in
     { title = title
-    , content = content
+    , content =
+        case loggedIn.hasObjectives of
+            LoggedIn.FeatureLoaded True ->
+                content
+
+            LoggedIn.FeatureLoaded False ->
+                Page.fullPageNotFound
+                    (t "error.pageNotFound")
+                    (t "community.objectives.disabled.description")
+
+            LoggedIn.FeatureLoading ->
+                Page.fullPageLoading
     }
 
 

--- a/src/elm/Page/Community/ObjectiveEditor.elm
+++ b/src/elm/Page/Community/ObjectiveEditor.elm
@@ -118,6 +118,9 @@ initObjectiveForm =
 view : LoggedIn.Model -> Model -> { title : String, content : Html Msg }
 view ({ shared } as loggedIn) model =
     let
+        { t } =
+            shared.translators
+
         title =
             case model.status of
                 Loaded _ editStatus ->
@@ -125,14 +128,14 @@ view ({ shared } as loggedIn) model =
                         action =
                             case editStatus of
                                 NewObjective _ ->
-                                    t shared.translations "menu.create"
+                                    t "menu.create"
 
                                 EditObjective _ _ ->
-                                    t shared.translations "menu.edit"
+                                    t "menu.edit"
                     in
                     action
                         ++ " "
-                        ++ t shared.translations "community.objectives.title"
+                        ++ t "community.objectives.title"
 
                 _ ->
                     ""
@@ -143,17 +146,17 @@ view ({ shared } as loggedIn) model =
                     Page.fullPageLoading
 
                 NotFound ->
-                    Page.fullPageNotFound (t shared.translations "community.objectives.editor.not_found") ""
+                    Page.fullPageNotFound (t "community.objectives.editor.not_found") ""
 
                 LoadCommunityFailed err ->
-                    Page.fullPageGraphQLError (t shared.translations "community.objectives.editor.error") err
+                    Page.fullPageGraphQLError (t "community.objectives.editor.error") err
 
                 Unauthorized ->
                     text "not allowed to edit"
 
                 Loaded { symbol } editStatus ->
                     div []
-                        [ Page.viewHeader loggedIn (t shared.translations "community.objectives.title") (Route.Objectives symbol)
+                        [ Page.viewHeader loggedIn (t "community.objectives.title") (Route.Objectives symbol)
                         , case editStatus of
                             NewObjective objForm ->
                                 viewForm loggedIn objForm
@@ -163,7 +166,18 @@ view ({ shared } as loggedIn) model =
                         ]
     in
     { title = title
-    , content = content
+    , content =
+        case loggedIn.hasObjectives of
+            LoggedIn.FeatureLoaded True ->
+                content
+
+            LoggedIn.FeatureLoaded False ->
+                Page.fullPageNotFound
+                    (t "error.pageNotFound")
+                    (t "community.objectives.disabled.description")
+
+            LoggedIn.FeatureLoading ->
+                Page.fullPageLoading
     }
 
 

--- a/src/elm/Page/Dashboard/Claim.elm
+++ b/src/elm/Page/Dashboard/Claim.elm
@@ -104,7 +104,18 @@ view ({ shared } as loggedIn) model =
                 ]
     in
     { title = title
-    , content = content
+    , content =
+        case loggedIn.hasObjectives of
+            LoggedIn.FeatureLoaded True ->
+                content
+
+            LoggedIn.FeatureLoaded False ->
+                Page.fullPageNotFound
+                    (t "error.pageNotFound")
+                    (t "community.objectives.disabled.description")
+
+            LoggedIn.FeatureLoading ->
+                Page.fullPageLoading
     }
 
 

--- a/src/elm/Page/Shop.elm
+++ b/src/elm/Page/Shop.elm
@@ -150,6 +150,9 @@ type ValidationError
 view : LoggedIn.Model -> Model -> { title : String, content : Html Msg }
 view loggedIn model =
     let
+        { t } =
+            loggedIn.shared.translators
+
         selectedCommunityName =
             case loggedIn.profile of
                 LoggedIn.Loaded profile ->
@@ -172,7 +175,7 @@ view loggedIn model =
         title =
             selectedCommunityName
                 ++ " "
-                ++ t loggedIn.shared.translations "shop.title"
+                ++ t "shop.title"
 
         content =
             case model.cards of
@@ -184,7 +187,7 @@ view loggedIn model =
                         ]
 
                 LoadingFailed e ->
-                    Page.fullPageGraphQLError (t loggedIn.shared.translations "shop.title") e
+                    Page.fullPageGraphQLError (t "shop.title") e
 
                 Loaded cards ->
                     div []
@@ -196,7 +199,18 @@ view loggedIn model =
                         ]
     in
     { title = title
-    , content = content
+    , content =
+        case loggedIn.hasShop of
+            LoggedIn.FeatureLoaded True ->
+                content
+
+            LoggedIn.FeatureLoaded False ->
+                Page.fullPageNotFound
+                    (t "error.pageNotFound")
+                    (t "shop.disabled.description")
+
+            LoggedIn.FeatureLoading ->
+                Page.fullPageLoading
     }
 
 

--- a/src/elm/Page/Shop/Editor.elm
+++ b/src/elm/Page/Shop/Editor.elm
@@ -231,7 +231,18 @@ view loggedIn model =
                     viewForm shared balances imageStatus True True Closed form
     in
     { title = title
-    , content = content
+    , content =
+        case loggedIn.hasShop of
+            LoggedIn.FeatureLoaded True ->
+                content
+
+            LoggedIn.FeatureLoaded False ->
+                Page.fullPageNotFound
+                    (t "error.pageNotFound")
+                    (t "shop.disabled.description")
+
+            LoggedIn.FeatureLoading ->
+                Page.fullPageLoading
     }
 
 

--- a/src/elm/Page/Shop/Viewer.elm
+++ b/src/elm/Page/Shop/Viewer.elm
@@ -338,8 +338,11 @@ cardFromSale sale =
 view : LoggedIn.Model -> Model -> { title : String, content : Html Msg }
 view loggedIn model =
     let
+        { t } =
+            loggedIn.shared.translators
+
         shopTitle =
-            t loggedIn.shared.translations "shop.title"
+            t "shop.title"
 
         title =
             case model.status of
@@ -370,7 +373,7 @@ view loggedIn model =
                         ]
 
                 LoadingFailed e ->
-                    Page.fullPageGraphQLError (t loggedIn.shared.translations "shop.title") e
+                    Page.fullPageGraphQLError (t "shop.title") e
 
                 LoadedSale maybeSale ->
                     case maybeSale of
@@ -391,7 +394,18 @@ view loggedIn model =
                                 ]
     in
     { title = title
-    , content = content
+    , content =
+        case loggedIn.hasShop of
+            LoggedIn.FeatureLoaded True ->
+                content
+
+            LoggedIn.FeatureLoaded False ->
+                Page.fullPageNotFound
+                    (t "error.pageNotFound")
+                    (t "shop.disabled.description")
+
+            LoggedIn.FeatureLoading ->
+                Page.fullPageLoading
     }
 
 

--- a/src/elm/Session/LoggedIn.elm
+++ b/src/elm/Session/LoggedIn.elm
@@ -1,6 +1,7 @@
 module Session.LoggedIn exposing
     ( External(..)
     , ExternalMsg(..)
+    , FeatureStatus(..)
     , FeedbackStatus(..)
     , FeedbackVisibility(..)
     , Model
@@ -138,10 +139,15 @@ type alias Model =
     , auth : Auth.Model
     , showCommunitySelector : Bool
     , feedback : FeedbackVisibility
-    , hasShop : Bool
-    , hasObjectives : Bool
-    , hasKyc : Bool
+    , hasShop : FeatureStatus
+    , hasObjectives : FeatureStatus
+    , hasKyc : FeatureStatus
     }
+
+
+type FeatureStatus
+    = FeatureLoaded Bool
+    | FeatureLoading
 
 
 initModel : Shared -> Auth.Model -> Eos.Name -> Symbol -> Model
@@ -161,9 +167,9 @@ initModel shared authModel accountName selectedCommunity =
     , auth = authModel
     , feedback = Hidden
     , showCommunitySelector = False
-    , hasShop = True
-    , hasObjectives = False
-    , hasKyc = False
+    , hasShop = FeatureLoading
+    , hasObjectives = FeatureLoading
+    , hasKyc = FeatureLoading
     }
 
 
@@ -312,9 +318,14 @@ viewHelper thisMsg page profile_ ({ shared } as model) content =
             ]
 
         isContentAllowed =
-            List.member page availableWithoutKyc
-                || not model.hasKyc
-                || (model.hasKyc && hasUserKycFilled)
+            case model.hasKyc of
+                FeatureLoaded isKycEnabled ->
+                    List.member page availableWithoutKyc
+                        || not isKycEnabled
+                        || (isKycEnabled && hasUserKycFilled)
+
+                _ ->
+                    False
 
         viewKycRestriction =
             div [ class "mx-auto container max-w-sm" ]
@@ -596,20 +607,21 @@ viewMainMenu page model =
             [ Icons.dashboard iconClass
             , text (t model.shared.translations "menu.dashboard")
             ]
-        , if model.hasShop then
-            a
-                [ classList
-                    [ ( menuItemClass, True )
-                    , ( activeClass, isActive page (Route.Shop Shop.All) )
+        , case model.hasShop of
+            FeatureLoaded True ->
+                a
+                    [ classList
+                        [ ( menuItemClass, True )
+                        , ( activeClass, isActive page (Route.Shop Shop.All) )
+                        ]
+                    , Route.href (Route.Shop Shop.All)
                     ]
-                , Route.href (Route.Shop Shop.All)
-                ]
-                [ Icons.shop iconClass
-                , text (t model.shared.translations "menu.shop")
-                ]
+                    [ Icons.shop iconClass
+                    , text (t model.shared.translations "menu.shop")
+                    ]
 
-          else
-            text ""
+            _ ->
+                text ""
         ]
 
 
@@ -787,7 +799,11 @@ update msg model =
         CompletedLoadSettings (Ok settings_) ->
             case settings_ of
                 Just settings ->
-                    { model | hasShop = settings.hasShop, hasObjectives = settings.hasObjectives, hasKyc = settings.hasKyc }
+                    { model
+                        | hasShop = FeatureLoaded settings.hasShop
+                        , hasObjectives = FeatureLoaded settings.hasObjectives
+                        , hasKyc = FeatureLoaded settings.hasKyc
+                    }
                         |> UR.init
 
                 Nothing ->


### PR DESCRIPTION
## What issue does this PR close
Closes #348 

## Changes Proposed ( a list of new changes introduced by this PR)
Replace `withFeature` function from `Main.elm` with more explicit feature checking. Make sure we have `hasShop` and `hasObjectives` loaded before the actual checking if the page was reloaded by hand.

## How to test ( a list of instructions on how to test this PR)
- Make sure you have `hasShop` enabled. These routes should load correctly by the URL
(try to reload the page with `Cmd/Ctrl+R`):
    + `Shop`,
    + `NewSale`,
    + `EditSale`,
    + `ViewSale`.
- Then disable `hasShop` and make sure that these pages are not available.
- With `hasObjectives` enabled these routes should load correctly by the URL:
    + `Claim`,
    + `EditAction`,
    + `NewAction`,
    + `EditObjective`,
    + `NewObjective`,
    + `Objectives`.
- With `hasObjectives` disabled these pages should be disabled.
