### PR TITLE
Fixes the quotation marks of the plausible script

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -28,7 +28,7 @@
     <meta name="theme-color" content="#ffffff">
     <link href="https://fonts.googleapis.com/css2?family=Nunito:ital,wght@0,300;0,400;0,600;0,700;1,300;1,400;1,600;1,700&display=swap" rel="stylesheet">
 
-    <script async defer data-domain=“muda.cambiatus.io” src=“https://plausible.io/js/plausible.js”></script>
+    <script async defer data-domain="muda.cambiatus.io" src="https://plausible.io/js/plausible.js"></script>
     <script src="%PUBLIC_URL%/env-config.js"></script>
 
     <title>Cambiatus</title>


### PR DESCRIPTION
## What issue does this PR close
Fixes #407 

## Changes Proposed ( a list of new changes introduced by this PR)
The Plausible auto-generated script comes with special quotation marks (“ ”) that was not picking up the data for our domain.
This fixes the quotation marks of the plausible auto-generated script to the regular quotation marks (" ").

## How to test ( a list of instructions on how to test this PR)
Tested the plausible script with a personal website and works properly when using the regular quotation marks.