### PR TITLE
Fix/Modal Scrolling

### DIFF
--- a/src/elm/View/Components.elm
+++ b/src/elm/View/Components.elm
@@ -1,8 +1,8 @@
 module View.Components exposing
     ( loadingLogoAnimated, loadingLogoAnimatedFluid
     , dialogBubble
-    , Orientation(..)
     , tooltip
+    , bgNoScroll
     )
 
 {-| This module exports some simple components that don't need to manage any
@@ -27,6 +27,11 @@ state or configuration, such as loading indicators and containers
 # Elements
 
 @docs tooltip
+
+
+# Helpers
+
+@docs bgNoScroll
 
 -}
 
@@ -61,13 +66,6 @@ loadingLogoAnimatedFluid =
 -- CONTAINERS
 
 
-type Orientation
-    = Up
-    | Down
-    | Left
-    | Right
-
-
 dialogBubble : { class_ : String, minWidth : Int } -> List (Html msg) -> Html msg
 dialogBubble { class_, minWidth } elements =
     node "dialog-bubble"
@@ -88,3 +86,14 @@ tooltip { t } tooltipMessage =
         , div [ class "icon-tooltip-content" ]
             [ text (t tooltipMessage) ]
         ]
+
+
+
+-- HELPERS
+
+
+{-| A node that prevents the body from scrolling
+-}
+bgNoScroll : List (Html.Attribute msg) -> Html msg
+bgNoScroll attrs =
+    node "bg-no-scroll" attrs []

--- a/src/elm/View/Modal.elm
+++ b/src/elm/View/Modal.elm
@@ -32,6 +32,7 @@ import Html exposing (Html, button, div, h3, text)
 import Html.Attributes exposing (class, classList)
 import Icons
 import Utils exposing (onClickNoBubble)
+import View.Components
 
 
 
@@ -150,11 +151,10 @@ viewModalDetails options =
     in
     div
         [ class "modal fade-in" ]
-        [ div
+        [ View.Components.bgNoScroll
             [ class "modal-bg"
             , onClickNoBubble options.closeMsg
             ]
-            []
         , div
             [ class "modal-content"
             , classList [ ( "modal-content-lg", options.isLarge ) ]

--- a/src/index.js
+++ b/src/index.js
@@ -93,6 +93,31 @@ window.customElements.define('dialog-bubble',
   }
 )
 
+window.customElements.define('bg-no-scroll',
+  class BgNoScroll extends HTMLElement {
+    constructor () {
+      super()
+      this._preventScrollingClass = 'overflow-hidden'
+    }
+
+    connectedCallback () {
+      if (document.body.classList.contains(this._preventScrollingClass)) {
+        return
+      }
+
+      document.body.classList.add(this._preventScrollingClass)
+    }
+
+    disconnectedCallback () {
+      if (!document.body.classList.contains(this._preventScrollingClass)) {
+        return
+      }
+
+      document.body.classList.remove(this._preventScrollingClass)
+    }
+  }
+)
+
 // =========================================
 // App startup
 // =========================================


### PR DESCRIPTION
## What issue does this PR close
Closes #487  

## Changes Proposed ( a list of new changes introduced by this PR)
Prevent the document body from scrolling when modal is open

## How to test ( a list of instructions on how to test this PR)
1. Open a page that has a modal and that is big enough to be scrollable (e.g. Dashboard when you have no contacts)
2. Try to scroll the background (shouldn't be possible)
3. Make your screen small enough so you can scroll the modal
4. Try to scroll the modal (should be possible)