### PR TITLE
Login passphrase input element change 

### DIFF
--- a/src/elm/Auth.elm
+++ b/src/elm/Auth.elm
@@ -678,11 +678,16 @@ update msg shared model =
                         | passphrase = phrase
                     }
             in
-            { model
-                | form = newForm
-                , problems = []
-            }
-                |> UR.init
+            case model.status of
+                Options LoginStepPassphrase ->
+                    { model
+                        | form = newForm
+                        , problems = []
+                    }
+                        |> UR.init
+
+                _ ->
+                    UR.init model
 
         SubmittedLoginPrivateKey form ->
             case validate pinValidator form of

--- a/src/elm/Auth.elm
+++ b/src/elm/Auth.elm
@@ -344,7 +344,7 @@ viewLoginSteps isModal shared model loginStep =
                         |> List.length
                         |> String.fromInt
             in
-            [ form [ class "sf-content", onSubmit ClickedViewLoginPinStep ]
+            [ form [ class "sf-content" ]
                 [ illustration "login_key.svg"
                 , p [ class pClass ]
                     [ span [ class "text-green text-caption tracking-wide uppercase block mb-1" ]
@@ -368,6 +368,7 @@ viewLoginSteps isModal shared model loginStep =
                         , id passphraseId
                         , value model.form.passphrase
                         , onInput EnteredPassphrase
+                        , onSubmit ClickedViewLoginPinStep
                         , required True
                         , autocomplete False
                         ]
@@ -831,11 +832,11 @@ update msg shared model =
             if isEnter then
                 UR.init model
                     |> UR.addCmd
-                        (Task.succeed (SubmittedLoginPrivateKey model.form)
+                        (Task.succeed ClickedViewLoginPinStep
                             |> Task.perform identity
                         )
                     |> UR.addCmd
-                        (Task.succeed ClickedViewLoginPinStep
+                        (Task.succeed (SubmittedLoginPrivateKey model.form)
                             |> Task.perform identity
                         )
 

--- a/src/elm/Auth.elm
+++ b/src/elm/Auth.elm
@@ -30,7 +30,7 @@ import Graphql.Http
 import Graphql.Operation exposing (RootMutation)
 import Graphql.OptionalArgument exposing (OptionalArgument(..))
 import Graphql.SelectionSet as SelectionSet exposing (SelectionSet, with)
-import Html exposing (Html, a, button, div, form, h2, img, input, label, li, p, span, strong, text, ul, textarea)
+import Html exposing (Html, a, button, div, form, h2, img, label, li, p, span, strong, text, ul, textarea)
 import Html.Attributes exposing (autocomplete, autofocus, class, disabled, for, id, placeholder, required, src, title, type_, value)
 import Html.Events exposing (on, keyCode, onClick, onInput, onSubmit)
 import I18Next exposing (t)

--- a/src/elm/Auth.elm
+++ b/src/elm/Auth.elm
@@ -830,15 +830,22 @@ update msg shared model =
 
         KeyPressed isEnter ->
             if isEnter then
-                UR.init model
-                    |> UR.addCmd
-                        (Task.succeed ClickedViewLoginPinStep
-                            |> Task.perform identity
-                        )
-                    |> UR.addCmd
-                        (Task.succeed (SubmittedLoginPrivateKey model.form)
-                            |> Task.perform identity
-                        )
+                if model.status == Options LoginStepPassphrase then
+                    UR.init model
+                        |> UR.addCmd
+                            (Task.succeed ClickedViewLoginPinStep
+                                |> Task.perform identity
+                            )
+
+                else if model.status == Options LoginStepPIN then
+                    UR.init model
+                        |> UR.addCmd
+                            (Task.succeed (SubmittedLoginPrivateKey model.form)
+                                |> Task.perform identity
+                            )
+
+                else
+                    UR.init model
 
             else
                 UR.init model

--- a/src/elm/Auth.elm
+++ b/src/elm/Auth.elm
@@ -30,9 +30,9 @@ import Graphql.Http
 import Graphql.Operation exposing (RootMutation)
 import Graphql.OptionalArgument exposing (OptionalArgument(..))
 import Graphql.SelectionSet as SelectionSet exposing (SelectionSet, with)
-import Html exposing (Html, a, button, div, form, h2, img, input, label, li, p, span, strong, text, ul)
+import Html exposing (Html, a, button, div, form, h2, img, input, label, li, p, span, strong, text, ul, textarea)
 import Html.Attributes exposing (autocomplete, autofocus, class, disabled, for, id, placeholder, required, src, title, type_, value)
-import Html.Events exposing (onClick, onInput, onSubmit)
+import Html.Events exposing (on, keyCode, onClick, onInput, onSubmit)
 import I18Next exposing (t)
 import Json.Decode as Decode
 import Json.Decode.Pipeline as Decode
@@ -344,7 +344,7 @@ viewLoginSteps isModal shared model loginStep =
                         |> List.length
                         |> String.fromInt
             in
-            [ form [ class "sf-content", onSubmit ClickedViewLoginPinStep ]
+            [ form [ class "sf-content" ]
                 [ illustration "login_key.svg"
                 , p [ class pClass ]
                     [ span [ class "text-green text-caption tracking-wide uppercase block mb-1" ]
@@ -354,7 +354,7 @@ viewLoginSteps isModal shared model loginStep =
                     ]
                 , viewFieldLabel shared.translators "auth.login.wordsMode.input" passphraseId
                 , div [ class "relative" ]
-                    [ input
+                    [ textarea
                         [ class "form-textarea h-19 min-w-full block"
                         , placeholder (t "auth.login.wordsMode.input.placeholder")
                         , View.Form.noGrammarly
@@ -368,6 +368,7 @@ viewLoginSteps isModal shared model loginStep =
                         , id passphraseId
                         , value model.form.passphrase
                         , onInput EnteredPassphrase
+                        , onEnter ClickedViewLoginPinStep
                         , required True
                         , autocomplete False
                         ]
@@ -953,6 +954,16 @@ msgToString msg =
         KeyPressed _ ->
             [ "KeyPressed" ]
 
+onEnter : Msg -> Html.Attribute Msg
+onEnter msg =
+        let
+            isEnter code =
+                if code == 13 then
+                    Decode.succeed msg
+                else
+                    Decode.fail "wrong key stroke"
+        in
+            on "keydown" (Decode.andThen isEnter keyCode)
 
 viewPin : Model -> Shared -> Html Msg
 viewPin ({ form } as model) shared =

--- a/src/elm/Auth.elm
+++ b/src/elm/Auth.elm
@@ -830,22 +830,23 @@ update msg shared model =
 
         KeyPressed isEnter ->
             if isEnter then
-                if model.status == Options LoginStepPassphrase then
-                    UR.init model
-                        |> UR.addCmd
-                            (Task.succeed ClickedViewLoginPinStep
-                                |> Task.perform identity
-                            )
+                case model.status of
+                    Options LoginStepPassphrase ->
+                        UR.init model
+                            |> UR.addCmd
+                                (Task.succeed ClickedViewLoginPinStep
+                                    |> Task.perform identity
+                                )
 
-                else if model.status == Options LoginStepPIN then
-                    UR.init model
-                        |> UR.addCmd
-                            (Task.succeed (SubmittedLoginPrivateKey model.form)
-                                |> Task.perform identity
-                            )
+                    Options LoginStepPIN ->
+                        UR.init model
+                            |> UR.addCmd
+                                (Task.succeed (SubmittedLoginPrivateKey model.form)
+                                    |> Task.perform identity
+                                )
 
-                else
-                    UR.init model
+                    _ ->
+                        UR.init model
 
             else
                 UR.init model

--- a/src/elm/Auth.elm
+++ b/src/elm/Auth.elm
@@ -30,7 +30,7 @@ import Graphql.Http
 import Graphql.Operation exposing (RootMutation)
 import Graphql.OptionalArgument exposing (OptionalArgument(..))
 import Graphql.SelectionSet as SelectionSet exposing (SelectionSet, with)
-import Html exposing (Html, a, button, div, form, h2, img, input, label, li, p, span, strong, text, textarea, ul)
+import Html exposing (Html, a, button, div, form, h2, img, input, label, li, p, span, strong, text, ul)
 import Html.Attributes exposing (autocomplete, autofocus, class, disabled, for, id, placeholder, required, src, title, type_, value)
 import Html.Events exposing (onClick, onInput, onSubmit)
 import I18Next exposing (t)

--- a/src/elm/Auth.elm
+++ b/src/elm/Auth.elm
@@ -344,7 +344,7 @@ viewLoginSteps isModal shared model loginStep =
                         |> List.length
                         |> String.fromInt
             in
-            [ form [ class "sf-content", onSubmit ClickedViewLoginPinStep]
+            [ form [ class "sf-content", onSubmit ClickedViewLoginPinStep ]
                 [ illustration "login_key.svg"
                 , p [ class pClass ]
                     [ span [ class "text-green text-caption tracking-wide uppercase block mb-1" ]
@@ -835,12 +835,13 @@ update msg shared model =
                             |> Task.perform identity
                         )
                     |> UR.addCmd
-                        (Task.succeed (ClickedViewLoginPinStep)
+                        (Task.succeed ClickedViewLoginPinStep
                             |> Task.perform identity
                         )
 
             else
                 UR.init model
+
 
 loginFailedGraphql : Graphql.Http.Error (Maybe Profile) -> Model -> UpdateResult
 loginFailedGraphql httpError model =
@@ -955,9 +956,6 @@ msgToString msg =
 
         KeyPressed _ ->
             [ "KeyPressed" ]
-
-
-
 
 
 viewPin : Model -> Shared -> Html Msg

--- a/src/elm/Auth.elm
+++ b/src/elm/Auth.elm
@@ -32,7 +32,7 @@ import Graphql.OptionalArgument exposing (OptionalArgument(..))
 import Graphql.SelectionSet as SelectionSet exposing (SelectionSet, with)
 import Html exposing (Html, a, button, div, form, h2, img, label, li, p, span, strong, text, textarea, ul)
 import Html.Attributes exposing (autocomplete, autofocus, class, disabled, for, id, placeholder, required, src, title, type_, value)
-import Html.Events exposing (keyCode, on, onClick, onInput, onSubmit)
+import Html.Events exposing (onClick, onInput, onSubmit)
 import I18Next exposing (t)
 import Json.Decode as Decode
 import Json.Decode.Pipeline as Decode
@@ -344,7 +344,7 @@ viewLoginSteps isModal shared model loginStep =
                         |> List.length
                         |> String.fromInt
             in
-            [ form [ class "sf-content" ]
+            [ form [ class "sf-content", onSubmit ClickedViewLoginPinStep]
                 [ illustration "login_key.svg"
                 , p [ class pClass ]
                     [ span [ class "text-green text-caption tracking-wide uppercase block mb-1" ]
@@ -368,7 +368,6 @@ viewLoginSteps isModal shared model loginStep =
                         , id passphraseId
                         , value model.form.passphrase
                         , onInput EnteredPassphrase
-                        , onEnter ClickedViewLoginPinStep
                         , required True
                         , autocomplete False
                         ]
@@ -835,10 +834,13 @@ update msg shared model =
                         (Task.succeed (SubmittedLoginPrivateKey model.form)
                             |> Task.perform identity
                         )
+                    |> UR.addCmd
+                        (Task.succeed (ClickedViewLoginPinStep)
+                            |> Task.perform identity
+                        )
 
             else
                 UR.init model
-
 
 loginFailedGraphql : Graphql.Http.Error (Maybe Profile) -> Model -> UpdateResult
 loginFailedGraphql httpError model =
@@ -955,17 +957,7 @@ msgToString msg =
             [ "KeyPressed" ]
 
 
-onEnter : Msg -> Html.Attribute Msg
-onEnter msg =
-    let
-        isEnter code =
-            if code == 13 then
-                Decode.succeed msg
 
-            else
-                Decode.fail "wrong key stroke"
-    in
-    on "keydown" (Decode.andThen isEnter keyCode)
 
 
 viewPin : Model -> Shared -> Html Msg

--- a/src/elm/Auth.elm
+++ b/src/elm/Auth.elm
@@ -30,9 +30,9 @@ import Graphql.Http
 import Graphql.Operation exposing (RootMutation)
 import Graphql.OptionalArgument exposing (OptionalArgument(..))
 import Graphql.SelectionSet as SelectionSet exposing (SelectionSet, with)
-import Html exposing (Html, a, button, div, form, h2, img, label, li, p, span, strong, text, ul, textarea)
+import Html exposing (Html, a, button, div, form, h2, img, label, li, p, span, strong, text, textarea, ul)
 import Html.Attributes exposing (autocomplete, autofocus, class, disabled, for, id, placeholder, required, src, title, type_, value)
-import Html.Events exposing (on, keyCode, onClick, onInput, onSubmit)
+import Html.Events exposing (keyCode, on, onClick, onInput, onSubmit)
 import I18Next exposing (t)
 import Json.Decode as Decode
 import Json.Decode.Pipeline as Decode
@@ -954,16 +954,19 @@ msgToString msg =
         KeyPressed _ ->
             [ "KeyPressed" ]
 
+
 onEnter : Msg -> Html.Attribute Msg
 onEnter msg =
-        let
-            isEnter code =
-                if code == 13 then
-                    Decode.succeed msg
-                else
-                    Decode.fail "wrong key stroke"
-        in
-            on "keydown" (Decode.andThen isEnter keyCode)
+    let
+        isEnter code =
+            if code == 13 then
+                Decode.succeed msg
+
+            else
+                Decode.fail "wrong key stroke"
+    in
+    on "keydown" (Decode.andThen isEnter keyCode)
+
 
 viewPin : Model -> Shared -> Html Msg
 viewPin ({ form } as model) shared =

--- a/src/elm/Auth.elm
+++ b/src/elm/Auth.elm
@@ -30,7 +30,7 @@ import Graphql.Http
 import Graphql.Operation exposing (RootMutation)
 import Graphql.OptionalArgument exposing (OptionalArgument(..))
 import Graphql.SelectionSet as SelectionSet exposing (SelectionSet, with)
-import Html exposing (Html, a, button, div, h2, img, label, li, p, span, strong, text, textarea, ul)
+import Html exposing (Html, a, button, div, form, h2, img, input, label, li, p, span, strong, text, textarea, ul)
 import Html.Attributes exposing (autocomplete, autofocus, class, disabled, for, id, placeholder, required, src, title, type_, value)
 import Html.Events exposing (onClick, onInput, onSubmit)
 import I18Next exposing (t)
@@ -344,7 +344,7 @@ viewLoginSteps isModal shared model loginStep =
                         |> List.length
                         |> String.fromInt
             in
-            [ div [ class "sf-content" ]
+            [ form [ class "sf-content", onSubmit ClickedViewLoginPinStep ]
                 [ illustration "login_key.svg"
                 , p [ class pClass ]
                     [ span [ class "text-green text-caption tracking-wide uppercase block mb-1" ]
@@ -354,7 +354,7 @@ viewLoginSteps isModal shared model loginStep =
                     ]
                 , viewFieldLabel shared.translators "auth.login.wordsMode.input" passphraseId
                 , div [ class "relative" ]
-                    [ textarea
+                    [ input
                         [ class "form-textarea h-19 min-w-full block"
                         , placeholder (t "auth.login.wordsMode.input.placeholder")
                         , View.Form.noGrammarly


### PR DESCRIPTION
## What issue does this PR close
Closes #418 

## Changes Proposed ( a list of new changes introduced by this PR)
- Changes the textarea element of the passphrase input to a regular input element.
- Adds passphrase submit on enter key pressed.

## How to test ( a list of instructions on how to test this PR)
1- Go to login page
2- Input your passphrase and press enter to go to the next step (Login Pin set up)

