### PR TITLE
Add vote claim error messages

### DIFF
--- a/public/translations/cat-CAT.json
+++ b/public/translations/cat-CAT.json
@@ -88,7 +88,21 @@
     "unknown": "Oh oh. Alguna cosa ha anat malament.",
     "accountNotFound": "Compte no trobat. Esteu segur que heu creat el vostre compte?",
     "phone": "Utilitzeu un número de telèfon vàlid",
-    "zipcode": "Codi postal no vàlid"
+    "zipcode": "Codi postal no vàlid",
+    "contracts": {
+      "verifyclaim": {
+        "Can't vote on already verified claim": "No es pot votar sobre una reclamació ja verificada",
+        "This is action is already completed, can't verify claim": "Aquesta acció ja s'ha completat, no es pot verificar la reclamació",
+        "There are no usages left for this action": "No queden usos per a aquesta acció",
+        "Can't find claim with given claim_id": "No es pot trobar la reclamació amb la reclamació indicada",
+        "Can't find action with given claim_id": "No es pot trobar cap acció amb claim_id donat",
+        "Can't find objective with given claim_id": "No es pot trobar objectiu amb la reclamació_id donada",
+        "Can't find community with given claim_id": "No es pot trobar la comunitat amb l'indicació claim_id",
+        "This community don't have objectives enabled.": "Aquesta comunitat no té objectius activats.",
+        "Verifier is not in the action validator list": "El verificador no es troba a la llista de validadors d'accions",
+        "Deadline exceeded": "S'ha superat el termini",
+        "The verifier cannot check the same claim more than once": "El verificador no pot comprovar la mateixa reclamació més d’una vegada"
+      }
   },
   "auth": {
     "title": "Utilitzeu la vostra clau privada i el PIN o connecteu-vos per",

--- a/public/translations/en-US.json
+++ b/public/translations/en-US.json
@@ -92,8 +92,16 @@
     "contracts": {
       "verifyclaim": {
         "Can't vote on already verified claim": "Can't vote on already verified claim",
-        "This is action is already completed, can't verify claim": "This is action is already completed, can't verify claim",
-        "There are no usages left for this action": "There are no usages left for this action"
+        "This is action is already completed, can't verify claim": "This action is already completed, can't verify claim",
+        "There are no usages left for this action": "There are no usages left for this action",
+        "Can't find claim with given claim_id": "Can't find claim with given claim_id",
+        "Can't find action with given claim_id": "Can't find action with given claim_id",
+        "Can't find objective with given claim_id": "Can't find objective with given claim_id",
+        "Can't find community with given claim_id": "Can't find community with given claim_id",
+        "This community don't have objectives enabled.": "This community doesn't have objectives enabled.",
+        "Verifier is not in the action validator list": "Verifier is not in the action validator list",
+        "Deadline exceeded": "Deadline exceeded",
+        "The verifier cannot check the same claim more than once": "The verifier cannot check the same claim more than once"
       }
     }
   },

--- a/public/translations/en-US.json
+++ b/public/translations/en-US.json
@@ -88,7 +88,14 @@
     "unknown": "Uoh. Something wrong happened.",
     "accountNotFound": "Account not found. Are you sure you created your account?",
     "phone": "Please use a valid phone number",
-    "zipcode": "Invalid zipcode"
+    "zipcode": "Invalid zipcode",
+    "contracts": {
+      "verifyclaim": {
+        "Can't vote on already verified claim": "Can't vote on already verified claim",
+        "This is action is already completed, can't verify claim": "This is action is already completed, can't verify claim",
+        "There are no usages left for this action": "There are no usages left for this action"
+      }
+    }
   },
   "auth": {
     "title": "Use your private key and PIN or log in by",

--- a/public/translations/es-ES.json
+++ b/public/translations/es-ES.json
@@ -88,7 +88,21 @@
     "unknown": "Oh oh. Algo salió mal.",
     "accountNotFound": "Cuenta no encontrada. ¿Estás seguro de haber creado tu cuenta?",
     "phone": "Utilice un número de teléfono válido",
-    "zipcode": "Código postal no válido"
+    "zipcode": "Código postal no válido",
+    "contracts": {
+      "verifyclaim": {
+        "Can't vote on already verified claim": "No puedo votar sobre un reclamo ya verificado",
+        "This is action is already completed, can't verify claim": "Esta acción ya se completó, no se puede verificar el reclamo",
+        "There are no usages left for this action": "No quedan usos para esta acción",
+        "Can't find claim with given claim_id": "No se puede encontrar el reclamo con el ID de reclamo dado",
+        "Can't find action with given claim_id": "No se puede encontrar la acción con el claim_id especificado",
+        "Can't find objective with given claim_id": "No se puede encontrar el objetivo con el claim_id especificado",
+        "Can't find community with given claim_id": "No se puede encontrar la comunidad con el ID de reclamo especificado",
+        "This community don't have objectives enabled.": "Esta comunidad no tiene objetivos habilitados.",
+        "Verifier is not in the action validator list": "El verificador no está en la lista de validadores de acciones",
+        "Deadline exceeded": "Fecha límite excedida",
+        "The verifier cannot check the same claim more than once": "El verificador no puede verificar la misma afirmación más de una vez."
+      }
   },
   "auth": {
     "title": "Use su clave privada y PIN o inicie sesión por",

--- a/public/translations/pt-BR.json
+++ b/public/translations/pt-BR.json
@@ -93,7 +93,15 @@
       "verifyclaim": {
         "Can't vote on already verified claim": "Não é possível votar em uma reivindicação já verificada",
         "This is action is already completed, can't verify claim": "Esta ação já foi concluída, não é possível verificar a reivindicação",
-        "There are no usages left for this action": "Não há usos restantes para esta ação"
+        "There are no usages left for this action": "Não há usos restantes para esta ação",
+        "Can't find claim with given claim_id": "Não é possível encontrar a reivindicação com o claim_id fornecido",
+        "Can't find action with given claim_id": "Não é possível encontrar ação com o claim_id fornecido",
+        "Can't find objective with given claim_id": "Não é possível encontrar o objetivo com o claim_id fornecido",
+        "Can't find community with given claim_id": "Não é possível encontrar a comunidade com o claim_id fornecido",
+        "This community don't have objectives enabled.": "Esta comunidade não tem objetivos habilitados.",
+        "Verifier is not in the action validator list": "O verificador não está na lista de validadores de ação",
+        "Deadline exceeded": "Prazo excedido",
+        "The verifier cannot check the same claim more than once": "O verificador não pode verificar a mesma reivindicação mais de uma vez"
       }
     }
   },

--- a/public/translations/pt-BR.json
+++ b/public/translations/pt-BR.json
@@ -88,7 +88,14 @@
     "unknown": "Opa. Algo de errado aconteceu =(.",
     "accountNotFound": "Conta não encontrada. Tem certeza que criou uma conta com essa chave?",
     "phone": "Por favor insira um número de telefone válido",
-    "zipcode": "CEP inválido"
+    "zipcode": "CEP inválido",
+    "contracts": {
+      "verifyclaim": {
+        "Can't vote on already verified claim": "Não é possível votar em uma reivindicação já verificada",
+        "This is action is already completed, can't verify claim": "Esta ação já foi concluída, não é possível verificar a reivindicação",
+        "There are no usages left for this action": "Não há usos restantes para esta ação"
+      }
+    }
   },
   "auth": {
     "title": "Use sua chave privada e PIN ou faça o login",

--- a/src/elm/Eos/EosError.elm
+++ b/src/elm/Eos/EosError.elm
@@ -1,4 +1,4 @@
-module Eos.EosError exposing (prepareErrorMessage)
+module Eos.EosError exposing (parseErrorMessage)
 
 import Json.Decode as Decode exposing (at, decodeString, field, list, string)
 import Session.Shared exposing (Translators)
@@ -32,8 +32,8 @@ extractFailure json =
             "error.unknown"
 
 
-prepareErrorMessage : Translators -> Maybe String -> String
-prepareErrorMessage { t } eosErrorString =
+parseErrorMessage : Translators -> Maybe String -> String
+parseErrorMessage { t } eosErrorString =
     t <|
         case eosErrorString of
             Just err ->

--- a/src/elm/Eos/EosError.elm
+++ b/src/elm/Eos/EosError.elm
@@ -1,6 +1,7 @@
-module Eos.EosError exposing (extractFailure)
+module Eos.EosError exposing (prepareErrorMessage)
 
 import Json.Decode as Decode exposing (at, decodeString, field, list, string)
+import Session.Shared exposing (Translators)
 
 
 {-| Extracts failure description from the first error message received from the EOS:
@@ -29,6 +30,18 @@ extractFailure json =
 
         _ ->
             "error.unknown"
+
+
+prepareErrorMessage : Translators -> Maybe String -> String
+prepareErrorMessage { t } eosErrorString =
+    t <|
+        case eosErrorString of
+            Just err ->
+                "error.contracts.verifyclaim."
+                    ++ extractFailure err
+
+            Nothing ->
+                "community.verifyClaim.error"
 
 
 decodeErrorDetails : Decode.Decoder (List String)

--- a/src/elm/Eos/EosError.elm
+++ b/src/elm/Eos/EosError.elm
@@ -1,0 +1,37 @@
+module Eos.EosError exposing (extractFailure)
+
+import Json.Decode as Decode exposing (at, decodeString, field, list, string)
+
+
+{-| Extracts failure description from the first error message received from the EOS:
+
+    extractFailure "assertion failure with message: Can't vote on already verified claim"
+        == "Can't vote on already verified claim"
+
+The result is a string which can be translated and showed to the user.
+
+-}
+extractFailure : String -> String
+extractFailure json =
+    let
+        eosErrorMessages =
+            decodeString decodeErrorDetails json
+    in
+    case eosErrorMessages of
+        Ok (firstMessage :: _) ->
+            case String.split ": " firstMessage of
+                _ :: msg :: [] ->
+                    msg
+
+                _ ->
+                    -- Keep whole message (may be verbose, with no translation, but better than nothing)
+                    firstMessage
+
+        _ ->
+            "error.unknown"
+
+
+decodeErrorDetails : Decode.Decoder (List String)
+decodeErrorDetails =
+    at [ "error", "details" ] <|
+        list (field "message" string)

--- a/src/elm/Page/Dashboard.elm
+++ b/src/elm/Page/Dashboard.elm
@@ -743,7 +743,7 @@ update msg model loggedIn =
         GotVoteResult claimId (Err eosErrorString) ->
             let
                 errorMessage =
-                    EosError.prepareErrorMessage loggedIn.shared.translators eosErrorString
+                    EosError.parseErrorMessage loggedIn.shared.translators eosErrorString
             in
             case model.analysis of
                 LoadedGraphql claims pageInfo ->

--- a/src/elm/Page/Dashboard.elm
+++ b/src/elm/Page/Dashboard.elm
@@ -742,14 +742,7 @@ update msg model loggedIn =
         GotVoteResult claimId (Err eosErrorString) ->
             let
                 errorMessage =
-                    t <|
-                        case eosErrorString of
-                            Just err ->
-                                "error.contracts.verifyclaim."
-                                    ++ EosError.extractFailure err
-
-                            Nothing ->
-                                "community.verifyClaim.error"
+                    EosError.prepareErrorMessage loggedIn.shared.translators eosErrorString
             in
             case model.analysis of
                 LoadedGraphql claims pageInfo ->

--- a/src/elm/Page/Dashboard.elm
+++ b/src/elm/Page/Dashboard.elm
@@ -409,8 +409,9 @@ viewAnalysis loggedIn claimStatus =
         ClaimVoted _ ->
             text ""
 
-        ClaimVoteFailed _ ->
-            div [ class "text-red" ] [ text "failed" ]
+        ClaimVoteFailed claim ->
+            Claim.viewClaimCard loggedIn claim
+                |> Html.map ClaimMsg
 
 
 viewTransfers : LoggedIn.Model -> Model -> Html Msg

--- a/src/elm/Page/Dashboard/Analysis.elm
+++ b/src/elm/Page/Dashboard/Analysis.elm
@@ -437,7 +437,7 @@ update msg model loggedIn =
         GotVoteResult _ (Err eosErrorString) ->
             let
                 errorMessage =
-                    EosError.prepareErrorMessage loggedIn.shared.translators eosErrorString
+                    EosError.parseErrorMessage loggedIn.shared.translators eosErrorString
             in
             case model.status of
                 Loaded claims pageInfo ->

--- a/src/elm/Page/Dashboard/Claim.elm
+++ b/src/elm/Page/Dashboard/Claim.elm
@@ -483,7 +483,7 @@ update msg model loggedIn =
         GotVoteResult _ (Err eosErrorString) ->
             let
                 errorMsg =
-                    EosError.prepareErrorMessage loggedIn.shared.translators eosErrorString
+                    EosError.parseErrorMessage loggedIn.shared.translators eosErrorString
             in
             case model.statusClaim of
                 Loaded claim ->

--- a/src/elm/Page/Dashboard/Claim.elm
+++ b/src/elm/Page/Dashboard/Claim.elm
@@ -5,6 +5,7 @@ import Cambiatus.Query
 import Claim
 import Eos exposing (Symbol)
 import Eos.Account as Eos
+import Eos.EosError as EosError
 import Graphql.Http
 import Html exposing (Html, button, div, h3, img, label, p, span, strong, text)
 import Html.Attributes exposing (class, classList, src)
@@ -391,7 +392,7 @@ type alias UpdateResult =
 type Msg
     = ClaimLoaded (Result (Graphql.Http.Error Claim.Model) Claim.Model)
     | VoteClaim Claim.ClaimId Bool
-    | GotVoteResult Claim.ClaimId (Result Decode.Value String)
+    | GotVoteResult Claim.ClaimId (Result (Maybe String) String)
     | ClaimMsg Claim.Msg
 
 
@@ -479,7 +480,11 @@ update msg model loggedIn =
                     }
                         |> UR.init
 
-        GotVoteResult _ (Err v) ->
+        GotVoteResult _ (Err eosErrorString) ->
+            let
+                errorMsg =
+                    EosError.prepareErrorMessage loggedIn.shared.translators eosErrorString
+            in
             case model.statusClaim of
                 Loaded claim ->
                     { model
@@ -487,13 +492,10 @@ update msg model loggedIn =
                         , claimModalStatus = Claim.Closed
                     }
                         |> UR.init
-                        |> UR.logDebugValue msg v
-                        |> UR.addExt (LoggedIn.ShowFeedback LoggedIn.Failure (t "community.verifyClaim.error"))
+                        |> UR.addExt (LoggedIn.ShowFeedback LoggedIn.Failure errorMsg)
 
                 _ ->
-                    model
-                        |> UR.init
-                        |> UR.logDebugValue msg v
+                    model |> UR.init
 
 
 
@@ -521,7 +523,8 @@ jsAddressToMsg addr val =
                 (Decode.oneOf
                     [ Decode.field "transactionId" Decode.string
                         |> Decode.map Ok
-                    , Decode.succeed (Err Encode.null)
+                    , Decode.field "error" (Decode.nullable Decode.string)
+                        |> Decode.map Err
                     ]
                 )
                 val


### PR DESCRIPTION
## What issue does this PR close
Closes #422 

## Changes Proposed (a list of new changes introduced by this PR)
After the `verifyclaim` transaction Elm may receive a JS `Value` with the field `error` containing the JSON-string representation of the errors from EOS:
![image](https://user-images.githubusercontent.com/140053/98809076-18512a00-242e-11eb-9bde-0874c049776c.png)

Proposed changes are:
- Add a module for parsing JSON-strings with errors from EOS.
- Extract the appropriate message from the EOS errors list and show it to the user as a feedback message when an error occurs.

## How to test (a list of instructions on how to test this PR)
Try to vote some non-valid Claim from the Dashboard, Analysis, or Claim View page and see the error like this:
![image](https://user-images.githubusercontent.com/140053/98808141-c22fb700-242c-11eb-9399-7140b3e2a150.png)

