### PR TITLE
Fix EOS error to be a Value instead of a String

### DIFF
--- a/src/elm/Eos/EosError.elm
+++ b/src/elm/Eos/EosError.elm
@@ -3,7 +3,7 @@ module Eos.EosError exposing
     , parseTransferError
     )
 
-import Json.Decode as Decode exposing (at, decodeString, field, list, string)
+import Json.Decode as Decode exposing (Value, at, decodeValue, field, list, string)
 import Session.Shared exposing (Translators)
 
 
@@ -15,11 +15,11 @@ import Session.Shared exposing (Translators)
 The result is a string which can be translated and showed to the user.
 
 -}
-extractFailure : String -> String
+extractFailure : Value -> String
 extractFailure json =
     let
         eosErrorMessages =
-            decodeString decodeErrorDetails json
+            decodeValue decodeErrorDetails json
     in
     case eosErrorMessages of
         Ok (firstMessage :: _) ->
@@ -35,7 +35,7 @@ extractFailure json =
             "error.unknown"
 
 
-parseErrorMessage : Translators -> String -> String -> Maybe String -> String
+parseErrorMessage : Translators -> String -> String -> Maybe Value -> String
 parseErrorMessage { t } translationPrefix translationDefault eosErrorString =
     t <|
         case eosErrorString of
@@ -57,7 +57,7 @@ decodeErrorDetails =
 -- MESSAGES FOR MODULES
 
 
-parseClaimError : Translators -> Maybe String -> String
+parseClaimError : Translators -> Maybe Value -> String
 parseClaimError translators eosErrorString =
     parseErrorMessage
         translators
@@ -66,7 +66,7 @@ parseClaimError translators eosErrorString =
         eosErrorString
 
 
-parseTransferError : Translators -> Maybe String -> String
+parseTransferError : Translators -> Maybe Value -> String
 parseTransferError translators eosErrorString =
     parseErrorMessage
         translators

--- a/src/elm/Page/Community/Transfer.elm
+++ b/src/elm/Page/Community/Transfer.elm
@@ -283,7 +283,7 @@ type Msg
     | SubmitForm
     | PressedEnter Bool
     | PushTransaction
-    | GotTransferResult (Result (Maybe String) String)
+    | GotTransferResult (Result (Maybe Value) String)
     | Redirect Value
 
 
@@ -550,7 +550,7 @@ jsAddressToMsg addr val =
                 (Decode.oneOf
                     [ Decode.field "transactionId" Decode.string
                         |> Decode.map Ok
-                    , Decode.field "error" (Decode.nullable Decode.string)
+                    , Decode.field "error" (Decode.nullable Decode.value)
                         |> Decode.map Err
                     ]
                 )

--- a/src/elm/Page/Dashboard.elm
+++ b/src/elm/Page/Dashboard.elm
@@ -567,7 +567,7 @@ type Msg
     | CommunityLoaded (Result (Graphql.Http.Error (Maybe Community.DashboardInfo)) (Maybe Community.DashboardInfo))
     | ClaimMsg Claim.Msg
     | VoteClaim Claim.ClaimId Bool
-    | GotVoteResult Claim.ClaimId (Result (Maybe String) String)
+    | GotVoteResult Claim.ClaimId (Result (Maybe Value) String)
     | CreateInvite
     | CloseInviteModal
     | CompletedInviteCreation (Result Http.Error String)
@@ -945,7 +945,7 @@ jsAddressToMsg addr val =
                 (Decode.oneOf
                     [ Decode.field "transactionId" Decode.string
                         |> Decode.map Ok
-                    , Decode.field "error" (Decode.nullable Decode.string)
+                    , Decode.field "error" (Decode.nullable Decode.value)
                         |> Decode.map Err
                     ]
                 )

--- a/src/elm/Page/Dashboard/Analysis.elm
+++ b/src/elm/Page/Dashboard/Analysis.elm
@@ -23,7 +23,7 @@ import Html.Attributes exposing (class, selected, src, value)
 import Html.Events exposing (onClick)
 import I18Next
 import Icons
-import Json.Decode as Decode
+import Json.Decode as Decode exposing (Value)
 import Json.Encode as Encode
 import List.Extra as List
 import Page
@@ -310,7 +310,7 @@ type Msg
     = ClaimsLoaded (Result (Graphql.Http.Error (Maybe Claim.Paginated)) (Maybe Claim.Paginated))
     | ClaimMsg Claim.Msg
     | VoteClaim Claim.ClaimId Bool
-    | GotVoteResult Claim.ClaimId (Result (Maybe String) String)
+    | GotVoteResult Claim.ClaimId (Result (Maybe Value) String)
     | SelectMsg (Select.Msg Profile)
     | OnSelectVerifier (Maybe Profile)
     | CompletedCommunityLoad (Result (Graphql.Http.Error (Maybe Community.Model)) (Maybe Community.Model))
@@ -690,7 +690,7 @@ jsAddressToMsg addr val =
                 (Decode.oneOf
                     [ Decode.field "transactionId" Decode.string
                         |> Decode.map Ok
-                    , Decode.field "error" (Decode.nullable Decode.string)
+                    , Decode.field "error" (Decode.nullable Decode.value)
                         |> Decode.map Err
                     ]
                 )

--- a/src/elm/Page/Dashboard/Claim.elm
+++ b/src/elm/Page/Dashboard/Claim.elm
@@ -11,7 +11,7 @@ import Html exposing (Html, button, div, h3, img, label, p, span, strong, text)
 import Html.Attributes exposing (class, classList, src)
 import Html.Events exposing (onClick)
 import I18Next
-import Json.Decode as Decode
+import Json.Decode as Decode exposing (Value)
 import Json.Encode as Encode
 import Page
 import Profile
@@ -392,7 +392,7 @@ type alias UpdateResult =
 type Msg
     = ClaimLoaded (Result (Graphql.Http.Error Claim.Model) Claim.Model)
     | VoteClaim Claim.ClaimId Bool
-    | GotVoteResult Claim.ClaimId (Result (Maybe String) String)
+    | GotVoteResult Claim.ClaimId (Result (Maybe Value) String)
     | ClaimMsg Claim.Msg
 
 
@@ -523,7 +523,7 @@ jsAddressToMsg addr val =
                 (Decode.oneOf
                     [ Decode.field "transactionId" Decode.string
                         |> Decode.map Ok
-                    , Decode.field "error" (Decode.nullable Decode.string)
+                    , Decode.field "error" (Decode.nullable Decode.value)
                         |> Decode.map Err
                     ]
                 )


### PR DESCRIPTION
This came into after improving Sentry errors in #434

## What issue does this PR close
Closes N/A.

## Changes Proposed ( a list of new changes introduced by this PR)
Now we are passing the error as a JS object instead of a String from the port, so we need to handle it like a `Value` in Elm.

## How to test ( a list of instructions on how to test this PR)
Send the transaction which will cause an error, like transferring coins to yourself. There must be an error on top of the website with the appropriate message.
