### PR TITLE
Change text on dashboard to be more explict

### DIFF
--- a/public/translations/cat-CAT.json
+++ b/public/translations/cat-CAT.json
@@ -629,7 +629,7 @@
   "dashboard": {
     "back": "Tornar",
     "transfer": "Transferir a un company",
-    "explore": "Sobre aquesta comunitat",
+    "explore": "Com guanyar {{symbol}}",
     "invite": "Convida els teus amics",
     "sorry": "ho sentim!",
     "action_rejected": "S'ha rebutjat la teva acció",

--- a/public/translations/en-US.json
+++ b/public/translations/en-US.json
@@ -627,7 +627,7 @@
   "dashboard": {
     "back": "Back",
     "transfer": "Transfer to a friend",
-    "explore": "About this community",
+    "explore": "How to earn {{symbol}}",
     "invite": "Invite your friends",
     "sorry": "Sorry!",
     "action_rejected": "Your action was rejected",

--- a/public/translations/es-ES.json
+++ b/public/translations/es-ES.json
@@ -629,7 +629,7 @@
   "dashboard": {
     "back": "Atrás",
     "transfer": "Transferir a un(a) colega",
-    "explore": "Acerca de esta comunidad",
+    "explore": "Como obtener {{symbol}}",
     "invite": "Invita a tus amigas(os)",
     "sorry": "¡Lo sentimos!",
     "action_rejected": "Tu acción fue rechazada",

--- a/public/translations/pt-BR.json
+++ b/public/translations/pt-BR.json
@@ -632,7 +632,7 @@
   "dashboard": {
     "back": "Voltar",
     "transfer": "Transferir para um amigo",
-    "explore": "Sobre essa comunidade",
+    "explore": "Como ganhar {{symbol}}",
     "invite": "Convide seus amigos",
     "sorry": "Desculpe!",
     "action_rejected": "Sua ação foi rejeitada",

--- a/src/elm/Page/Dashboard.elm
+++ b/src/elm/Page/Dashboard.elm
@@ -570,10 +570,10 @@ viewAmount amount symbol =
 
 
 viewBalance : LoggedIn.Model -> Model -> Balance -> Html Msg
-viewBalance loggedIn _ balance =
+viewBalance ({ shared } as loggedIn) _ balance =
     let
-        text_ s =
-            text (I18Next.t loggedIn.shared.translations s)
+        text_ =
+            text << shared.translators.t
 
         symbolText =
             Eos.symbolToSymbolCodeString balance.asset.symbol
@@ -600,7 +600,9 @@ viewBalance loggedIn _ balance =
                 [ class "flex w-full items-center justify-between h-12 text-gray border-b"
                 , Route.href <| Route.Community loggedIn.selectedCommunity
                 ]
-                [ text_ "dashboard.explore", Icons.arrowDown "rotate--90" ]
+                [ text <| shared.translators.tr "dashboard.explore" [ ( "symbol", Eos.symbolToSymbolCodeString loggedIn.selectedCommunity ) ]
+                , Icons.arrowDown "rotate--90"
+                ]
             , button
                 [ class "flex w-full items-center justify-between h-12 text-gray"
                 , onClick CreateInvite

--- a/src/elm/Page/Register/Common.elm
+++ b/src/elm/Page/Register/Common.elm
@@ -1,4 +1,16 @@
-module Page.Register.Common exposing (Errors(..), ProblemEvent(..), containsLetters, containsNumberGreaterThan, fieldProblems, findId, getCities, getDistricts, ifEmptyTuple, validateAccountName, viewSelectField)
+module Page.Register.Common exposing
+    ( Errors(..)
+    , ProblemEvent(..)
+    , containsLetters
+    , containsNumberGreaterThan
+    , fieldProblems
+    , findId
+    , getCities
+    , getDistricts
+    , ifEmptyTuple
+    , validateAccountName
+    , viewSelectField
+    )
 
 import Address
 import Cambiatus.Scalar exposing (Id(..))


### PR DESCRIPTION
## What issue does this PR close
Closes N/A

## Changes Proposed ( a list of new changes introduced by this PR)
Change text on dashboard. It was a big suggestion during a feature meetings, that is quick to apply. 

<img width="468" alt="Captura de Tela 2020-11-03 às 19 32 11" src="https://user-images.githubusercontent.com/1082127/98047797-51c0de80-1e0b-11eb-85ef-12527316efe7.png">

## How to test ( a list of instructions on how to test this PR)
- Login
- Check the change on the dashboard card

