### PR TITLE
Save selected community on login

### DIFF
--- a/src/elm/Session/LoggedIn.elm
+++ b/src/elm/Session/LoggedIn.elm
@@ -103,7 +103,8 @@ initLogin shared authModel profile_ =
     ( { model
         | profile = Loaded profile_
       }
-    , Api.Graphql.query shared (Community.settingsQuery selectedCommunity) CompletedLoadSettings
+    , Task.succeed selectedCommunity
+        |> Task.perform SelectCommunity
     )
 
 


### PR DESCRIPTION
## What issue does this PR close
Closes #424 by saving the current community to the `localStorage` for future use after the user is logged in. This will keep the current community selected after page reloading.

## Changes Proposed (a list of new changes introduced by this PR)
- [x] Show the correct logo of the community.
- [x] Show the Shop menu link and Objectives according to the community settings.

This could be achieved by performing the same actions as we do for selecting the community from the community selector. We should just trigger them while the user is logging in.

## How to test (a list of instructions on how to test this PR)
- Make sure your user is _a member of only one community_. The inconsistent state, described in #424 is related to that kind of user.
- Logout and then login.
- Reload the page. The community logo, shop, and objectives should be displayed correctly, according to the settings of the community.
