### PR TITLE
Fix/cursor

### DIFF
--- a/src/elm/Claim.elm
+++ b/src/elm/Claim.elm
@@ -275,8 +275,8 @@ updateClaimModalStatus msg model =
 
 {-| Claim card with a short claim overview. Used on Dashboard and Analysis pages.
 -}
-viewClaimCard : LoggedIn.Model -> Model -> Maybe Time.Posix -> Html Msg
-viewClaimCard { shared, accountName } claim now =
+viewClaimCard : LoggedIn.Model -> Model -> Maybe Time.Posix -> Maybe String -> Html Msg
+viewClaimCard { shared, accountName } claim now maybeCursorId =
     let
         { t } =
             shared.translators
@@ -302,6 +302,7 @@ viewClaimCard { shared, accountName } claim now =
                 claim.action.objective.id
                 claim.action.id
                 claim.id
+                maybeCursorId
     in
     div [ class "w-full sm:w-1/2 lg:w-1/3 xl:w-1/4 px-2" ]
         [ div

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -801,10 +801,10 @@ changeRouteTo maybeRoute model =
                 >> updateStatusWith ActionEditor GotActionEditorMsg model
                 |> withLoggedIn (Route.EditAction symbol objectiveId actionId)
 
-        Just (Route.Claim objectiveId actionId claimId) ->
-            (\l -> Claim.init l claimId)
+        Just (Route.Claim objectiveId actionId claimId maybeCursorId) ->
+            (\l -> Claim.init l claimId maybeCursorId)
                 >> updateStatusWith Claim GotVerifyClaimMsg model
-                |> withLoggedIn (Route.Claim objectiveId actionId claimId)
+                |> withLoggedIn (Route.Claim objectiveId actionId claimId maybeCursorId)
 
         Just (Route.Shop maybeFilter) ->
             (\l -> Shop.init l maybeFilter)
@@ -840,10 +840,10 @@ changeRouteTo maybeRoute model =
                 >> updateStatusWith Transfer GotTransferMsg model
                 |> withLoggedIn (Route.Transfer symbol maybeTo)
 
-        Just Route.Analysis ->
-            (\l -> Analysis.init l)
+        Just (Route.Analysis  maybeCursorId) ->
+            (\l -> Analysis.init l maybeCursorId)
                 >> updateStatusWith Analysis GotAnalysisMsg model
-                |> withLoggedIn Route.Analysis
+                |> withLoggedIn (Route.Analysis maybeCursorId)
 
 
 jsAddressToMsg : List String -> Value -> Maybe Msg

--- a/src/elm/Page/Dashboard.elm
+++ b/src/elm/Page/Dashboard.elm
@@ -415,7 +415,7 @@ viewAnalysisList loggedIn model =
                                 ]
                             , a
                                 [ class "button button-secondary font-medium "
-                                , Route.href Route.Analysis
+                                , Route.href (Route.Analysis Nothing)
                                 ]
                                 [ text_ "dashboard.analysis.all" ]
                             ]
@@ -477,7 +477,7 @@ viewAnalysis : LoggedIn.Model -> ClaimStatus -> Maybe Time.Posix -> Html Msg
 viewAnalysis loggedIn claimStatus now =
     case claimStatus of
         ClaimLoaded claim ->
-            Claim.viewClaimCard loggedIn claim now
+            Claim.viewClaimCard loggedIn claim now Nothing
                 |> Html.map ClaimMsg
 
         ClaimLoading _ ->
@@ -490,7 +490,7 @@ viewAnalysis loggedIn claimStatus now =
             text ""
 
         ClaimVoteFailed claim ->
-            Claim.viewClaimCard loggedIn claim now
+            Claim.viewClaimCard loggedIn claim now Nothing
                 |> Html.map ClaimMsg
 
 

--- a/src/elm/Page/Dashboard/Analysis.elm
+++ b/src/elm/Page/Dashboard/Analysis.elm
@@ -541,7 +541,7 @@ update msg model loggedIn =
                     let
                         cursor : Maybe String
                         cursor =
-                            Maybe.andThen .endCursor (pageInfo |> Debug.log "pageInfo")
+                            Maybe.andThen .endCursor pageInfo
                     in
                     model
                         |> UR.init

--- a/src/elm/Page/Dashboard/Claim.elm
+++ b/src/elm/Page/Dashboard/Claim.elm
@@ -31,9 +31,9 @@ import View.Feedback as Feedback
 -- INIT
 
 
-init : LoggedIn.Model -> Claim.ClaimId -> ( Model, Cmd Msg )
-init { shared, authToken } claimId =
-    ( initModel claimId
+init : LoggedIn.Model -> Claim.ClaimId -> Maybe String -> ( Model, Cmd Msg )
+init { shared, authToken } claimId maybeCursorId =
+    ( initModel claimId maybeCursorId
     , Cmd.batch
         [ Task.perform GotTime Time.now
         , fetchClaim claimId shared authToken
@@ -51,16 +51,18 @@ type alias Model =
     , claimModalStatus : Claim.ModalStatus
     , isValidated : Bool
     , now : Maybe Posix
+    , maybeCursorId : Maybe String
     }
 
 
-initModel : Claim.ClaimId -> Model
-initModel claimId =
+initModel : Claim.ClaimId -> Maybe String -> Model
+initModel claimId maybeCursorId =
     { claimId = claimId
     , statusClaim = Loading
     , claimModalStatus = Claim.Closed
     , isValidated = False
     , now = Nothing
+    , maybeCursorId = maybeCursorId
     }
 
 
@@ -96,7 +98,7 @@ view ({ shared } as loggedIn) model =
 
                     Loaded claim ->
                         div [ class "bg-gray-100" ]
-                            [ Page.viewHeader loggedIn claim.action.description Route.Analysis
+                            [ Page.viewHeader loggedIn claim.action.description (Route.Analysis model.maybeCursorId)
                             , div [ class "mt-10 mb-8" ]
                                 [ Profile.viewLarge shared loggedIn.accountName claim.claimer
                                 ]

--- a/src/elm/Page/Profile/Claims.elm
+++ b/src/elm/Page/Profile/Claims.elm
@@ -108,7 +108,7 @@ viewResults : LoggedIn.Model -> List Claim.Model -> Maybe Time.Posix -> Html Msg
 viewResults loggedIn claims now =
     let
         viewClaim claim =
-            Claim.viewClaimCard loggedIn claim now
+            Claim.viewClaimCard loggedIn claim now Nothing
                 |> Html.map ClaimMsg
     in
     div [ class "container mx-auto px-4 mb-10" ]


### PR DESCRIPTION
## What issue does this PR close
Closes #521 

## Changes Proposed ( a list of new changes introduced by this PR)
Give the user the ability to navigate into specific filtered claims' pages, and when using the back button, have the previous filtering result displayed. This implements storing `cursorId` and `pageInfo` to be able to save the previously Loaded list of claims to have a more intuitive and functional analysis exploring UX. 

- Saves the `cursorId` string
- Creates a `Show previous 16 Claims` button

## How to test ( a list of instructions on how to test this PR)
1. Go to /dashboard/analysis page
2. Click on "Show next 16 items"
3. Click on any claim
4. Try to go back
5. See the previous filtering state
