### PR TITLE
Show loading spinner if KYC setting is not fully loaded

### DIFF
--- a/src/elm/Session/LoggedIn.elm
+++ b/src/elm/Session/LoggedIn.elm
@@ -317,16 +317,6 @@ viewHelper thisMsg page profile_ ({ shared } as model) content =
             , ViewTransfer
             ]
 
-        isContentAllowed =
-            case model.hasKyc of
-                FeatureLoaded isKycEnabled ->
-                    List.member page availableWithoutKyc
-                        || not isKycEnabled
-                        || (isKycEnabled && hasUserKycFilled)
-
-                _ ->
-                    False
-
         viewKycRestriction =
             div [ class "mx-auto container max-w-sm" ]
                 [ div [ class "my-6 mx-4 text-center" ]
@@ -362,11 +352,23 @@ viewHelper thisMsg page profile_ ({ shared } as model) content =
             Hidden ->
                 text ""
         , div [ class "flex-grow" ]
-            [ if isContentAllowed then
-                content
+            [ case model.hasKyc of
+                FeatureLoading ->
+                    div [ class "full-spinner-container h-full" ]
+                        [ div [ class "spinner spinner--delay mt-8" ] [] ]
 
-              else
-                viewKycRestriction
+                FeatureLoaded isKycEnabled ->
+                    let
+                        isContentAllowed =
+                            List.member page availableWithoutKyc
+                                || not isKycEnabled
+                                || (isKycEnabled && hasUserKycFilled)
+                    in
+                    if isContentAllowed then
+                        content
+
+                    else
+                        viewKycRestriction
             ]
         , viewFooter shared
         , Modal.initWith


### PR DESCRIPTION
## What issue does this PR close
Closes N/A.

Sometimes the KYC restrictions screen blinks for a split of a second while loading a page by a direct URL:![image](https://user-images.githubusercontent.com/140053/96862990-e1ab7380-146e-11eb-849f-d5ca4bbd1364.png)

## Changes Proposed ( a list of new changes introduced by this PR)
Handle loading state of KYC setting properly by showing the loading spinner (now this state is consideres as a restriction).

## How to test ( a list of instructions on how to test this PR)
Go to Dashboard, Shop, and some other pages by direct URL (or just press `Cmd/Crt+R`) in any community. Make sure everything works fine and you _don't see_ a blinking screen with KYC restrictions.

