### PR TITLE
Fix/limit units add header

### DIFF
--- a/public/translations/pt-BR.json
+++ b/public/translations/pt-BR.json
@@ -628,6 +628,7 @@
     "message_placeholder": "Digite sua mensagem aqui ou envie diretamente por Whatsapp ou chat.",
     "create_offer": "Criar oferta",
     "edit_offer": "Editar oferta",
+    "create_offer_success": "Oferta criada com sucesso!",
     "delete_offer_success": "Oferta removida com sucesso",
     "unauthorized": "Você não tem autorização para editar essa venda",
     "photo_label": "Enviar imagem",

--- a/src/elm/Page/Shop/Editor.elm
+++ b/src/elm/Page/Shop/Editor.elm
@@ -425,6 +425,7 @@ viewForm ({ shared } as loggedIn) balances imageStatus isEdit isDisabled deleteM
                             , required True
                             , disabled isDisabled
                             , Html.Attributes.min "0"
+                            , Html.Attributes.max "12"
                             ]
                             []
                         , span [ class "w-1/5 flex text-white items-center justify-center bg-indigo-500 text-body uppercase rounded-r-sm" ]

--- a/src/elm/Page/Shop/Editor.elm
+++ b/src/elm/Page/Shop/Editor.elm
@@ -288,8 +288,7 @@ viewForm ({ shared } as loggedIn) balances imageStatus isEdit isDisabled deleteM
             [ div
                 [ class "bg-white rounded-lg" ]
                 [ div [ class "px-4 py-6" ]
-                    [ div [ class "text-heading font-medium" ] [ text pageTitle ]
-                    , if isEdit then
+                    [ if isEdit then
                         button
                             [ class "btn delete-button"
                             , disabled isDisabled

--- a/src/elm/Page/Shop/Editor.elm
+++ b/src/elm/Page/Shop/Editor.elm
@@ -719,10 +719,18 @@ update msg model loggedIn =
                 |> UR.init
 
         EnteredPrice value ->
+            let
+                trimmedPrice =
+                    if String.length value > 12 then
+                        String.left 12 value
+
+                    else
+                        value
+            in
             model
                 |> updateForm
                     (\form ->
-                        { form | price = updateInput (getNumericValues value) form.price }
+                        { form | price = updateInput (getNumericValues trimmedPrice) form.price }
                     )
                 |> UR.init
 

--- a/src/elm/Page/Shop/Editor.elm
+++ b/src/elm/Page/Shop/Editor.elm
@@ -11,7 +11,7 @@ import Eos.Account as Eos
 import File exposing (File)
 import Graphql.Http
 import Html exposing (Html, button, div, input, label, option, p, select, span, text, textarea)
-import Html.Attributes exposing (accept, attribute, class, classList, disabled, for, hidden, id, maxlength, multiple, required, selected, style, type_, value)
+import Html.Attributes exposing (accept, class, classList, disabled, for, id, maxlength, multiple, required, selected, style, type_, value)
 import Html.Events exposing (on, onClick, onInput)
 import Http
 import I18Next
@@ -21,7 +21,6 @@ import Page
 import Result exposing (Result)
 import Route
 import Session.LoggedIn as LoggedIn exposing (External(..), FeedbackStatus(..))
-import Session.Shared exposing (Shared)
 import Shop exposing (Sale, SaleId)
 import Task
 import UpdateResult as UR
@@ -131,11 +130,6 @@ initForm balanceOptions =
             []
                 |> longerThan 10
                 |> newValidator "" (\v -> Just v) True
-
-        symbol =
-            []
-                |> oneOf balanceOptions
-                |> newValidator Nothing (Maybe.map Eos.symbolToString) True
 
         trackStock =
             []

--- a/src/styles/legacy_main.css
+++ b/src/styles/legacy_main.css
@@ -3165,9 +3165,8 @@ textarea.form-input {
 
 .shop-editor__image-upload label {
     height: 150px;
-    background-color: #d8d8d8;
+    background-color: #f8f8f8;
     text-transform: uppercase;
-    color: var(--white);
     border-radius: 4px;
     font-size: 14px;
     font-weight: 500;
@@ -3175,6 +3174,7 @@ textarea.form-input {
     align-items: center;
     justify-content: center;
     flex-direction: column;
+    border-radius: 8px;
     cursor: pointer;
     background-size: cover;
     background-repeat: no-repeat;


### PR DESCRIPTION
## What issue does this PR close
N/A

## Changes Proposed ( a list of new changes introduced by this PR)
We had a bug tonight when a user added a units value of `1000000000000000128`, event-source bugged out because this is not a permitted integer value. So this PR fix the frontend part.

The transaction can be seem [here](https://local.bloks.io/transaction/732ef02547238d4cac29b4339d20542f1a61610d91b1038c5fbfa7fdf470b813?nodeUrl=http%3A%2F%2Fmuda.cambiatus.io&systemDomain=eosio)

- Adds  header (well, wouldn't hurt to add it)
- Remove symbol input, now uses selected community
- Adds counter to description textarea
- add symbol to the price input
- add validation to the title of the sale
- Improve input to only accept a certain length on the prices

## How to test ( a list of instructions on how to test this PR)
Try to create a new sale with lots of units (more than 2000) 

