### PR TITLE
Disable Grammarly for the passphrase textarea

### DIFF
--- a/src/elm/Auth.elm
+++ b/src/elm/Auth.elm
@@ -45,6 +45,7 @@ import Task
 import UpdateResult as UR
 import Utils
 import Validate exposing (Validator, validate)
+import View.Form
 import View.Pin as Pin
 
 
@@ -356,6 +357,7 @@ viewLoginSteps isModal shared model loginStep =
                     [ textarea
                         [ class "form-textarea h-19 min-w-full block"
                         , placeholder (t "auth.login.wordsMode.input.placeholder")
+                        , View.Form.noGrammarly
                         , autofocus True
                         , class <|
                             if not (List.isEmpty passphraseErrors) then

--- a/src/elm/View/Form.elm
+++ b/src/elm/View/Form.elm
@@ -1,4 +1,4 @@
-module View.Form exposing (label, primaryLabel)
+module View.Form exposing (label, noGrammarly, primaryLabel)
 
 import Html exposing (Html, span, text)
 import Html.Attributes exposing (class, for)
@@ -28,3 +28,8 @@ label id_ labelText =
         [ span [ class "text-green tracking-wide uppercase text-caption block mb-1" ]
             [ text labelText ]
         ]
+
+
+noGrammarly : Html.Attribute msg
+noGrammarly =
+    Html.Attributes.attribute "data-gramm_editor" "false"


### PR DESCRIPTION
## What issue does this PR close
Closes N/A.

During the login process, the Grammarly browser extension (which is very popular) [causes exceptions](https://github.com/elm/html/issues/44) in Elm runtime.

To reproduce:
- Install Grammarly browser extension for [Chrome](https://chrome.google.com/webstore/detail/grammarly-for-chrome/kbfnbcaeplbcioakkpcpgfkobkghlhen) or any other browser;
- Try to login and see the errors in the console in the prod build or see how everything just blows up in the dev environment.

## Changes Proposed ( a list of new changes introduced by this PR)
Add `"data-gramm_editor" "false"` attribute to `textarea` with the passphrase as described [here](https://github.com/elm/html/issues/44#issuecomment-534665947).

## How to test ( a list of instructions on how to test this PR)
Try to login with the Grammarly extension enabled and the browser console opened. There shouldn't be DOM-related errors.
