### PR TITLE
Fix community logo size

### DIFF
--- a/src/elm/Page/Community.elm
+++ b/src/elm/Page/Community.elm
@@ -171,7 +171,7 @@ view loggedIn model =
                                 , div [ class "bg-white p-4" ]
                                     [ div [ class "container mx-auto px-4" ]
                                         [ div [ class "h-24 w-24 rounded-full mx-auto" ]
-                                            [ img [ src community.logo, class "object-scale-down" ] []
+                                            [ img [ src community.logo, class "max-h-full m-auto object-scale-down" ] []
                                             ]
                                         , div [ class "flex flex-wrap w-full items-center" ]
                                             [ p [ class "text-4xl font-bold" ]

--- a/src/elm/Session/LoggedIn.elm
+++ b/src/elm/Session/LoggedIn.elm
@@ -554,7 +554,7 @@ communitySelectorModal model =
                 [ class "flex items-center p-4 text-body cursor-pointer hover:text-black hover:bg-gray-100"
                 , onClick <| SelectCommunity c.id
                 ]
-                [ img [ src c.logo, class "h-16 w-16 mr-5" ] []
+                [ img [ src c.logo, class "h-16 w-16 mr-5 object-scale-down" ] []
                 , text c.name
                 ]
     in


### PR DESCRIPTION
## What issue does this PR close
Closes N/A.

## Changes Proposed ( a list of new changes introduced by this PR)
Make sure that the community logo on the "Objectives and Actions" page won't overlap the community name:
![image](https://user-images.githubusercontent.com/140053/98541172-0f325280-22a0-11eb-8e8d-8e9bf4892afa.png)

Also, fixes the proportions of the logos on the community selector dropdown:
![image](https://user-images.githubusercontent.com/140053/98541205-1fe2c880-22a0-11eb-9fb0-34659c541393.png)

## How to test ( a list of instructions on how to test this PR)
Make sure your current user is a member of some community with the non-square logo.

- Check the `community/<community-name>` page (Objectives and Actions).
- Check the change community dropdown from the left top corner.
