### PR TITLE
Fix statusToRoute

### DIFF
--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -748,7 +748,7 @@ statusToRoute status =
                 |> Just
 
         Community _ ->
-            Just Route.CommunitySettings
+            Just Route.Community
 
         CommunityEditor _ ->
             Just Route.NewCommunity


### PR DESCRIPTION
## What issue does this PR close
Closes #565 

## Changes Proposed ( a list of new changes introduced by this PR)
Change the `statusToRoute` case that mapped `Community _ -> Just Route.CommunitySettings`  to map `Community _ -> Just Route.Community`

## How to test ( a list of instructions on how to test this PR)
1. Go to `/community`
2. Claim an action
3. Click on the "Back" button
4. Be redirected to `/community`
