### PR TITLE
Add error messages to the Shop

### DIFF
--- a/public/translations/cat-CAT.json
+++ b/public/translations/cat-CAT.json
@@ -110,7 +110,8 @@
         "Can't find community with given Symbol": "No es pot trobar la comunitat amb el símbol donat",
         "This community don't have objectives enabled.": "Aquesta comunitat no té objectius activats.",
         "You can't use transfersale to this sale if you aren't part of the community": "No podeu fer servir la venda de transferències a aquesta venda si no formeu part de la comunitat",
-        "Sale creator and sale doesn't match": "El creador de la venda i la venda no coincideixen"
+        "Sale creator and sale doesn't match": "El creador de la venda i la venda no coincideixen",
+        "Invalid number of units": "Nombre d'unitats no vàlid"
       },
       "verifyclaim": {
         "Can't vote on already verified claim": "No es pot votar sobre una reclamació ja verificada",

--- a/public/translations/cat-CAT.json
+++ b/public/translations/cat-CAT.json
@@ -99,7 +99,18 @@
         "symbol precision mismatch": "Desajust de precisió de símbols",
         "memo has more than 256 bytes": "La nota té més de 256 símbols",
         "from account doesn't belong to the community": "Des del compte no pertany a la comunitat",
-        "to account doesn't belong to the community": "El compte no pertany a la comunitat"
+        "to account doesn't belong to the community": "El compte no pertany a la comunitat",
+        "The sale creator (to) account doesn't exists": "El compte de creador de venda (a) no existeix",
+        "Can't sale for yourself": "No es pot vendre per vosaltres mateixos",
+        "Can't find any sale with given sale_id": "No trobo cap venda amb sale_id determinat",
+        "Invalid number of units, must be greater than 0": "El nombre d'unitats no vàlid ha de ser superior a 0",
+        "Sale doesn't have that many units available": "La venda no té tantes unitats disponibles",
+        "Amount offered doesn't correspond to expected value": "L'import ofert no correspon al valor esperat",
+        "Quantity must be the same as the sale price": "La quantitat ha de ser la mateixa que el preu de venda",
+        "Can't find community with given Symbol": "No es pot trobar la comunitat amb el símbol donat",
+        "This community don't have objectives enabled.": "Aquesta comunitat no té objectius activats.",
+        "You can't use transfersale to this sale if you aren't part of the community": "No podeu fer servir la venda de transferències a aquesta venda si no formeu part de la comunitat",
+        "Sale creator and sale doesn't match": "El creador de la venda i la venda no coincideixen"
       },
       "verifyclaim": {
         "Can't vote on already verified claim": "No es pot votar sobre una reclamació ja verificada",

--- a/public/translations/en-US.json
+++ b/public/translations/en-US.json
@@ -95,7 +95,7 @@
         "destination account doesn't exists": "Destination account doesn't exist",
         "token with given symbol doesn't exists": "Token with given symbol doesn't exist",
         "invalid quantity": "Invalid quantity",
-        "quantity must be positive": "La quantitat ha de ser positiva",
+        "quantity must be positive": "Quantity must be positive",
         "symbol precision mismatch": "Symbol precision mismatch",
         "memo has more than 256 bytes": "The memo has more than 256 symbols",
         "from account doesn't belong to the community": "From account doesn't belong to the community",

--- a/public/translations/en-US.json
+++ b/public/translations/en-US.json
@@ -110,7 +110,8 @@
         "Can't find community with given Symbol": "Can't find community with given Symbol",
         "This community don't have objectives enabled.": "This community doesn't have objectives enabled",
         "You can't use transfersale to this sale if you aren't part of the community": "You can't use transfersale to this sale if you aren't part of the community",
-        "Sale creator and sale doesn't match": "Sale creator and sale doesn't match"
+        "Sale creator and sale doesn't match": "Sale creator and sale doesn't match",
+        "Invalid number of units": "Invalid number of units"
       },
       "verifyclaim": {
         "Can't vote on already verified claim": "Can't vote on already verified claim",

--- a/public/translations/en-US.json
+++ b/public/translations/en-US.json
@@ -99,7 +99,18 @@
         "symbol precision mismatch": "Symbol precision mismatch",
         "memo has more than 256 bytes": "The memo has more than 256 symbols",
         "from account doesn't belong to the community": "From account doesn't belong to the community",
-        "to account doesn't belong to the community": "To account doesn't belong to the community"
+        "to account doesn't belong to the community": "To account doesn't belong to the community",
+        "The sale creator (to) account doesn't exists": "The sale creator (to) account doesn't exist",
+        "Can't sale for yourself": "Can't sell for yourself",
+        "Can't find any sale with given sale_id": "Can't find any sale with given sale_id",
+        "Invalid number of units, must be greater than 0": "Invalid number of units, must be greater than 0",
+        "Sale doesn't have that many units available": "Sale doesn't have that many units available",
+        "Amount offered doesn't correspond to expected value": "Amount offered doesn't correspond to expected value",
+        "Quantity must be the same as the sale price": "Quantity must be the same as the sale price",
+        "Can't find community with given Symbol": "Can't find community with given Symbol",
+        "This community don't have objectives enabled.": "This community doesn't have objectives enabled",
+        "You can't use transfersale to this sale if you aren't part of the community": "You can't use transfersale to this sale if you aren't part of the community",
+        "Sale creator and sale doesn't match": "Sale creator and sale doesn't match"
       },
       "verifyclaim": {
         "Can't vote on already verified claim": "Can't vote on already verified claim",

--- a/public/translations/es-ES.json
+++ b/public/translations/es-ES.json
@@ -110,7 +110,8 @@
         "Can't find community with given Symbol": "No se puede encontrar la comunidad con el símbolo dado",
         "This community don't have objectives enabled.": "Esta comunidad no tiene objetivos habilitados.",
         "You can't use transfersale to this sale if you aren't part of the community": "No puede usar la venta transferible para esta venta si no es parte de la comunidad",
-        "Sale creator and sale doesn't match": "Creador de venta y venta no coincide"
+        "Sale creator and sale doesn't match": "Creador de venta y venta no coincide",
+        "Invalid number of units": "Número de unidades no válido"
       },
       "verifyclaim": {
         "Can't vote on already verified claim": "No puedo votar sobre un reclamo ya verificado",

--- a/public/translations/es-ES.json
+++ b/public/translations/es-ES.json
@@ -99,7 +99,18 @@
         "symbol precision mismatch": "Falta de coincidencia de precisión de símbolo",
         "memo has more than 256 bytes": "El memo tiene más de 256 símbolos",
         "from account doesn't belong to the community": "De la cuenta no pertenece a la comunidad",
-        "to account doesn't belong to the community": "La cuenta no pertenece a la comunidad"
+        "to account doesn't belong to the community": "La cuenta no pertenece a la comunidad",
+        "The sale creator (to) account doesn't exists": "La cuenta de creador de ventas (a) no existe",
+        "Can't sale for yourself": "No se puede vender por ti mismo",
+        "Can't find any sale with given sale_id": "No se puede encontrar ninguna venta con sale_id dado",
+        "Invalid number of units, must be greater than 0": "Número de unidades no válido, debe ser mayor que 0",
+        "Sale doesn't have that many units available": "La venta no tiene tantas unidades disponibles",
+        "Amount offered doesn't correspond to expected value": "La cantidad ofrecida no corresponde al valor esperado",
+        "Quantity must be the same as the sale price": "La cantidad debe ser igual al precio de oferta.",
+        "Can't find community with given Symbol": "No se puede encontrar la comunidad con el símbolo dado",
+        "This community don't have objectives enabled.": "Esta comunidad no tiene objetivos habilitados.",
+        "You can't use transfersale to this sale if you aren't part of the community": "No puede usar la venta transferible para esta venta si no es parte de la comunidad",
+        "Sale creator and sale doesn't match": "Creador de venta y venta no coincide"
       },
       "verifyclaim": {
         "Can't vote on already verified claim": "No puedo votar sobre un reclamo ya verificado",

--- a/public/translations/pt-BR.json
+++ b/public/translations/pt-BR.json
@@ -99,7 +99,18 @@
         "symbol precision mismatch": "Precisão do símbolo incompatível",
         "memo has more than 256 bytes": "a mensagem não pode ter mais que 256 carácteres",
         "from account doesn't belong to the community": "A conta de origem não pertence à comunidade",
-        "to account doesn't belong to the community": "A conta de destino não pertence à comunidade"
+        "to account doesn't belong to the community": "A conta de destino não pertence à comunidade",
+        "The sale creator (to) account doesn't exists": "A conta do criador da venda (para) não existe",
+        "Can't sale for yourself": "Não pode vender para você",
+        "Can't find any sale with given sale_id": "Não é possível encontrar nenhuma venda com determinado sale_id",
+        "Invalid number of units, must be greater than 0": "Número de unidades inválido, deve ser maior que 0",
+        "Sale doesn't have that many units available": "A venda não tem tantas unidades disponíveis",
+        "Amount offered doesn't correspond to expected value": "O valor oferecido não corresponde ao valor esperado",
+        "Quantity must be the same as the sale price": "A quantidade deve ser igual ao preço de venda",
+        "Can't find community with given Symbol": "Não é possível encontrar a comunidade com o símbolo fornecido",
+        "This community don't have objectives enabled.": "Esta comunidade não tem objetivos habilitados.",
+        "You can't use transfersale to this sale if you aren't part of the community": "Você não pode usar transfersale para esta venda se você não fizer parte da comunidade",
+        "Sale creator and sale doesn't match": "O criador da venda e a venda não correspondem"
       },
       "verifyclaim": {
         "Can't vote on already verified claim": "Não é possível votar em uma reivindicação já verificada",

--- a/public/translations/pt-BR.json
+++ b/public/translations/pt-BR.json
@@ -110,7 +110,8 @@
         "Can't find community with given Symbol": "Não é possível encontrar a comunidade com o símbolo fornecido",
         "This community don't have objectives enabled.": "Esta comunidade não tem objetivos habilitados.",
         "You can't use transfersale to this sale if you aren't part of the community": "Você não pode usar transfersale para esta venda se você não fizer parte da comunidade",
-        "Sale creator and sale doesn't match": "O criador da venda e a venda não correspondem"
+        "Sale creator and sale doesn't match": "O criador da venda e a venda não correspondem",
+        "Invalid number of units": "Número inválido de unidades"
       },
       "verifyclaim": {
         "Can't vote on already verified claim": "Não é possível votar em uma reivindicação já verificada",

--- a/src/elm/Eos/EosError.elm
+++ b/src/elm/Eos/EosError.elm
@@ -66,6 +66,8 @@ parseClaimError translators eosErrorString =
         eosErrorString
 
 
+{-| Handle errors for both `transfer` and `transfersale` transactions.
+-}
 parseTransferError : Translators -> Maybe Value -> String
 parseTransferError translators eosErrorString =
     parseErrorMessage

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -880,6 +880,10 @@ jsAddressToMsg address val =
             Maybe.map GotShopEditorMsg
                 (ShopEditor.jsAddressToMsg rAddress val)
 
+        "GotShopViewerMsg" :: rAddress ->
+            Maybe.map GotShopViewerMsg
+                (ShopViewer.jsAddressToMsg rAddress val)
+
         "GotRegisterMsg" :: rAddress ->
             Maybe.map GotRegisterMsg
                 (Register.jsAddressToMsg rAddress val)


### PR DESCRIPTION
## What issue does this PR close
Part of #419.

## Changes Proposed ( a list of new changes introduced by this PR)
- [x] Add better error messages.
- [x] Redirect the user to the main Shop page only if the transaction was successful.
- [x] Get rid of "Impossible error" after buying a product.

## How to test ( a list of instructions on how to test this PR)
Try to buy something in the shop. Make sure to check some error states, like buying 0 products.
