### PR TITLE
Update API usage on the app

### DIFF
--- a/src/elm/Cambiatus/InputObject.elm
+++ b/src/elm/Cambiatus/InputObject.elm
@@ -456,6 +456,31 @@ encodeObjectiveInput input =
         [ ( "id", Encode.int input.id |> Just ) ]
 
 
+buildProductsFilterInput :
+    ProductsFilterInputRequiredFields
+    -> ProductsFilterInput
+buildProductsFilterInput required =
+    { account = required.account }
+
+
+type alias ProductsFilterInputRequiredFields =
+    { account : String }
+
+
+{-| Type for the ProductsFilterInput input object.
+-}
+type alias ProductsFilterInput =
+    { account : String }
+
+
+{-| Encode a ProductsFilterInput into a value that can be used as an argument.
+-}
+encodeProductsFilterInput : ProductsFilterInput -> Value
+encodeProductsFilterInput input =
+    Encode.maybeObject
+        [ ( "account", Encode.string input.account |> Just ) ]
+
+
 buildProfileInput :
     (ProfileInputOptionalFields -> ProfileInputOptionalFields)
     -> ProfileInput
@@ -590,69 +615,6 @@ encodeReadNotificationInput : ReadNotificationInput -> Value
 encodeReadNotificationInput input =
     Encode.maybeObject
         [ ( "id", Encode.int input.id |> Just ) ]
-
-
-buildSaleInput :
-    SaleInputRequiredFields
-    -> SaleInput
-buildSaleInput required =
-    { id = required.id }
-
-
-type alias SaleInputRequiredFields =
-    { id : Int }
-
-
-{-| Type for the SaleInput input object.
--}
-type alias SaleInput =
-    { id : Int }
-
-
-{-| Encode a SaleInput into a value that can be used as an argument.
--}
-encodeSaleInput : SaleInput -> Value
-encodeSaleInput input =
-    Encode.maybeObject
-        [ ( "id", Encode.int input.id |> Just ) ]
-
-
-buildSalesInput :
-    (SalesInputOptionalFields -> SalesInputOptionalFields)
-    -> SalesInput
-buildSalesInput fillOptionals =
-    let
-        optionals =
-            fillOptionals
-                { account = Absent, all = Absent, communities = Absent, communityId = Absent }
-    in
-    { account = optionals.account, all = optionals.all, communities = optionals.communities, communityId = optionals.communityId }
-
-
-type alias SalesInputOptionalFields =
-    { account : OptionalArgument String
-    , all : OptionalArgument String
-    , communities : OptionalArgument String
-    , communityId : OptionalArgument String
-    }
-
-
-{-| Type for the SalesInput input object.
--}
-type alias SalesInput =
-    { account : OptionalArgument String
-    , all : OptionalArgument String
-    , communities : OptionalArgument String
-    , communityId : OptionalArgument String
-    }
-
-
-{-| Encode a SalesInput into a value that can be used as an argument.
--}
-encodeSalesInput : SalesInput -> Value
-encodeSalesInput input =
-    Encode.maybeObject
-        [ ( "account", Encode.string |> Encode.optional input.account ), ( "all", Encode.string |> Encode.optional input.all ), ( "communities", Encode.string |> Encode.optional input.communities ), ( "communityId", Encode.string |> Encode.optional input.communityId ) ]
 
 
 buildSignUpInput :

--- a/src/elm/Cambiatus/Object.elm
+++ b/src/elm/Cambiatus/Object.elm
@@ -73,8 +73,16 @@ type Objective
     = Objective
 
 
+type Order
+    = Order
+
+
 type PageInfo
     = PageInfo
+
+
+type Product
+    = Product
 
 
 type Profile
@@ -83,14 +91,6 @@ type Profile
 
 type PushSubscription
     = PushSubscription
-
-
-type Sale
-    = Sale
-
-
-type SaleHistory
-    = SaleHistory
 
 
 type SignUp

--- a/src/elm/Cambiatus/Object/Community.elm
+++ b/src/elm/Cambiatus/Object/Community.elm
@@ -135,9 +135,9 @@ precision =
     Object.selectionForField "Int" "precision" [] Decode.int
 
 
-saleCount : SelectionSet Int Cambiatus.Object.Community
-saleCount =
-    Object.selectionForField "Int" "saleCount" [] Decode.int
+productCount : SelectionSet Int Cambiatus.Object.Community
+productCount =
+    Object.selectionForField "Int" "productCount" [] Decode.int
 
 
 supply : SelectionSet (Maybe Float) Cambiatus.Object.Community

--- a/src/elm/Cambiatus/Object/Order.elm
+++ b/src/elm/Cambiatus/Object/Order.elm
@@ -2,7 +2,7 @@
 -- https://github.com/dillonkearns/elm-graphql
 
 
-module Cambiatus.Object.SaleHistory exposing (..)
+module Cambiatus.Object.Order exposing (..)
 
 import Cambiatus.InputObject
 import Cambiatus.Interface
@@ -19,64 +19,84 @@ import Graphql.SelectionSet exposing (SelectionSet)
 import Json.Decode as Decode
 
 
-amount : SelectionSet Float Cambiatus.Object.SaleHistory
+amount : SelectionSet Float Cambiatus.Object.Order
 amount =
     Object.selectionForField "Float" "amount" [] Decode.float
 
 
 community :
     SelectionSet decodesTo Cambiatus.Object.Community
-    -> SelectionSet decodesTo Cambiatus.Object.SaleHistory
+    -> SelectionSet decodesTo Cambiatus.Object.Order
 community object_ =
     Object.selectionForCompositeField "community" [] object_ identity
 
 
-communityId : SelectionSet String Cambiatus.Object.SaleHistory
+communityId : SelectionSet String Cambiatus.Object.Order
 communityId =
     Object.selectionForField "String" "communityId" [] Decode.string
 
 
+createdAt : SelectionSet Cambiatus.ScalarCodecs.DateTime Cambiatus.Object.Order
+createdAt =
+    Object.selectionForField "ScalarCodecs.DateTime" "createdAt" [] (Cambiatus.ScalarCodecs.codecs |> Cambiatus.Scalar.unwrapCodecs |> .codecDateTime |> .decoder)
+
+
+createdBlock : SelectionSet Int Cambiatus.Object.Order
+createdBlock =
+    Object.selectionForField "Int" "createdBlock" [] Decode.int
+
+
+createdEosAccount : SelectionSet String Cambiatus.Object.Order
+createdEosAccount =
+    Object.selectionForField "String" "createdEosAccount" [] Decode.string
+
+
+createdTx : SelectionSet String Cambiatus.Object.Order
+createdTx =
+    Object.selectionForField "String" "createdTx" [] Decode.string
+
+
 from :
     SelectionSet decodesTo Cambiatus.Object.Profile
-    -> SelectionSet decodesTo Cambiatus.Object.SaleHistory
+    -> SelectionSet decodesTo Cambiatus.Object.Order
 from object_ =
     Object.selectionForCompositeField "from" [] object_ identity
 
 
-fromId : SelectionSet String Cambiatus.Object.SaleHistory
+fromId : SelectionSet String Cambiatus.Object.Order
 fromId =
     Object.selectionForField "String" "fromId" [] Decode.string
 
 
-id : SelectionSet Int Cambiatus.Object.SaleHistory
+id : SelectionSet Int Cambiatus.Object.Order
 id =
     Object.selectionForField "Int" "id" [] Decode.int
 
 
-sale :
-    SelectionSet decodesTo Cambiatus.Object.Sale
-    -> SelectionSet decodesTo Cambiatus.Object.SaleHistory
-sale object_ =
-    Object.selectionForCompositeField "sale" [] object_ identity
+product :
+    SelectionSet decodesTo Cambiatus.Object.Product
+    -> SelectionSet decodesTo Cambiatus.Object.Order
+product object_ =
+    Object.selectionForCompositeField "product" [] object_ identity
 
 
-saleId : SelectionSet Int Cambiatus.Object.SaleHistory
-saleId =
-    Object.selectionForField "Int" "saleId" [] Decode.int
+productId : SelectionSet Int Cambiatus.Object.Order
+productId =
+    Object.selectionForField "Int" "productId" [] Decode.int
 
 
 to :
     SelectionSet decodesTo Cambiatus.Object.Profile
-    -> SelectionSet decodesTo Cambiatus.Object.SaleHistory
+    -> SelectionSet decodesTo Cambiatus.Object.Order
 to object_ =
     Object.selectionForCompositeField "to" [] object_ identity
 
 
-toId : SelectionSet String Cambiatus.Object.SaleHistory
+toId : SelectionSet String Cambiatus.Object.Order
 toId =
     Object.selectionForField "String" "toId" [] Decode.string
 
 
-units : SelectionSet (Maybe Int) Cambiatus.Object.SaleHistory
+units : SelectionSet (Maybe Int) Cambiatus.Object.Order
 units =
     Object.selectionForField "(Maybe Int)" "units" [] (Decode.int |> Decode.nullable)

--- a/src/elm/Cambiatus/Object/Product.elm
+++ b/src/elm/Cambiatus/Object/Product.elm
@@ -2,7 +2,7 @@
 -- https://github.com/dillonkearns/elm-graphql
 
 
-module Cambiatus.Object.Sale exposing (..)
+module Cambiatus.Object.Product exposing (..)
 
 import Cambiatus.InputObject
 import Cambiatus.Interface
@@ -21,78 +21,78 @@ import Json.Decode as Decode
 
 community :
     SelectionSet decodesTo Cambiatus.Object.Community
-    -> SelectionSet decodesTo Cambiatus.Object.Sale
+    -> SelectionSet decodesTo Cambiatus.Object.Product
 community object_ =
     Object.selectionForCompositeField "community" [] object_ identity
 
 
-communityId : SelectionSet String Cambiatus.Object.Sale
+communityId : SelectionSet String Cambiatus.Object.Product
 communityId =
     Object.selectionForField "String" "communityId" [] Decode.string
 
 
-createdAt : SelectionSet Cambiatus.ScalarCodecs.DateTime Cambiatus.Object.Sale
+createdAt : SelectionSet Cambiatus.ScalarCodecs.DateTime Cambiatus.Object.Product
 createdAt =
     Object.selectionForField "ScalarCodecs.DateTime" "createdAt" [] (Cambiatus.ScalarCodecs.codecs |> Cambiatus.Scalar.unwrapCodecs |> .codecDateTime |> .decoder)
 
 
-createdBlock : SelectionSet Int Cambiatus.Object.Sale
+createdBlock : SelectionSet Int Cambiatus.Object.Product
 createdBlock =
     Object.selectionForField "Int" "createdBlock" [] Decode.int
 
 
-createdEosAccount : SelectionSet String Cambiatus.Object.Sale
+createdEosAccount : SelectionSet String Cambiatus.Object.Product
 createdEosAccount =
     Object.selectionForField "String" "createdEosAccount" [] Decode.string
 
 
-createdTx : SelectionSet String Cambiatus.Object.Sale
+createdTx : SelectionSet String Cambiatus.Object.Product
 createdTx =
     Object.selectionForField "String" "createdTx" [] Decode.string
 
 
 creator :
     SelectionSet decodesTo Cambiatus.Object.Profile
-    -> SelectionSet decodesTo Cambiatus.Object.Sale
+    -> SelectionSet decodesTo Cambiatus.Object.Product
 creator object_ =
     Object.selectionForCompositeField "creator" [] object_ identity
 
 
-creatorId : SelectionSet String Cambiatus.Object.Sale
+creatorId : SelectionSet String Cambiatus.Object.Product
 creatorId =
     Object.selectionForField "String" "creatorId" [] Decode.string
 
 
-description : SelectionSet String Cambiatus.Object.Sale
+description : SelectionSet String Cambiatus.Object.Product
 description =
     Object.selectionForField "String" "description" [] Decode.string
 
 
-id : SelectionSet Int Cambiatus.Object.Sale
+id : SelectionSet Int Cambiatus.Object.Product
 id =
     Object.selectionForField "Int" "id" [] Decode.int
 
 
-image : SelectionSet (Maybe String) Cambiatus.Object.Sale
+image : SelectionSet (Maybe String) Cambiatus.Object.Product
 image =
     Object.selectionForField "(Maybe String)" "image" [] (Decode.string |> Decode.nullable)
 
 
-price : SelectionSet Float Cambiatus.Object.Sale
+price : SelectionSet Float Cambiatus.Object.Product
 price =
     Object.selectionForField "Float" "price" [] Decode.float
 
 
-title : SelectionSet String Cambiatus.Object.Sale
+title : SelectionSet String Cambiatus.Object.Product
 title =
     Object.selectionForField "String" "title" [] Decode.string
 
 
-trackStock : SelectionSet Bool Cambiatus.Object.Sale
+trackStock : SelectionSet Bool Cambiatus.Object.Product
 trackStock =
     Object.selectionForField "Bool" "trackStock" [] Decode.bool
 
 
-units : SelectionSet Int Cambiatus.Object.Sale
+units : SelectionSet Int Cambiatus.Object.Product
 units =
     Object.selectionForField "Int" "units" [] Decode.int

--- a/src/elm/Cambiatus/Query.elm
+++ b/src/elm/Cambiatus/Query.elm
@@ -170,6 +170,43 @@ objective requiredArgs object_ =
     Object.selectionForCompositeField "objective" [ Argument.required "input" requiredArgs.input Cambiatus.InputObject.encodeObjectiveInput ] object_ (identity >> Decode.nullable)
 
 
+type alias ProductRequiredArguments =
+    { id : Int }
+
+
+product :
+    ProductRequiredArguments
+    -> SelectionSet decodesTo Cambiatus.Object.Product
+    -> SelectionSet (Maybe decodesTo) RootQuery
+product requiredArgs object_ =
+    Object.selectionForCompositeField "product" [ Argument.required "id" requiredArgs.id Encode.int ] object_ (identity >> Decode.nullable)
+
+
+type alias ProductsOptionalArguments =
+    { filters : OptionalArgument Cambiatus.InputObject.ProductsFilterInput }
+
+
+type alias ProductsRequiredArguments =
+    { communityId : String }
+
+
+products :
+    (ProductsOptionalArguments -> ProductsOptionalArguments)
+    -> ProductsRequiredArguments
+    -> SelectionSet decodesTo Cambiatus.Object.Product
+    -> SelectionSet (List decodesTo) RootQuery
+products fillInOptionals requiredArgs object_ =
+    let
+        filledInOptionals =
+            fillInOptionals { filters = Absent }
+
+        optionalArgs =
+            [ Argument.optional "filters" filledInOptionals.filters Cambiatus.InputObject.encodeProductsFilterInput ]
+                |> List.filterMap identity
+    in
+    Object.selectionForCompositeField "products" (optionalArgs ++ [ Argument.required "communityId" requiredArgs.communityId Encode.string ]) object_ (identity >> Decode.list)
+
+
 type alias ProfileRequiredArguments =
     { input : Cambiatus.InputObject.ProfileInput }
 
@@ -182,43 +219,6 @@ profile :
     -> SelectionSet (Maybe decodesTo) RootQuery
 profile requiredArgs object_ =
     Object.selectionForCompositeField "profile" [ Argument.required "input" requiredArgs.input Cambiatus.InputObject.encodeProfileInput ] object_ (identity >> Decode.nullable)
-
-
-type alias SaleRequiredArguments =
-    { input : Cambiatus.InputObject.SaleInput }
-
-
-{-| A single sale from Cambiatus
--}
-sale :
-    SaleRequiredArguments
-    -> SelectionSet decodesTo Cambiatus.Object.Sale
-    -> SelectionSet (Maybe decodesTo) RootQuery
-sale requiredArgs object_ =
-    Object.selectionForCompositeField "sale" [ Argument.required "input" requiredArgs.input Cambiatus.InputObject.encodeSaleInput ] object_ (identity >> Decode.nullable)
-
-
-{-| A list of sale history
--}
-saleHistory :
-    SelectionSet decodesTo Cambiatus.Object.SaleHistory
-    -> SelectionSet (Maybe (List (Maybe decodesTo))) RootQuery
-saleHistory object_ =
-    Object.selectionForCompositeField "saleHistory" [] object_ (identity >> Decode.nullable >> Decode.list >> Decode.nullable)
-
-
-type alias SalesRequiredArguments =
-    { input : Cambiatus.InputObject.SalesInput }
-
-
-{-| A list of sales in Cambiatus
--}
-sales :
-    SalesRequiredArguments
-    -> SelectionSet decodesTo Cambiatus.Object.Sale
-    -> SelectionSet (List decodesTo) RootQuery
-sales requiredArgs object_ =
-    Object.selectionForCompositeField "sales" [ Argument.required "input" requiredArgs.input Cambiatus.InputObject.encodeSalesInput ] object_ (identity >> Decode.list)
 
 
 type alias TransferRequiredArguments =

--- a/src/elm/Cambiatus/Subscription.elm
+++ b/src/elm/Cambiatus/Subscription.elm
@@ -33,33 +33,6 @@ newcommunity requiredArgs object_ =
     Object.selectionForCompositeField "newcommunity" [ Argument.required "input" requiredArgs.input Cambiatus.InputObject.encodeNewCommunityInput ] object_ identity
 
 
-{-| A subscription for sale history
--}
-saleHistoryOperation :
-    SelectionSet decodesTo Cambiatus.Object.SaleHistory
-    -> SelectionSet (Maybe decodesTo) RootSubscription
-saleHistoryOperation object_ =
-    Object.selectionForCompositeField "saleHistoryOperation" [] object_ (identity >> Decode.nullable)
-
-
-{-| A subscription to resolve operations on the sales table
--}
-salesOperation :
-    SelectionSet decodesTo Cambiatus.Object.Sale
-    -> SelectionSet (Maybe decodesTo) RootSubscription
-salesOperation object_ =
-    Object.selectionForCompositeField "salesOperation" [] object_ (identity >> Decode.nullable)
-
-
-{-| A subscription for transfers
--}
-transfers :
-    SelectionSet decodesTo Cambiatus.Object.Transfer
-    -> SelectionSet (Maybe decodesTo) RootSubscription
-transfers object_ =
-    Object.selectionForCompositeField "transfers" [] object_ (identity >> Decode.nullable)
-
-
 type alias TransfersucceedRequiredArguments =
     { input : Cambiatus.InputObject.TransferSucceedInput }
 

--- a/src/elm/Cambiatus/Union/NotificationType.elm
+++ b/src/elm/Cambiatus/Union/NotificationType.elm
@@ -21,7 +21,7 @@ import Json.Decode as Decode
 
 type alias Fragments decodesTo =
     { onTransfer : SelectionSet decodesTo Cambiatus.Object.Transfer
-    , onSaleHistory : SelectionSet decodesTo Cambiatus.Object.SaleHistory
+    , onOrder : SelectionSet decodesTo Cambiatus.Object.Order
     , onMint : SelectionSet decodesTo Cambiatus.Object.Mint
     }
 
@@ -34,7 +34,7 @@ fragments :
 fragments selections =
     Object.exhaustiveFragmentSelection
         [ Object.buildFragment "Transfer" selections.onTransfer
-        , Object.buildFragment "SaleHistory" selections.onSaleHistory
+        , Object.buildFragment "Order" selections.onOrder
         , Object.buildFragment "Mint" selections.onMint
         ]
 
@@ -45,6 +45,6 @@ update syntax to add `SelectionSet`s for the types you want to handle.
 maybeFragments : Fragments (Maybe decodesTo)
 maybeFragments =
     { onTransfer = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
-    , onSaleHistory = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
+    , onOrder = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
     , onMint = Graphql.SelectionSet.empty |> Graphql.SelectionSet.map (\_ -> Nothing)
     }

--- a/src/elm/Community.elm
+++ b/src/elm/Community.elm
@@ -144,7 +144,7 @@ dashboardSelectionSet =
         |> with Community.memberCount
         |> with Community.transferCount
         |> with Community.actionCount
-        |> with Community.saleCount
+        |> with Community.productCount
         |> with Community.hasObjectives
         |> with (Eos.nameSelectionSet Community.creator)
 

--- a/src/elm/Notification.elm
+++ b/src/elm/Notification.elm
@@ -1,12 +1,25 @@
-module Notification exposing (History, MintData, Model, Notification, NotificationType(..), SaleHistoryData, TransferData, addNotification, init, markAsReadMutation, notificationHistoryQuery, readAll)
+module Notification exposing
+    ( History
+    , MintData
+    , Model
+    , Notification
+    , NotificationType(..)
+    , OrderData
+    , TransferData
+    , addNotification
+    , init
+    , markAsReadMutation
+    , notificationHistoryQuery
+    , readAll
+    )
 
 import Cambiatus.Mutation as Mutation
 import Cambiatus.Object
 import Cambiatus.Object.Community as Community
 import Cambiatus.Object.Mint as Mint
 import Cambiatus.Object.NotificationHistory as NotificationHistory
-import Cambiatus.Object.Sale as Sale
-import Cambiatus.Object.SaleHistory as SaleHistory
+import Cambiatus.Object.Order as Order
+import Cambiatus.Object.Product as Product
 import Cambiatus.Object.Transfer as Transfer
 import Cambiatus.Query as Query
 import Cambiatus.Scalar exposing (DateTime(..))
@@ -73,13 +86,13 @@ type alias TransferData =
     }
 
 
-type alias SaleHistoryData =
+type alias OrderData =
     { amount : Float
     , community : Community
     , fromId : Eos.Name
     , toId : Eos.Name
     , communityId : String
-    , sale : Sale
+    , product : Product
     }
 
 
@@ -96,7 +109,7 @@ type alias Community =
     }
 
 
-type alias Sale =
+type alias Product =
     { id : Int
     , title : String
     , image : Maybe String
@@ -105,7 +118,7 @@ type alias Sale =
 
 type NotificationType
     = Transfer TransferData
-    | SaleHistory SaleHistoryData
+    | SaleHistory OrderData
     | Mint MintData
 
 
@@ -155,7 +168,7 @@ typeUnionSelectionSet : SelectionSet NotificationType Cambiatus.Union.Notificati
 typeUnionSelectionSet =
     Cambiatus.Union.NotificationType.fragments
         { onTransfer = SelectionSet.map Transfer transferSelectionSet
-        , onSaleHistory = SelectionSet.map SaleHistory saleHistorySelectionSet
+        , onOrder = SelectionSet.map SaleHistory saleHistorySelectionSet
         , onMint = SelectionSet.map Mint mintSelectionSet
         }
 
@@ -180,20 +193,20 @@ transferSelectionSet =
         |> with (Transfer.community logoSelectionSet)
 
 
-saleHistorySelectionSet : SelectionSet SaleHistoryData Cambiatus.Object.SaleHistory
+saleHistorySelectionSet : SelectionSet OrderData Cambiatus.Object.Order
 saleHistorySelectionSet =
-    SelectionSet.succeed SaleHistoryData
-        |> with SaleHistory.amount
-        |> with (SaleHistory.community logoSelectionSet)
-        |> with (Eos.nameSelectionSet SaleHistory.fromId)
-        |> with (Eos.nameSelectionSet SaleHistory.toId)
-        |> with SaleHistory.communityId
+    SelectionSet.succeed OrderData
+        |> with Order.amount
+        |> with (Order.community logoSelectionSet)
+        |> with (Eos.nameSelectionSet Order.fromId)
+        |> with (Eos.nameSelectionSet Order.toId)
+        |> with Order.communityId
         |> with
-            (SaleHistory.sale
-                (SelectionSet.succeed Sale
-                    |> with Sale.id
-                    |> with Sale.title
-                    |> with Sale.image
+            (Order.product
+                (SelectionSet.succeed Product
+                    |> with Product.id
+                    |> with Product.title
+                    |> with Product.image
                 )
             )
 

--- a/src/elm/Page/Notification.elm
+++ b/src/elm/Page/Notification.elm
@@ -10,7 +10,7 @@ import Html exposing (Html, div, img, p, text)
 import Html.Attributes exposing (class, src)
 import Html.Events exposing (onClick)
 import I18Next exposing (Delims(..))
-import Notification exposing (History, MintData, NotificationType(..), SaleHistoryData, TransferData)
+import Notification exposing (History, MintData, NotificationType(..), OrderData, TransferData)
 import Page
 import Route
 import Session.LoggedIn as LoggedIn exposing (External(..))
@@ -28,7 +28,10 @@ import Utils
 init : LoggedIn.Model -> ( Model, Cmd Msg )
 init ({ shared } as loggedIn) =
     ( initModel
-    , Api.Graphql.query shared (Notification.notificationHistoryQuery loggedIn.accountName) CompletedLoadNotificationHistory
+    , Api.Graphql.query
+        shared
+        (Notification.notificationHistoryQuery loggedIn.accountName)
+        CompletedLoadNotificationHistory
     )
 
 
@@ -52,7 +55,7 @@ type Status
 
 type Payload
     = T TransferData
-    | S SaleHistoryData
+    | S OrderData
     | M MintData
 
 
@@ -236,7 +239,7 @@ viewNotificationMint shared history notification =
         ]
 
 
-viewNotificationSaleHistory : LoggedIn.Model -> History -> SaleHistoryData -> Html Msg
+viewNotificationSaleHistory : LoggedIn.Model -> History -> OrderData -> Html Msg
 viewNotificationSaleHistory ({ shared } as loggedIn) notification sale =
     let
         maybeLogo =
@@ -274,7 +277,7 @@ viewNotificationSaleHistory ({ shared } as loggedIn) notification sale =
         )
 
 
-viewNotificationSaleHistoryDetail : LoggedIn.Model -> SaleHistoryData -> String -> List (Html msg)
+viewNotificationSaleHistoryDetail : LoggedIn.Model -> OrderData -> String -> List (Html msg)
 viewNotificationSaleHistoryDetail ({ shared } as loggedIn) sale date =
     let
         isBuy =
@@ -283,13 +286,13 @@ viewNotificationSaleHistoryDetail ({ shared } as loggedIn) sale date =
         description =
             if isBuy then
                 [ ( "user", Eos.nameToString sale.toId )
-                , ( "sale", sale.sale.title )
+                , ( "sale", sale.product.title )
                 ]
                     |> I18Next.tr shared.translations I18Next.Curly "notifications.saleHistory.buy"
 
             else
                 [ ( "user", Eos.nameToString sale.fromId )
-                , ( "sale", sale.sale.title )
+                , ( "sale", sale.product.title )
                 ]
                     |> I18Next.tr shared.translations I18Next.Curly "notifications.saleHistory.sell"
     in
@@ -303,7 +306,7 @@ viewNotificationSaleHistoryDetail ({ shared } as loggedIn) sale date =
         ]
     , div [ class "flex flex-none pl-4" ]
         [ img
-            [ src (Maybe.withDefault "" sale.sale.image)
+            [ src (Maybe.withDefault "" sale.product.image)
             , class "object-scale-down rounded-full h-10"
             ]
             []
@@ -394,7 +397,7 @@ update msg model loggedIn =
                         |> UR.init
                         |> UR.addCmd cmd
                         |> UR.addCmd
-                            (Route.ViewSale (String.fromInt sale.sale.id)
+                            (Route.ViewSale (String.fromInt sale.product.id)
                                 |> Route.replaceUrl loggedIn.shared.navKey
                             )
 

--- a/src/elm/Page/Shop.elm
+++ b/src/elm/Page/Shop.elm
@@ -23,7 +23,6 @@ import Html.Events exposing (on, onClick)
 import Html.Lazy as Lazy
 import Http
 import I18Next exposing (t)
-import Icons
 import Json.Decode exposing (Value)
 import Json.Encode as Encode
 import List.Extra as LE

--- a/src/elm/Page/Shop.elm
+++ b/src/elm/Page/Shop.elm
@@ -31,7 +31,7 @@ import Page exposing (Session(..))
 import Profile exposing (viewProfileNameTag)
 import Route
 import Session.LoggedIn as LoggedIn exposing (External(..))
-import Shop exposing (Filter, Sale)
+import Shop exposing (Filter, Product)
 import Task
 import Time exposing (Posix)
 import Transfer
@@ -51,7 +51,7 @@ init loggedIn filter =
     ( model
     , Cmd.batch
         [ Api.Graphql.query loggedIn.shared
-            (Shop.salesQuery filter loggedIn.accountName loggedIn.selectedCommunity)
+            (Shop.productsQuery filter loggedIn.accountName loggedIn.selectedCommunity)
             CompletedSalesLoad
         , Api.getBalances loggedIn.shared loggedIn.accountName CompletedLoadBalances
         , Task.perform GotTime Time.now
@@ -94,19 +94,19 @@ initModel filter =
 type Status
     = Loading
     | Loaded (List Card)
-    | LoadingFailed (Graphql.Http.Error (List Sale))
+    | LoadingFailed (Graphql.Http.Error (List Product))
 
 
 type alias Card =
-    { sale : Sale
+    { product : Product
     , rate : Maybe Int
     , form : SaleTransferForm
     }
 
 
-cardFromSale : Sale -> Card
-cardFromSale sale =
-    { sale = sale
+cardFromSale : Product -> Card
+cardFromSale p =
+    { product = p
     , rate = Nothing
     , form = initSaleFrom
     }
@@ -279,10 +279,10 @@ viewCard : Model -> LoggedIn.Model -> Int -> Card -> Html Msg
 viewCard model ({ shared } as loggedIn) index card =
     let
         image =
-            Maybe.withDefault "" card.sale.image
+            Maybe.withDefault "" card.product.image
 
         maybeBal =
-            LE.find (\bal -> bal.asset.symbol == card.sale.symbol) model.balances
+            LE.find (\bal -> bal.asset.symbol == card.product.symbol) model.balances
 
         symbolBalance =
             case maybeBal of
@@ -293,31 +293,31 @@ viewCard model ({ shared } as loggedIn) index card =
                     0.0
 
         currBalance =
-            String.fromFloat symbolBalance ++ " " ++ Eos.symbolToSymbolCodeString card.sale.symbol
+            String.fromFloat symbolBalance ++ " " ++ Eos.symbolToSymbolCodeString card.product.symbol
 
         tr r_id replaces =
             I18Next.tr shared.translations I18Next.Curly r_id replaces
 
         title =
-            if String.length card.sale.title > 17 then
-                String.slice 0 17 card.sale.title ++ " ..."
+            if String.length card.product.title > 17 then
+                String.slice 0 17 card.product.title ++ " ..."
 
             else
-                card.sale.title
+                card.product.title
     in
     a
         [ class "w-full md:w-1/2 lg:w-1/3 xl:w-1/4 px-2 mb-6"
-        , Route.href (Route.ViewSale (String.fromInt card.sale.id))
+        , Route.href (Route.ViewSale (String.fromInt card.product.id))
         ]
         [ div [ class "md:hidden rounded-lg bg-white h-32 flex" ]
             [ div [ class "w-1/4" ]
                 [ img [ class "rounded-l-lg object-cover h-32 w-full", src image, on "error" (Json.Decode.succeed (OnImageError index)) ] []
                 ]
             , div [ class "px-4 pb-2 flex flex-wrap" ]
-                [ p [ class "font-medium pt-2 w-full" ] [ text card.sale.title ]
-                , viewProfileNameTag loggedIn.accountName card.sale.creator shared.translations
+                [ p [ class "font-medium pt-2 w-full" ] [ text card.product.title ]
+                , viewProfileNameTag loggedIn.accountName card.product.creator shared.translations
                 , div [ class "h-16 w-full flex flex-wrap items-end" ]
-                    [ if card.sale.units == 0 && card.sale.trackStock then
+                    [ if card.product.units == 0 && card.product.trackStock then
                         div [ class "w-full" ]
                             [ p [ class "text-3xl text-red" ]
                                 [ text (t shared.translations "shop.out_of_stock")
@@ -326,8 +326,8 @@ viewCard model ({ shared } as loggedIn) index card =
 
                       else
                         div [ class "flex flex-none w-full items-center" ]
-                            [ p [ class "text-green text-2xl font-medium" ] [ text (String.fromFloat card.sale.price) ]
-                            , div [ class "uppercase text-xs ml-2 font-thin font-sans text-green" ] [ text (Eos.symbolToSymbolCodeString card.sale.symbol) ]
+                            [ p [ class "text-green text-2xl font-medium" ] [ text (String.fromFloat card.product.price) ]
+                            , div [ class "uppercase text-xs ml-2 font-thin font-sans text-green" ] [ text (Eos.symbolToSymbolCodeString card.product.symbol) ]
                             ]
                     , div [ class "w-full h-4" ]
                         [ div [ class "bg-gray-100 absolute uppercase text-xs px-2" ]
@@ -342,7 +342,7 @@ viewCard model ({ shared } as loggedIn) index card =
             [ div [ class "w-full relative bg-gray-500" ]
                 [ img [ class "w-full h-48 object-cover", src image ] []
                 , div [ class "absolute right-1 bottom-1 " ]
-                    [ Profile.view shared loggedIn.accountName card.sale.creator ]
+                    [ Profile.view shared loggedIn.accountName card.product.creator ]
                 ]
             , div [ class "w-full px-6 pt-4" ]
                 [ p [ class "text-xl" ] [ text title ]
@@ -353,7 +353,7 @@ viewCard model ({ shared } as loggedIn) index card =
                 , Icons.thumbDown ""
                 , p [ class "pl-2 pr-6 text-sm" ] [ text "0" ]
                 ]
-            , if card.sale.units == 0 && card.sale.trackStock then
+            , if card.product.units == 0 && card.product.trackStock then
                 div [ class "border-t border-gray-300 flex flex-none w-full px-6 pb-2" ]
                     [ p [ class "text-3xl text-red" ]
                         [ text (t loggedIn.shared.translations "shop.out_of_stock")
@@ -362,8 +362,8 @@ viewCard model ({ shared } as loggedIn) index card =
 
               else
                 div [ class "border-t border-gray-300 flex flex-none w-full px-6 pb-2" ]
-                    [ p [ class "text-green text-3xl" ] [ text (String.fromFloat card.sale.price) ]
-                    , div [ class "uppercase text-xs font-thin mt-3 ml-2 font-sans text-green" ] [ text (Eos.symbolToSymbolCodeString card.sale.symbol) ]
+                    [ p [ class "text-green text-3xl" ] [ text (String.fromFloat card.product.price) ]
+                    , div [ class "uppercase text-xs font-thin mt-3 ml-2 font-sans text-green" ] [ text (Eos.symbolToSymbolCodeString card.product.symbol) ]
                     ]
             , div [ class "px-6 pb-6" ]
                 [ div [ class "bg-gray-200 flex items-center justify-left text-xs px-4" ]
@@ -384,7 +384,7 @@ type alias UpdateResult =
 type Msg
     = Ignored
     | GotTime Posix
-    | CompletedSalesLoad (Result (Graphql.Http.Error (List Sale)) (List Sale))
+    | CompletedSalesLoad (Result (Graphql.Http.Error (List Product)) (List Product))
     | ClickedSendTransfer Card Int
     | ClickedMessages Int Eos.Name
     | ClickedFilter Filter
@@ -412,7 +412,7 @@ update msg model loggedIn =
         ClickedSendTransfer card cardIndex ->
             let
                 newForm =
-                    validateForm card.sale card.form
+                    validateForm card.product card.form
             in
             if isFormValid newForm then
                 if LoggedIn.isAuth loggedIn then
@@ -431,18 +431,18 @@ update msg model loggedIn =
                                     1
 
                         tAmount =
-                            card.sale.price * toFloat wantedUnits
+                            card.product.price * toFloat wantedUnits
 
                         quantity =
                             { amount = tAmount
-                            , symbol = card.sale.symbol
+                            , symbol = card.product.symbol
                             }
 
                         from =
                             loggedIn.accountName
 
                         to =
-                            card.sale.creatorId
+                            card.product.creatorId
                     in
                     UR.init model
                         |> UR.addPort
@@ -465,7 +465,7 @@ update msg model loggedIn =
                                       , name = "transfersale"
                                       , authorization = authorization
                                       , data =
-                                            { id = card.sale.id
+                                            { id = card.product.id
                                             , from = from
                                             , to = to
                                             , quantity = quantity
@@ -530,7 +530,7 @@ update msg model loggedIn =
                         Just card ->
                             let
                                 oldSale =
-                                    card.sale
+                                    card.product
 
                                 icon =
                                     "/icons/shop-placeholder" ++ (index |> modBy 3 |> String.fromInt) ++ ".svg"
@@ -539,7 +539,7 @@ update msg model loggedIn =
                                     { oldSale | image = Just icon }
 
                                 newCard =
-                                    { card | sale = newSale }
+                                    { card | product = newSale }
 
                                 newList =
                                     Array.set index newCard cardArray
@@ -581,7 +581,7 @@ updateCard msg cardIndex transform ({ model } as uResult) =
             UR.logImpossible msg [] uResult
 
 
-validateForm : Sale -> SaleTransferForm -> SaleTransferForm
+validateForm : Product -> SaleTransferForm -> SaleTransferForm
 validateForm sale form =
     let
         unitValidation : Validation

--- a/src/elm/Page/Shop.elm
+++ b/src/elm/Page/Shop.elm
@@ -347,21 +347,15 @@ viewCard model ({ shared } as loggedIn) index card =
             , div [ class "w-full px-6 pt-4" ]
                 [ p [ class "text-xl" ] [ text title ]
                 ]
-            , div [ class "flex flex-none items-center pt-3 px-6 pb-4" ]
-                [ Icons.thumbUp "text-indigo-500"
-                , p [ class "pl-2 pr-6 text-sm" ] [ text "0" ]
-                , Icons.thumbDown ""
-                , p [ class "pl-2 pr-6 text-sm" ] [ text "0" ]
-                ]
             , if card.product.units == 0 && card.product.trackStock then
-                div [ class "border-t border-gray-300 flex flex-none w-full px-6 pb-2" ]
+                div [ class "flex flex-none w-full px-6 pb-2" ]
                     [ p [ class "text-3xl text-red" ]
                         [ text (t loggedIn.shared.translations "shop.out_of_stock")
                         ]
                     ]
 
               else
-                div [ class "border-t border-gray-300 flex flex-none w-full px-6 pb-2" ]
+                div [ class "flex flex-none w-full px-6 pb-2" ]
                     [ p [ class "text-green text-3xl" ] [ text (String.fromFloat card.product.price) ]
                     , div [ class "uppercase text-xs font-thin mt-3 ml-2 font-sans text-green" ] [ text (Eos.symbolToSymbolCodeString card.product.symbol) ]
                     ]

--- a/src/elm/Page/Shop/Editor.elm
+++ b/src/elm/Page/Shop/Editor.elm
@@ -1,4 +1,14 @@
-module Page.Shop.Editor exposing (Model, Msg(..), initCreate, initUpdate, jsAddressToMsg, msgToString, subscriptions, update, view)
+module Page.Shop.Editor exposing
+    ( Model
+    , Msg(..)
+    , initCreate
+    , initUpdate
+    , jsAddressToMsg
+    , msgToString
+    , subscriptions
+    , update
+    , view
+    )
 
 import Api
 import Api.Graphql
@@ -21,7 +31,7 @@ import Page
 import Result exposing (Result)
 import Route
 import Session.LoggedIn as LoggedIn exposing (External(..), FeedbackStatus(..))
-import Shop exposing (Sale, SaleId)
+import Shop exposing (Product, ProductId)
 import Task
 import UpdateResult as UR
 import Utils exposing (decodeEnterKeyDown)
@@ -40,9 +50,9 @@ initCreate loggedIn =
     )
 
 
-initUpdate : SaleId -> LoggedIn.Model -> ( Model, Cmd Msg )
-initUpdate saleId loggedIn =
-    ( LoadingBalancesUpdate saleId
+initUpdate : ProductId -> LoggedIn.Model -> ( Model, Cmd Msg )
+initUpdate productId loggedIn =
+    ( LoadingBalancesUpdate productId
     , Api.getBalances loggedIn.shared loggedIn.accountName CompletedBalancesLoad
     )
 
@@ -71,14 +81,14 @@ type
     | EditingCreate (List Balance) ImageStatus Form
     | Creating (List Balance) ImageStatus Form
       -- Update
-    | LoadingBalancesUpdate SaleId
-    | LoadingSaleUpdate (List Balance) SaleId
-    | EditingUpdate (List Balance) Sale ImageStatus DeleteModalStatus Form
-    | Saving (List Balance) Sale ImageStatus Form
-    | Deleting (List Balance) Sale ImageStatus Form
+    | LoadingBalancesUpdate ProductId
+    | LoadingSaleUpdate (List Balance) ProductId
+    | EditingUpdate (List Balance) Product ImageStatus DeleteModalStatus Form
+    | Saving (List Balance) Product ImageStatus Form
+    | Deleting (List Balance) Product ImageStatus Form
       -- Errors
     | LoadBalancesFailed Http.Error
-    | LoadSaleFailed (Graphql.Http.Error (Maybe Sale))
+    | LoadSaleFailed (Graphql.Http.Error (Maybe Product))
 
 
 type DeleteModalStatus
@@ -506,7 +516,7 @@ type alias UpdateResult =
 
 type Msg
     = CompletedBalancesLoad (Result Http.Error (List Balance))
-    | CompletedSaleLoad (Result (Graphql.Http.Error (Maybe Sale)) (Maybe Sale))
+    | CompletedSaleLoad (Result (Graphql.Http.Error (Maybe Product)) (Maybe Product))
     | CompletedImageUpload (Result Http.Error String)
     | EnteredImage (List File)
     | EnteredTitle String
@@ -552,7 +562,7 @@ update msg model loggedIn =
                                     Cmd.none
 
                                 Just id ->
-                                    Api.Graphql.query loggedIn.shared (Shop.saleQuery id) CompletedSaleLoad
+                                    Api.Graphql.query loggedIn.shared (Shop.productQuery id) CompletedSaleLoad
                     in
                     LoadingSaleUpdate balances saleId
                         |> UR.init
@@ -1097,11 +1107,11 @@ encodeCreateForm loggedIn form =
         ]
 
 
-encodeUpdateForm : Sale -> Form -> Symbol -> Value
-encodeUpdateForm sale form selectedCommunity =
+encodeUpdateForm : Product -> Form -> Symbol -> Value
+encodeUpdateForm product form selectedCommunity =
     let
         saleId =
-            Encode.int sale.id
+            Encode.int product.id
 
         image =
             Maybe.withDefault "" (getInput form.image)
@@ -1167,10 +1177,10 @@ getNumericValues value =
         |> String.join ""
 
 
-encodeDeleteForm : Sale -> Value
-encodeDeleteForm sale =
+encodeDeleteForm : Product -> Value
+encodeDeleteForm product =
     Encode.object
-        [ ( "sale_id", Encode.int sale.id )
+        [ ( "sale_id", Encode.int product.id )
         ]
 
 

--- a/src/elm/Shop.elm
+++ b/src/elm/Shop.elm
@@ -1,16 +1,16 @@
 module Shop exposing
     ( Filter(..)
-    , Sale
-    , SaleId
+    , Product
+    , ProductId
     , decodeTargetValueToFilter
     , encodeTransferSale
-    , saleQuery
-    , salesQuery
+    , productQuery
+    , productsQuery
     )
 
 import Cambiatus.Object
-import Cambiatus.Object.Sale
-import Cambiatus.Query
+import Cambiatus.Object.Product
+import Cambiatus.Query as Query
 import Eos exposing (Symbol)
 import Eos.Account as Eos
 import Graphql.Operation exposing (RootQuery)
@@ -26,15 +26,13 @@ import Profile exposing (Profile)
 -- Sale
 
 
-type alias Sale =
+type alias Product =
     { id : Int
     , title : String
     , description : String
     , creatorId : Eos.Name
-    , createdEosAccount : Eos.Name
     , price : Float
     , symbol : Symbol
-    , rateCount : Maybe Int
     , image : Maybe String
     , units : Int
     , trackStock : Bool
@@ -42,7 +40,7 @@ type alias Sale =
     }
 
 
-type alias SaleId =
+type alias ProductId =
     String
 
 
@@ -92,72 +90,45 @@ decodeTargetValueToFilter ( all, user ) =
 
 
 
--- SALE GRAPHQL API
+-- PRODUCT GRAPHQL API
 
 
-salesSelection : SelectionSet Sale Cambiatus.Object.Sale
-salesSelection =
-    SelectionSet.succeed Sale
-        |> with Cambiatus.Object.Sale.id
-        |> with Cambiatus.Object.Sale.title
-        |> with Cambiatus.Object.Sale.description
-        |> with (Eos.nameSelectionSet Cambiatus.Object.Sale.creatorId)
-        |> with (Eos.nameSelectionSet Cambiatus.Object.Sale.createdEosAccount)
-        |> with Cambiatus.Object.Sale.price
-        |> with (Eos.symbolSelectionSet Cambiatus.Object.Sale.communityId)
-        |> SelectionSet.hardcoded (Just <| 0)
-        |> with Cambiatus.Object.Sale.image
-        |> with Cambiatus.Object.Sale.units
-        |> with Cambiatus.Object.Sale.trackStock
-        |> with (Cambiatus.Object.Sale.creator Profile.selectionSet)
+productSelection : SelectionSet Product Cambiatus.Object.Product
+productSelection =
+    SelectionSet.succeed Product
+        |> with Cambiatus.Object.Product.id
+        |> with Cambiatus.Object.Product.title
+        |> with Cambiatus.Object.Product.description
+        |> with (Eos.nameSelectionSet Cambiatus.Object.Product.creatorId)
+        |> with Cambiatus.Object.Product.price
+        |> with (Eos.symbolSelectionSet Cambiatus.Object.Product.communityId)
+        |> with Cambiatus.Object.Product.image
+        |> with Cambiatus.Object.Product.units
+        |> with Cambiatus.Object.Product.trackStock
+        |> with (Cambiatus.Object.Product.creator Profile.selectionSet)
 
 
-saleQuery : Int -> SelectionSet (Maybe Sale) RootQuery
-saleQuery saleId =
-    let
-        args =
-            { input = { id = saleId } }
-    in
-    Cambiatus.Query.sale
-        args
-        salesSelection
+productQuery : Int -> SelectionSet (Maybe Product) RootQuery
+productQuery saleId =
+    Query.product { id = saleId } productSelection
 
 
-salesQuery : Filter -> Eos.Name -> Symbol -> SelectionSet (List Sale) RootQuery
-salesQuery filter accName communityId =
+productsQuery : Filter -> Eos.Name -> Symbol -> SelectionSet (List Product) RootQuery
+productsQuery filter accName communityId =
     case filter of
         UserSales ->
             let
-                accString =
-                    Eos.nameToString accName
-
                 args =
-                    { input =
-                        { account = Present accString
-                        , all = Absent
-                        , communities = Absent
-                        , communityId = Present (Eos.symbolToString communityId)
+                    \_ ->
+                        { filters = Present { account = Eos.nameToString accName }
                         }
-                    }
             in
-            Cambiatus.Query.sales
-                args
-                salesSelection
+            Query.products args { communityId = Eos.symbolToString communityId } productSelection
 
         All ->
             let
-                accString =
-                    Eos.nameToString accName
-
                 args =
-                    { input =
-                        { account = Absent
-                        , all = Present accString
-                        , communities = Absent
-                        , communityId = Present (Eos.symbolToString communityId)
-                        }
+                    { communityId = Eos.symbolToString communityId
                     }
             in
-            Cambiatus.Query.sales
-                args
-                salesSelection
+            Query.products identity args productSelection


### PR DESCRIPTION
## What issue does this PR close
N/A

## Changes Proposed ( a list of new changes introduced by this PR)
This PR is a companion to the [backend counterpart](https://github.com/cambiatus/backend/pull/119), it updates the shop graphql objects. It also does one important renaming. Now `sales` is called `products` and `sale_history` is called `order`. This change isn't just semantic, in the next months we will work on improving the shop to allow orders to have multiple payment options as well as a statuses. So this change is the first step to do it, cleaning up the api to help future change. 

It also changes the scope of the shop. Now `products` query always require the `communityId` following up the change of having the app scoping everything to one community at the time. It also changes the query to show the users sales on the main view (we used to hide it, now its displayed alongside with all other products offers).

Another change is the removal of the thumbs from the shop listings. 

## How to test ( a list of instructions on how to test this PR)
Just use the app normally, including shop parts. All should work as it should thanks to the strong elm type system
