### PR TITLE
Move contact modal to Dashboard.elm

### DIFF
--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -559,14 +559,6 @@ updateLoggedInUResult toStatus toMsg model uResult =
 
                         _ ->
                             ( m, cmds_ )
-
-                LoggedIn.ShowContactModal ->
-                    case m.session of
-                        Page.LoggedIn loggedIn ->
-                            ( { m | session = Page.LoggedIn (LoggedIn.showContactModal loggedIn) }, cmds_ )
-
-                        Page.Guest _ ->
-                            ( m, cmds_ )
         )
         ( { model | status = toStatus uResult.model }
         , []


### PR DESCRIPTION
## What issue does this PR close
Closes #511 

## Changes Proposed ( a list of new changes introduced by this PR)
Make the contact modal show up only in the Dashboard

## How to test ( a list of instructions on how to test this PR)

1. Be logged in already. Be part of any community and have it selected
2. Be sure to have no contact information
3. a. Open any page other than the dashboard
    b. You should *not* see the "add contact information" modal
4. a. Open the dashboard
    b. You *should* see the "add contact information" modal