### PR TITLE
Show errors for Transfers

### DIFF
--- a/public/translations/cat-CAT.json
+++ b/public/translations/cat-CAT.json
@@ -90,6 +90,17 @@
     "phone": "Utilitzeu un número de telèfon vàlid",
     "zipcode": "Codi postal no vàlid",
     "contracts": {
+      "transfer": {
+        "cannot transfer to self": "No es pot transferir a un mateix",
+        "destination account doesn't exists": "El compte de destinació no existeix",
+        "token with given symbol doesn't exists": "El testimoni amb el símbol donat no existeix",
+        "invalid quantity": "Quantitat no vàlida",
+        "quantity must be positive": "La quantitat ha de ser positiva",
+        "symbol precision mismatch": "Desajust de precisió de símbols",
+        "memo has more than 256 bytes": "La nota té més de 256 símbols",
+        "from account doesn't belong to the community": "Des del compte no pertany a la comunitat",
+        "to account doesn't belong to the community": "El compte no pertany a la comunitat"
+      },
       "verifyclaim": {
         "Can't vote on already verified claim": "No es pot votar sobre una reclamació ja verificada",
         "This is action is already completed, can't verify claim": "Aquesta acció ja s'ha completat, no es pot verificar la reclamació",

--- a/public/translations/en-US.json
+++ b/public/translations/en-US.json
@@ -90,6 +90,9 @@
     "phone": "Please use a valid phone number",
     "zipcode": "Invalid zipcode",
     "contracts": {
+      "transfer": {
+        "cannot transfer to self": "Cannot transfer to self"
+      },
       "verifyclaim": {
         "Can't vote on already verified claim": "Can't vote on already verified claim",
         "This is action is already completed, can't verify claim": "This action is already completed, can't verify claim",

--- a/public/translations/en-US.json
+++ b/public/translations/en-US.json
@@ -91,7 +91,15 @@
     "zipcode": "Invalid zipcode",
     "contracts": {
       "transfer": {
-        "cannot transfer to self": "Cannot transfer to self"
+        "cannot transfer to self": "Cannot transfer to self",
+        "destination account doesn't exists": "Destination account doesn't exist",
+        "token with given symbol doesn't exists": "Token with given symbol doesn't exist",
+        "invalid quantity": "Invalid quantity",
+        "quantity must be positive": "La quantitat ha de ser positiva",
+        "symbol precision mismatch": "Symbol precision mismatch",
+        "memo has more than 256 bytes": "The memo has more than 256 symbols",
+        "from account doesn't belong to the community": "From account doesn't belong to the community",
+        "to account doesn't belong to the community": "To account doesn't belong to the community"
       },
       "verifyclaim": {
         "Can't vote on already verified claim": "Can't vote on already verified claim",

--- a/public/translations/es-ES.json
+++ b/public/translations/es-ES.json
@@ -90,6 +90,17 @@
     "phone": "Utilice un número de teléfono válido",
     "zipcode": "Código postal no válido",
     "contracts": {
+      "transfer": {
+        "cannot transfer to self": "No se puede transferir a uno mismo",
+        "destination account doesn't exists": "La cuenta de destino no existe",
+        "token with given symbol doesn't exists": "El token con el símbolo dado no existe",
+        "invalid quantity": "Cantidad inválida",
+        "quantity must be positive": "La cantidad debe ser positiva",
+        "symbol precision mismatch": "Falta de coincidencia de precisión de símbolo",
+        "memo has more than 256 bytes": "El memo tiene más de 256 símbolos",
+        "from account doesn't belong to the community": "De la cuenta no pertenece a la comunidad",
+        "to account doesn't belong to the community": "La cuenta no pertenece a la comunidad"
+      },
       "verifyclaim": {
         "Can't vote on already verified claim": "No puedo votar sobre un reclamo ya verificado",
         "This is action is already completed, can't verify claim": "Esta acción ya se completó, no se puede verificar el reclamo",

--- a/public/translations/pt-BR.json
+++ b/public/translations/pt-BR.json
@@ -91,7 +91,7 @@
     "zipcode": "CEP inválido",
     "contracts": {
       "transfer": {
-        "cannot transfer to self": "Não pode transferir para mim",
+        "cannot transfer to self": "Não é possível transferir para si mesmo",
         "destination account doesn't exists": "A conta de destino não existe",
         "token with given symbol doesn't exists": "O token com o símbolo fornecido não existe",
         "invalid quantity": "Quantidade inválida",

--- a/public/translations/pt-BR.json
+++ b/public/translations/pt-BR.json
@@ -98,7 +98,7 @@
         "quantity must be positive": "Quantidade deve ser positiva",
         "symbol precision mismatch": "Precisão do símbolo incompatível",
         "memo has more than 256 bytes": "O memorando tem mais de 256 símbolos",
-        "from account doesn't belong to the community": "De conta não pertence à comunidade",
+        "from account doesn't belong to the community": "A conta de origem não pertence à comunidade",
         "to account doesn't belong to the community": "A conta não pertence à comunidade"
       },
       "verifyclaim": {

--- a/public/translations/pt-BR.json
+++ b/public/translations/pt-BR.json
@@ -97,7 +97,7 @@
         "invalid quantity": "Quantidade inválida",
         "quantity must be positive": "Quantidade deve ser positiva",
         "symbol precision mismatch": "Precisão do símbolo incompatível",
-        "memo has more than 256 bytes": "O memorando tem mais de 256 símbolos",
+        "memo has more than 256 bytes": "a mensagem não pode ter mais que 256 carácteres",
         "from account doesn't belong to the community": "A conta de origem não pertence à comunidade",
         "to account doesn't belong to the community": "A conta de destino não pertence à comunidade"
       },

--- a/public/translations/pt-BR.json
+++ b/public/translations/pt-BR.json
@@ -90,6 +90,17 @@
     "phone": "Por favor insira um número de telefone válido",
     "zipcode": "CEP inválido",
     "contracts": {
+      "transfer": {
+        "cannot transfer to self": "Não pode transferir para mim",
+        "destination account doesn't exists": "A conta de destino não existe",
+        "token with given symbol doesn't exists": "O token com o símbolo fornecido não existe",
+        "invalid quantity": "Quantidade inválida",
+        "quantity must be positive": "Quantidade deve ser positiva",
+        "symbol precision mismatch": "Precisão do símbolo incompatível",
+        "memo has more than 256 bytes": "O memorando tem mais de 256 símbolos",
+        "from account doesn't belong to the community": "De conta não pertence à comunidade",
+        "to account doesn't belong to the community": "A conta não pertence à comunidade"
+      },
       "verifyclaim": {
         "Can't vote on already verified claim": "Não é possível votar em uma reivindicação já verificada",
         "This is action is already completed, can't verify claim": "Esta ação já foi concluída, não é possível verificar a reivindicação",

--- a/public/translations/pt-BR.json
+++ b/public/translations/pt-BR.json
@@ -93,7 +93,7 @@
       "transfer": {
         "cannot transfer to self": "Não é possível transferir para si mesmo",
         "destination account doesn't exists": "A conta de destino não existe",
-        "token with given symbol doesn't exists": "O token com o símbolo fornecido não existe",
+        "token with given symbol doesn't exists": "Nenhuma moeda com o símbolo fornecido foi encontrada",
         "invalid quantity": "Quantidade inválida",
         "quantity must be positive": "Quantidade deve ser positiva",
         "symbol precision mismatch": "Precisão do símbolo incompatível",

--- a/public/translations/pt-BR.json
+++ b/public/translations/pt-BR.json
@@ -99,7 +99,7 @@
         "symbol precision mismatch": "Precisão do símbolo incompatível",
         "memo has more than 256 bytes": "O memorando tem mais de 256 símbolos",
         "from account doesn't belong to the community": "A conta de origem não pertence à comunidade",
-        "to account doesn't belong to the community": "A conta não pertence à comunidade"
+        "to account doesn't belong to the community": "A conta de destino não pertence à comunidade"
       },
       "verifyclaim": {
         "Can't vote on already verified claim": "Não é possível votar em uma reivindicação já verificada",

--- a/src/elm/Eos/EosError.elm
+++ b/src/elm/Eos/EosError.elm
@@ -1,4 +1,7 @@
-module Eos.EosError exposing (parseErrorMessage)
+module Eos.EosError exposing
+    ( parseClaimError
+    , parseTransferError
+    )
 
 import Json.Decode as Decode exposing (at, decodeString, field, list, string)
 import Session.Shared exposing (Translators)
@@ -32,19 +35,41 @@ extractFailure json =
             "error.unknown"
 
 
-parseErrorMessage : Translators -> Maybe String -> String
-parseErrorMessage { t } eosErrorString =
+parseErrorMessage : Translators -> String -> String -> Maybe String -> String
+parseErrorMessage { t } translationPrefix translationDefault eosErrorString =
     t <|
         case eosErrorString of
             Just err ->
-                "error.contracts.verifyclaim."
+                translationPrefix
                     ++ extractFailure err
 
             Nothing ->
-                "community.verifyClaim.error"
+                translationDefault
 
 
 decodeErrorDetails : Decode.Decoder (List String)
 decodeErrorDetails =
     at [ "error", "details" ] <|
         list (field "message" string)
+
+
+
+-- MESSAGES FOR MODULES
+
+
+parseClaimError : Translators -> Maybe String -> String
+parseClaimError translators eosErrorString =
+    parseErrorMessage
+        translators
+        "error.contracts.verifyclaim."
+        "community.verifyClaim.error"
+        eosErrorString
+
+
+parseTransferError : Translators -> Maybe String -> String
+parseTransferError translators eosErrorString =
+    parseErrorMessage
+        translators
+        "error.contracts.transfer."
+        "account.my_wallet.transfer.error"
+        eosErrorString

--- a/src/elm/Page/Community/Transfer.elm
+++ b/src/elm/Page/Community/Transfer.elm
@@ -489,7 +489,7 @@ update msg model ({ shared } as loggedIn) =
         GotTransferResult (Err eosErrorString) ->
             let
                 errorMessage =
-                    EosError.parseErrorMessage loggedIn.shared.translators eosErrorString
+                    EosError.parseTransferError loggedIn.shared.translators eosErrorString
             in
             case model.status of
                 Loaded c (SendingTransfer form) ->

--- a/src/elm/Page/Dashboard.elm
+++ b/src/elm/Page/Dashboard.elm
@@ -743,7 +743,7 @@ update msg model loggedIn =
         GotVoteResult claimId (Err eosErrorString) ->
             let
                 errorMessage =
-                    EosError.parseErrorMessage loggedIn.shared.translators eosErrorString
+                    EosError.parseClaimError loggedIn.shared.translators eosErrorString
             in
             case model.analysis of
                 LoadedGraphql claims pageInfo ->

--- a/src/elm/Page/Dashboard/Analysis.elm
+++ b/src/elm/Page/Dashboard/Analysis.elm
@@ -437,7 +437,7 @@ update msg model loggedIn =
         GotVoteResult _ (Err eosErrorString) ->
             let
                 errorMessage =
-                    EosError.parseErrorMessage loggedIn.shared.translators eosErrorString
+                    EosError.parseClaimError loggedIn.shared.translators eosErrorString
             in
             case model.status of
                 Loaded claims pageInfo ->

--- a/src/elm/Page/Dashboard/Claim.elm
+++ b/src/elm/Page/Dashboard/Claim.elm
@@ -483,7 +483,7 @@ update msg model loggedIn =
         GotVoteResult _ (Err eosErrorString) ->
             let
                 errorMsg =
-                    EosError.parseErrorMessage loggedIn.shared.translators eosErrorString
+                    EosError.parseClaimError loggedIn.shared.translators eosErrorString
             in
             case model.statusClaim of
                 Loaded claim ->


### PR DESCRIPTION
## What issue does this PR close
Part of #419. Contains the error handling and translations for the [Transfers](https://github.com/cambiatus/contracts/blob/1ae0906ba20451794713f6b41af1f750a3b747cd/token/token.cpp#L149) errors from the EOS.

## Changes Proposed ( a list of new changes introduced by this PR)
Show translated error messages if they happen while Transfering coins (see "Transfer to a friend" page).
![image](https://user-images.githubusercontent.com/140053/99397497-30282280-28f4-11eb-9db3-d36dfbc2197f.png)

## How to test ( a list of instructions on how to test this PR)
Try to transfer some coins from the "Transfer to a friend" page (the link on the Dashboard), emulate some errors:
- Transfer to yourself;
- Add memo more than 256 symbols;
- etc.
