### PR TITLE
Fix GitHub add-path deprecation

### DIFF
--- a/.github/workflows/on-push-action.yml
+++ b/.github/workflows/on-push-action.yml
@@ -21,10 +21,10 @@ jobs:
       - name: "Check elm-format"
         uses: sparksp/elm-format-action@v1
 
-#      - name: "Check elm-review"
-#        uses: sparksp/elm-review-action@v1.0.4
-#        env:
-#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: "Check elm-review"
+        uses: sparksp/elm-review-action@v1.0.4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build asset
         run: yarn build

--- a/.github/workflows/on-push-action.yml
+++ b/.github/workflows/on-push-action.yml
@@ -16,7 +16,7 @@ jobs:
         run: yarn install --production
 
       - name: Add `node_modules/.bin` to PATH
-        run: echo ::add-path::$(yarn bin)
+        run: echo $(yarn bin) >> $GITHUB_PATH
 
       - name: "Check elm-format"
         uses: sparksp/elm-format-action@v1


### PR DESCRIPTION
## What issue does this PR close
Closes N/A. Fixes deprecated `add-path` instruction which we are used before.

## Changes Proposed ( a list of new changes introduced by this PR)
Github [deprecated](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/) `add-path` so our frontend build process is broken now.

## How to test ( a list of instructions on how to test this PR)
See the GitHub Actions logs for this PR, all builds should be passed.
