### PR TITLE
Run sign_up mutations alongside with creating KYC and Address

### DIFF
--- a/src/elm/Auth.elm
+++ b/src/elm/Auth.elm
@@ -19,15 +19,9 @@ import Api.Graphql
 import Asset.Icon as Icon
 import Browser.Dom as Dom
 import Browser.Events
-import Cambiatus.Enum.SignUpStatus
-import Cambiatus.Mutation
-import Cambiatus.Object
-import Cambiatus.Object.SignUp as SignUp
 import Eos.Account as Eos
 import Graphql.Http
-import Graphql.Operation exposing (RootMutation)
 import Graphql.OptionalArgument exposing (OptionalArgument(..))
-import Graphql.SelectionSet as SelectionSet exposing (SelectionSet, with)
 import Html exposing (Html, a, button, div, h2, img, label, li, p, span, strong, text, textarea, ul)
 import Html.Attributes exposing (autocomplete, autofocus, class, disabled, for, id, placeholder, required, src, title, type_, value)
 import Html.Events exposing (onClick, onInput, onSubmit)

--- a/src/elm/Auth.elm
+++ b/src/elm/Auth.elm
@@ -3,14 +3,12 @@ module Auth exposing
     , LoginFormData
     , Model
     , Msg
-    , SignUpResult
     , init
     , initRegister
     , isAuth
     , jsAddressToMsg
     , maybePrivateKey
     , msgToString
-    , signUp
     , subscriptions
     , update
     , view
@@ -1015,61 +1013,3 @@ viewPinConfirmation ({ form } as model) shared =
         , isVisible = model.pinConfirmationVisibility
         , errors = errors
         }
-
-
-
--- GraphQL
-
-
-type alias SignUpResult =
-    { status : SignUpStatus
-    , reason : String
-    }
-
-
-type SignUpStatus
-    = Success
-    | Error
-
-
-signUp : Eos.Name -> String -> String -> String -> Maybe String -> SelectionSet SignUpResult RootMutation
-signUp account name email publicKey maybeInvitationId =
-    let
-        accountString =
-            Eos.nameToString account
-    in
-    Cambiatus.Mutation.signUp
-        { input =
-            { account = accountString
-            , name = name
-            , email = email
-            , publicKey = publicKey
-            , userType = Present ""
-            , invitationId =
-                case maybeInvitationId of
-                    Just i ->
-                        Present i
-
-                    Nothing ->
-                        Absent
-            }
-        }
-        signUpSelectionSet
-
-
-signUpSelectionSet : SelectionSet SignUpResult Cambiatus.Object.SignUp
-signUpSelectionSet =
-    let
-        mapSignUpStatus : Cambiatus.Enum.SignUpStatus.SignUpStatus -> SignUpStatus
-        mapSignUpStatus =
-            \s ->
-                case s of
-                    Cambiatus.Enum.SignUpStatus.Success ->
-                        Success
-
-                    Cambiatus.Enum.SignUpStatus.Error ->
-                        Error
-    in
-    SelectionSet.succeed SignUpResult
-        |> with (SignUp.status |> SelectionSet.map mapSignUpStatus)
-        |> with SignUp.reason

--- a/src/elm/Cambiatus/Mutation.elm
+++ b/src/elm/Cambiatus/Mutation.elm
@@ -103,6 +103,22 @@ signUp requiredArgs object_ =
     Object.selectionForCompositeField "signUp" [ Argument.required "input" requiredArgs.input Cambiatus.InputObject.encodeSignUpInput ] object_ identity
 
 
+type alias SignUpNaturalRequiredArguments =
+    { input : Cambiatus.InputObject.SignUpInput
+    , kyc : Cambiatus.InputObject.KycDataUpdateInput
+    }
+
+
+{-| Creates a new natural user account with KYC
+-}
+signUpNatural :
+    SignUpNaturalRequiredArguments
+    -> SelectionSet decodesTo Cambiatus.Object.SignUp
+    -> SelectionSet decodesTo RootMutation
+signUpNatural requiredArgs object_ =
+    Object.selectionForCompositeField "signUpNatural" [ Argument.required "input" requiredArgs.input Cambiatus.InputObject.encodeSignUpInput, Argument.required "kyc" requiredArgs.kyc Cambiatus.InputObject.encodeKycDataUpdateInput ] object_ identity
+
+
 type alias UpdateProfileRequiredArguments =
     { input : Cambiatus.InputObject.ProfileUpdateInput }
 

--- a/src/elm/Cambiatus/Mutation.elm
+++ b/src/elm/Cambiatus/Mutation.elm
@@ -89,6 +89,12 @@ registerPush requiredArgs object_ =
     Object.selectionForCompositeField "registerPush" [ Argument.required "input" requiredArgs.input Cambiatus.InputObject.encodePushSubscriptionInput ] object_ identity
 
 
+type alias SignUpOptionalArguments =
+    { address : OptionalArgument Cambiatus.InputObject.AddressUpdateInput
+    , kyc : OptionalArgument Cambiatus.InputObject.KycDataUpdateInput
+    }
+
+
 type alias SignUpRequiredArguments =
     { input : Cambiatus.InputObject.SignUpInput }
 
@@ -96,44 +102,20 @@ type alias SignUpRequiredArguments =
 {-| Creates a new user account
 -}
 signUp :
-    SignUpRequiredArguments
+    (SignUpOptionalArguments -> SignUpOptionalArguments)
+    -> SignUpRequiredArguments
     -> SelectionSet decodesTo Cambiatus.Object.SignUp
     -> SelectionSet decodesTo RootMutation
-signUp requiredArgs object_ =
-    Object.selectionForCompositeField "signUp" [ Argument.required "input" requiredArgs.input Cambiatus.InputObject.encodeSignUpInput ] object_ identity
+signUp fillInOptionals requiredArgs object_ =
+    let
+        filledInOptionals =
+            fillInOptionals { address = Absent, kyc = Absent }
 
-
-type alias SignUpJuridicalRequiredArguments =
-    { address : Cambiatus.InputObject.AddressUpdateInput
-    , input : Cambiatus.InputObject.SignUpInput
-    , kyc : Cambiatus.InputObject.KycDataUpdateInput
-    }
-
-
-{-| Creates a new juridical user account with KYC and Address
--}
-signUpJuridical :
-    SignUpJuridicalRequiredArguments
-    -> SelectionSet decodesTo Cambiatus.Object.SignUp
-    -> SelectionSet decodesTo RootMutation
-signUpJuridical requiredArgs object_ =
-    Object.selectionForCompositeField "signUpJuridical" [ Argument.required "address" requiredArgs.address Cambiatus.InputObject.encodeAddressUpdateInput, Argument.required "input" requiredArgs.input Cambiatus.InputObject.encodeSignUpInput, Argument.required "kyc" requiredArgs.kyc Cambiatus.InputObject.encodeKycDataUpdateInput ] object_ identity
-
-
-type alias SignUpNaturalRequiredArguments =
-    { input : Cambiatus.InputObject.SignUpInput
-    , kyc : Cambiatus.InputObject.KycDataUpdateInput
-    }
-
-
-{-| Creates a new natural user account with KYC
--}
-signUpNatural :
-    SignUpNaturalRequiredArguments
-    -> SelectionSet decodesTo Cambiatus.Object.SignUp
-    -> SelectionSet decodesTo RootMutation
-signUpNatural requiredArgs object_ =
-    Object.selectionForCompositeField "signUpNatural" [ Argument.required "input" requiredArgs.input Cambiatus.InputObject.encodeSignUpInput, Argument.required "kyc" requiredArgs.kyc Cambiatus.InputObject.encodeKycDataUpdateInput ] object_ identity
+        optionalArgs =
+            [ Argument.optional "address" filledInOptionals.address Cambiatus.InputObject.encodeAddressUpdateInput, Argument.optional "kyc" filledInOptionals.kyc Cambiatus.InputObject.encodeKycDataUpdateInput ]
+                |> List.filterMap identity
+    in
+    Object.selectionForCompositeField "signUp" (optionalArgs ++ [ Argument.required "input" requiredArgs.input Cambiatus.InputObject.encodeSignUpInput ]) object_ identity
 
 
 type alias UpdateProfileRequiredArguments =

--- a/src/elm/Cambiatus/Mutation.elm
+++ b/src/elm/Cambiatus/Mutation.elm
@@ -103,6 +103,23 @@ signUp requiredArgs object_ =
     Object.selectionForCompositeField "signUp" [ Argument.required "input" requiredArgs.input Cambiatus.InputObject.encodeSignUpInput ] object_ identity
 
 
+type alias SignUpJuridicalRequiredArguments =
+    { address : Cambiatus.InputObject.AddressUpdateInput
+    , input : Cambiatus.InputObject.SignUpInput
+    , kyc : Cambiatus.InputObject.KycDataUpdateInput
+    }
+
+
+{-| Creates a new juridical user account with KYC and Address
+-}
+signUpJuridical :
+    SignUpJuridicalRequiredArguments
+    -> SelectionSet decodesTo Cambiatus.Object.SignUp
+    -> SelectionSet decodesTo RootMutation
+signUpJuridical requiredArgs object_ =
+    Object.selectionForCompositeField "signUpJuridical" [ Argument.required "address" requiredArgs.address Cambiatus.InputObject.encodeAddressUpdateInput, Argument.required "input" requiredArgs.input Cambiatus.InputObject.encodeSignUpInput, Argument.required "kyc" requiredArgs.kyc Cambiatus.InputObject.encodeKycDataUpdateInput ] object_ identity
+
+
 type alias SignUpNaturalRequiredArguments =
     { input : Cambiatus.InputObject.SignUpInput
     , kyc : Cambiatus.InputObject.KycDataUpdateInput


### PR DESCRIPTION
## What issue does this PR close
This is the frontend part of cambiatus/backend/issues/113.

## Changes Proposed ( a list of new changes introduced by this PR)
Handle updated mutations for signing up which allow making sure that the user is created only if he/she has valid KYC and Address.

## How to test ( a list of instructions on how to test this PR)
- Create default/natural/juridical users for the community with enabled/disabled KYC.
- If there are errors in KYC or Address (like `000000000` for Cedula de Identidad) then the user shouldn't be created.
