### PR TITLE
Feature/Add char counter and character limit to Transfer page's memo field

### DIFF
--- a/src/elm/Page/Community/Transfer.elm
+++ b/src/elm/Page/Community/Transfer.elm
@@ -12,14 +12,14 @@ module Page.Community.Transfer exposing
 import Api.Graphql
 import Browser.Events
 import Community exposing (Model)
-import DataValidator exposing (getInput)
+import DataValidator exposing (Validator, getInput, longerThan, newValidator, shorterThan, updateInput)
 import Eos exposing (Symbol)
 import Eos.Account as Eos
 import Eos.EosError as EosError
 import Graphql.Document
 import Graphql.Http
 import Html exposing (Html, button, div, form, input, span, text, textarea)
-import Html.Attributes exposing (class, disabled, placeholder, required, rows, type_, value, maxlength)
+import Html.Attributes exposing (class, disabled, maxlength, placeholder, required, rows, type_, value)
 import Html.Events exposing (onInput, onSubmit)
 import Json.Decode as Decode exposing (Value)
 import Json.Encode as Encode exposing (Value)
@@ -34,11 +34,6 @@ import Transfer
 import UpdateResult as UR
 import Utils
 import View.Form.InputCounter
-import DataValidator exposing (Validator)
-import DataValidator exposing (longerThan)
-import DataValidator exposing (shorterThan)
-import DataValidator exposing (newValidator)
-import DataValidator exposing (updateInput)
 
 
 init : LoggedIn.Model -> Symbol -> Maybe String -> ( Model, Cmd Msg )
@@ -385,20 +380,21 @@ update msg model ({ shared } as loggedIn) =
                 limitedMemo =
                     if String.length value < 255 then
                         value
+
                     else
                         String.slice 0 255 value
             in
-                case model.status of
-                    Loaded community (EditingTransfer form) ->
-                        { model
-                            | status =
-                                EditingTransfer { form | memo =  updateInput limitedMemo form.memo}
-                                    |> Loaded community
-                        }
-                            |> UR.init
+            case model.status of
+                Loaded community (EditingTransfer form) ->
+                    { model
+                        | status =
+                            EditingTransfer { form | memo = updateInput limitedMemo form.memo }
+                                |> Loaded community
+                    }
+                        |> UR.init
 
-                    _ ->
-                        model |> UR.init
+                _ ->
+                    model |> UR.init
 
         SubmitForm ->
             case model.status of
@@ -467,7 +463,6 @@ update msg model ({ shared } as loggedIn) =
                                                 , symbol = model.communityId
                                                 }
                                             , memo = getInput form.memo
-
                                             }
                                                 |> Transfer.encodeEosActionData
                                       }
@@ -635,6 +630,6 @@ msgToString msg =
 defaultMemo : Validator String
 defaultMemo =
     []
-    |> longerThan -1
-    |> shorterThan 256
-    |> newValidator "" (\v -> Just v) True
+        |> longerThan -1
+        |> shorterThan 256
+        |> newValidator "" (\v -> Just v) True


### PR DESCRIPTION
## What issue does this PR close
Partially address #431

## Changes Proposed ( a list of new changes introduced by this PR)
- Check the length of the memo (validate this field) before sending the data.
- Add a counter to the memo textarea (see creating an Action page as an example).

## How to test ( a list of instructions on how to test this PR)
- Click in "Transfer to Friends" button
- Try to digit more de 255 characters on "message" field
- See the character counter updating its value on "message" field

