### PR TITLE
Fix/redirect on join

### DIFF
--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -729,8 +729,8 @@ hideFeedback model =
             { model | session = Page.Guest { guest | feedback = Feedback.Hidden } }
 
 
-statusToRoute : Status -> Maybe Route
-statusToRoute status =
+statusToRoute : Status -> Session -> Maybe Route
+statusToRoute status session =
     case status of
         Redirect ->
             Nothing
@@ -797,8 +797,16 @@ statusToRoute status =
             Just Route.Dashboard
 
         Login maybeRedirect _ ->
-            -- TODO
-            Just (Route.Login Nothing maybeRedirect)
+            let
+                maybeInvitation =
+                    case session of
+                        Page.LoggedIn _ ->
+                            Nothing
+
+                        Page.Guest guest ->
+                            guest.maybeInvitation
+            in
+            Just (Route.Login maybeInvitation maybeRedirect)
 
         Profile _ ->
             Just Route.Profile
@@ -926,7 +934,7 @@ changeRouteTo maybeRoute model =
                     )
 
         addRouteToHistory status loggedIn =
-            case statusToRoute status of
+            case statusToRoute status (Page.LoggedIn loggedIn) of
                 Nothing ->
                     loggedIn
 

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -840,8 +840,8 @@ statusToRoute status =
         Invite subModel ->
             Just (Route.Invite subModel.invitationId)
 
-        Join _ ->
-            Just Route.Join
+        Join subModel ->
+            Just (Route.Join subModel.maybeRedirect)
 
         Transfer subModel ->
             Just (Route.Transfer subModel.maybeTo)
@@ -973,8 +973,11 @@ changeRouteTo maybeRoute model =
                         Cmd.none
 
                       else
-                        Route.replaceUrl shared.navKey Route.Join
+                        Route.replaceUrl shared.navKey (Route.Join (Just route))
                     )
+
+        -- longersymbol - no auto invite
+        -- testanothertwo - yes auto invite
     in
     case maybeRoute of
         Nothing ->
@@ -1148,8 +1151,8 @@ changeRouteTo maybeRoute model =
             Invite.init session invitationId
                 |> updateStatusWith Invite GotInviteMsg model
 
-        Just Route.Join ->
-            Join.init session
+        Just (Route.Join maybeRedirect) ->
+            Join.init session maybeRedirect
                 |> updateStatusWith Join GotJoinMsg model
 
         Just (Route.Transfer maybeTo) ->

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -993,9 +993,6 @@ changeRouteTo maybeRoute model =
                       else
                         Route.replaceUrl shared.navKey (Route.Join (Just route))
                     )
-
-        -- longersymbol - no auto invite
-        -- testanothertwo - yes auto invite
     in
     case maybeRoute of
         Nothing ->

--- a/src/elm/Page.elm
+++ b/src/elm/Page.elm
@@ -277,7 +277,7 @@ update msg session =
 
         ( SignedIn (RemoteData.Failure error), Guest guest ) ->
             UR.init session
-                |> UR.addCmd (Route.replaceUrl guest.shared.navKey (Route.Login guest.afterLoginRedirect))
+                |> UR.addCmd (Route.replaceUrl guest.shared.navKey (Route.Login guest.maybeInvitation guest.afterLoginRedirect))
                 |> UR.logGraphqlError msg error
 
         ( _, _ ) ->
@@ -307,7 +307,7 @@ logout { shared } =
     in
     ( Guest { guest | shared = { shared | maybeAccount = Nothing } }
     , Cmd.batch
-        [ Route.replaceUrl shared.navKey (Route.Login Nothing)
+        [ Route.replaceUrl shared.navKey (Route.Login Nothing Nothing)
         , Cmd.map GotGuestMsg guestCmd
         ]
     )

--- a/src/elm/Page/Community/Settings/Info.elm
+++ b/src/elm/Page/Community/Settings/Info.elm
@@ -322,12 +322,7 @@ update msg model ({ shared } as loggedIn) =
                                             , hasShop = Eos.boolToEosBool community.hasShop
                                             , hasKyc = Eos.boolToEosBool community.hasKyc
                                             , hasAutoInvite = Eos.boolToEosBool model.hasAutoInvite
-                                            , website =
-                                                if String.startsWith "https://" model.websiteInput || String.startsWith "http://" model.websiteInput then
-                                                    model.websiteInput
-
-                                                else
-                                                    "http://" ++ model.websiteInput
+                                            , website = addProtocolToUrlString model.websiteInput
                                             }
                                                 |> Community.encodeUpdateData
                                       }
@@ -548,7 +543,10 @@ validateDescription model =
 
 addProtocolToUrlString : String -> String
 addProtocolToUrlString url =
-    if String.startsWith "https://" url || String.startsWith "http://" url then
+    if String.isEmpty url then
+        ""
+
+    else if String.startsWith "https://" url || String.startsWith "http://" url then
         url
 
     else

--- a/src/elm/Page/Join.elm
+++ b/src/elm/Page/Join.elm
@@ -237,7 +237,7 @@ view_ isGuest ({ translators } as shared) community model =
                                 [ text (translators.t "community.join.only_invited") ]
                             , a
                                 [ class "button button-primary w-full mt-4"
-                                , Route.href (Route.Login model.maybeRedirect)
+                                , Route.href (Route.Login Nothing model.maybeRedirect)
                                 ]
                                 [ text (translators.t "community.join.already_member") ]
                             ]

--- a/src/elm/Page/Join.elm
+++ b/src/elm/Page/Join.elm
@@ -23,12 +23,12 @@ import View.Feedback as Feedback
 
 
 type alias Model =
-    {}
+    { maybeRedirect : Maybe Route.Route }
 
 
-init : Page.Session -> ( Model, Cmd Msg )
-init session =
-    ( {}
+init : Page.Session -> Maybe Route.Route -> ( Model, Cmd Msg )
+init session maybeRedirect =
+    ( { maybeRedirect = maybeRedirect }
     , case session of
         Page.Guest _ ->
             Cmd.none
@@ -60,7 +60,7 @@ update session msg model =
                 Page.Guest guest ->
                     UR.init model
                         |> UR.addCmd
-                            (Route.pushUrl guest.shared.navKey (Route.Register Nothing (Just Route.Dashboard)))
+                            (Route.pushUrl guest.shared.navKey (Route.Register Nothing model.maybeRedirect))
 
                 Page.LoggedIn loggedIn ->
                     UR.init model
@@ -83,15 +83,18 @@ update session msg model =
                             List.map .account community.members
                                 |> List.member loggedIn.accountName
 
-                        redirectToDashboard =
+                        redirectToApp =
                             if isMember then
-                                UR.addCmd (Route.pushUrl loggedIn.shared.navKey Route.Dashboard)
+                                model.maybeRedirect
+                                    |> Maybe.withDefault Route.Dashboard
+                                    |> Route.pushUrl loggedIn.shared.navKey
+                                    |> UR.addCmd
 
                             else
                                 identity
                     in
                     UR.init model
-                        |> redirectToDashboard
+                        |> redirectToApp
 
         CompletedSignIn loggedIn (RemoteData.Success (Just { token, user })) ->
             let
@@ -134,7 +137,11 @@ update session msg model =
                 |> UR.init
                 |> UR.addExt ({ loggedIn | authToken = token } |> LoggedIn.UpdatedLoggedIn)
                 |> addCommunity
-                |> UR.addCmd (Route.replaceUrl loggedIn.shared.navKey Route.Dashboard)
+                |> UR.addCmd
+                    (model.maybeRedirect
+                        |> Maybe.withDefault Route.Dashboard
+                        |> Route.replaceUrl loggedIn.shared.navKey
+                    )
 
         CompletedSignIn loggedIn (RemoteData.Failure error) ->
             model
@@ -151,7 +158,7 @@ update session msg model =
 
 
 view : Page.Session -> Model -> { title : String, content : Html Msg }
-view session _ =
+view session model =
     let
         { translators } =
             Page.toShared session
@@ -180,10 +187,10 @@ view session _ =
         content =
             case session of
                 Page.Guest guest ->
-                    viewAsGuest title guest
+                    viewAsGuest title guest model
 
                 Page.LoggedIn loggedIn ->
-                    viewAsLoggedIn title loggedIn
+                    viewAsLoggedIn title loggedIn model
     in
     { title = title
     , content = content
@@ -201,8 +208,8 @@ type alias GenericCommunity community =
     }
 
 
-view_ : Bool -> Shared -> GenericCommunity community -> Html Msg
-view_ isGuest ({ translators } as shared) community =
+view_ : Bool -> Shared -> GenericCommunity community -> Model -> Html Msg
+view_ isGuest ({ translators } as shared) community model =
     div
         [ class "bg-purple-500 flex-grow flex flex-col md:justify-center items-center p-4 md:p-0"
         , classList [ ( "w-1/2", not isGuest ) ]
@@ -230,7 +237,7 @@ view_ isGuest ({ translators } as shared) community =
                                 [ text (translators.t "community.join.only_invited") ]
                             , a
                                 [ class "button button-primary w-full mt-4"
-                                , Route.href (Route.Login Nothing)
+                                , Route.href (Route.Login model.maybeRedirect)
                                 ]
                                 [ text (translators.t "community.join.already_member") ]
                             ]
@@ -258,11 +265,11 @@ viewLoading shared =
         [ View.Components.loadingLogoAnimated shared.translators "" ]
 
 
-viewAsGuest : String -> Guest.Model -> Html Msg
-viewAsGuest title guest =
+viewAsGuest : String -> Guest.Model -> Model -> Html Msg
+viewAsGuest title guest model =
     case guest.community of
         RemoteData.Success communityPreview ->
-            view_ True guest.shared communityPreview
+            view_ True guest.shared communityPreview model
 
         RemoteData.Failure err ->
             Page.fullPageGraphQLError title err
@@ -271,13 +278,13 @@ viewAsGuest title guest =
             viewLoading guest.shared
 
 
-viewAsLoggedIn : String -> LoggedIn.Model -> Html Msg
-viewAsLoggedIn title loggedIn =
+viewAsLoggedIn : String -> LoggedIn.Model -> Model -> Html Msg
+viewAsLoggedIn title loggedIn model =
     case loggedIn.selectedCommunity of
         RemoteData.Success community ->
             div [ class "flex-grow flex" ]
                 [ Community.communityPreviewImage True loggedIn.shared community
-                , view_ False loggedIn.shared community
+                , view_ False loggedIn.shared community model
                 ]
 
         RemoteData.Failure err ->

--- a/src/elm/Page/Login.elm
+++ b/src/elm/Page/Login.elm
@@ -267,7 +267,7 @@ viewPin { shared } model =
 
 viewIllustration : String -> Html msg
 viewIllustration fileName =
-    img [ class "h-40 mx-auto mt-8 mb-7", src ("images/" ++ fileName) ] []
+    img [ class "h-40 mx-auto mt-8 mb-7", src ("/images/" ++ fileName) ] []
 
 
 
@@ -482,7 +482,7 @@ updateWithPassphrase msg model { shared } =
 
 
 updateWithPin : PinMsg -> PinModel -> Guest.Model -> PinUpdateResult
-updateWithPin msg model { shared } =
+updateWithPin msg model ({ shared } as guest) =
     case msg of
         PinIgnored ->
             UR.init model
@@ -506,7 +506,7 @@ updateWithPin msg model { shared } =
                 |> UR.addCmd
                     (Api.Graphql.mutation shared
                         Nothing
-                        (Auth.signIn accountName shared Nothing)
+                        (Auth.signIn accountName shared guest.maybeInvitation)
                         (GotSignInResult privateKey)
                     )
 

--- a/src/elm/Page/Register.elm
+++ b/src/elm/Page/Register.elm
@@ -166,7 +166,7 @@ view ({ shared } as guest) model =
                                     False
                     in
                     if community.hasAutoInvite || hasInvite then
-                        viewCreateAccount shared.translators model
+                        viewCreateAccount shared.translators guest.afterLoginRedirect model
 
                     else
                         Page.fullPageLoading shared
@@ -185,8 +185,8 @@ view ({ shared } as guest) model =
     }
 
 
-viewCreateAccount : Translators -> Model -> Html Msg
-viewCreateAccount translators model =
+viewCreateAccount : Translators -> Maybe Route.Route -> Model -> Html Msg
+viewCreateAccount translators maybeRedirect model =
     let
         formClasses =
             "flex flex-grow flex-col bg-white px-4 px-0 md:max-w-sm sf-wrapper self-center w-full"
@@ -213,7 +213,7 @@ viewCreateAccount translators model =
             AccountTypeSelectorShowed ->
                 div [ class formClasses ]
                     [ viewAccountTypeSelector translators model
-                    , viewFooterDisabled translators
+                    , viewFooter translators False maybeRedirect
                     ]
 
             FormShowed formModel ->
@@ -224,7 +224,7 @@ viewCreateAccount translators model =
                     [ viewAccountTypeSelector translators model
                     , div [ class "sf-content" ]
                         [ viewRegistrationForm translators formModel ]
-                    , viewFooterEnabled translators
+                    , viewFooter translators True maybeRedirect
                     ]
 
             AccountCreated ->
@@ -244,18 +244,8 @@ viewCreateAccount translators model =
         ]
 
 
-viewFooterEnabled : Translators -> Html msg
-viewFooterEnabled translators =
-    viewFooter translators True
-
-
-viewFooterDisabled : Translators -> Html msg
-viewFooterDisabled translators =
-    viewFooter translators False
-
-
-viewFooter : Translators -> Bool -> Html msg
-viewFooter { t } isSubmitEnabled =
+viewFooter : Translators -> Bool -> Maybe Route.Route -> Html msg
+viewFooter { t } isSubmitEnabled maybeRedirect =
     let
         viewSubmitButton =
             button
@@ -276,7 +266,7 @@ viewFooter { t } isSubmitEnabled =
             [ text (t "register.login")
             , a
                 [ class "underline text-orange-300"
-                , Route.href (Route.Login Nothing)
+                , Route.href (Route.Login maybeRedirect)
                 ]
                 [ text (t "register.authLink") ]
             ]
@@ -818,7 +808,7 @@ update _ msg model { shared, afterLoginRedirect } =
             model
                 |> UR.init
                 |> UR.addCmd
-                    (Route.replaceUrl shared.navKey (Route.Login Nothing))
+                    (Route.replaceUrl shared.navKey (Route.Login afterLoginRedirect))
 
         CompletedSignUp (RemoteData.Success resp) ->
             case resp of

--- a/src/elm/Page/Register.elm
+++ b/src/elm/Page/Register.elm
@@ -166,7 +166,7 @@ view ({ shared } as guest) model =
                                     False
                     in
                     if community.hasAutoInvite || hasInvite then
-                        viewCreateAccount shared.translators guest.afterLoginRedirect model
+                        viewCreateAccount guest model
 
                     else
                         Page.fullPageLoading shared
@@ -185,9 +185,12 @@ view ({ shared } as guest) model =
     }
 
 
-viewCreateAccount : Translators -> Maybe Route.Route -> Model -> Html Msg
-viewCreateAccount translators maybeRedirect model =
+viewCreateAccount : Guest.Model -> Model -> Html Msg
+viewCreateAccount guest model =
     let
+        { translators } =
+            guest.shared
+
         formClasses =
             "flex flex-grow flex-col bg-white px-4 px-0 md:max-w-sm sf-wrapper self-center w-full"
 
@@ -213,7 +216,7 @@ viewCreateAccount translators maybeRedirect model =
             AccountTypeSelectorShowed ->
                 div [ class formClasses ]
                     [ viewAccountTypeSelector translators model
-                    , viewFooter translators False maybeRedirect
+                    , viewFooter translators False guest
                     ]
 
             FormShowed formModel ->
@@ -224,7 +227,7 @@ viewCreateAccount translators maybeRedirect model =
                     [ viewAccountTypeSelector translators model
                     , div [ class "sf-content" ]
                         [ viewRegistrationForm translators formModel ]
-                    , viewFooter translators True maybeRedirect
+                    , viewFooter translators True guest
                     ]
 
             AccountCreated ->
@@ -244,8 +247,8 @@ viewCreateAccount translators maybeRedirect model =
         ]
 
 
-viewFooter : Translators -> Bool -> Maybe Route.Route -> Html msg
-viewFooter { t } isSubmitEnabled maybeRedirect =
+viewFooter : Translators -> Bool -> Guest.Model -> Html msg
+viewFooter { t } isSubmitEnabled guest =
     let
         viewSubmitButton =
             button
@@ -266,7 +269,7 @@ viewFooter { t } isSubmitEnabled maybeRedirect =
             [ text (t "register.login")
             , a
                 [ class "underline text-orange-300"
-                , Route.href (Route.Login maybeRedirect)
+                , Route.href (Route.Login guest.maybeInvitation guest.afterLoginRedirect)
                 ]
                 [ text (t "register.authLink") ]
             ]
@@ -537,7 +540,7 @@ getSignUpFields form =
 
 
 update : InvitationId -> Msg -> Model -> Guest.Model -> UpdateResult
-update _ msg model { shared, afterLoginRedirect } =
+update _ msg model ({ shared } as guest) =
     let
         { t } =
             shared.translators
@@ -567,7 +570,7 @@ update _ msg model { shared, afterLoginRedirect } =
 
             else
                 UR.init model
-                    |> UR.addCmd (Route.pushUrl shared.navKey (Route.Join afterLoginRedirect))
+                    |> UR.addCmd (Route.pushUrl shared.navKey (Route.Join guest.afterLoginRedirect))
 
         ValidateForm formType ->
             let
@@ -808,7 +811,7 @@ update _ msg model { shared, afterLoginRedirect } =
             model
                 |> UR.init
                 |> UR.addCmd
-                    (Route.replaceUrl shared.navKey (Route.Login afterLoginRedirect))
+                    (Route.replaceUrl shared.navKey (Route.Login guest.maybeInvitation guest.afterLoginRedirect))
 
         CompletedSignUp (RemoteData.Success resp) ->
             case resp of

--- a/src/elm/Page/Register.elm
+++ b/src/elm/Page/Register.elm
@@ -547,7 +547,7 @@ getSignUpFields form =
 
 
 update : InvitationId -> Msg -> Model -> Guest.Model -> UpdateResult
-update _ msg model { shared } =
+update _ msg model { shared, afterLoginRedirect } =
     let
         { t } =
             shared.translators
@@ -577,7 +577,7 @@ update _ msg model { shared } =
 
             else
                 UR.init model
-                    |> UR.addCmd (Route.pushUrl shared.navKey Route.Join)
+                    |> UR.addCmd (Route.pushUrl shared.navKey (Route.Join afterLoginRedirect))
 
         ValidateForm formType ->
             let

--- a/src/elm/Route.elm
+++ b/src/elm/Route.elm
@@ -55,7 +55,7 @@ type Route
     | ViewSale String
     | ViewTransfer Int
     | Invite String
-    | Join
+    | Join (Maybe Route)
     | Transfer (Maybe String)
     | Analysis
 
@@ -124,7 +124,12 @@ parser url =
         , Url.map EditSale (s "shop" </> string </> s "edit")
         , Url.map ViewTransfer (s "transfer" </> int)
         , Url.map Invite (s "invite" </> string)
-        , Url.map Join (s "join")
+        , Url.map Join
+            (s "join"
+                <?> Query.map
+                        (parseRedirect url)
+                        (Query.string "redirect")
+            )
         , Url.map Transfer (s "community" </> s "transfer" <?> Query.string "to")
         , Url.map Analysis (s "dashboard" </> s "analysis")
         ]
@@ -430,8 +435,10 @@ routeToString route =
                 Invite invitationId ->
                     ( [ "invite", invitationId ], [] )
 
-                Join ->
-                    ( [ "join" ], [] )
+                Join maybeRedirect ->
+                    ( [ "join" ]
+                    , queryBuilder routeToString maybeRedirect "redirect"
+                    )
 
                 Transfer maybeTo ->
                     ( [ "community"

--- a/src/elm/Route.elm
+++ b/src/elm/Route.elm
@@ -25,7 +25,7 @@ type Route
     = Root
     | ComingSoon
     | Register (Maybe String) (Maybe Route)
-    | Login (Maybe Route)
+    | Login (Maybe String) (Maybe Route)
     | Logout
     | Notification
     | ProfileEditor
@@ -78,7 +78,14 @@ parser url =
                         (parseRedirect url)
                         (Query.string "redirect")
             )
-        , Url.map Login
+        , Url.map (Just >> Login)
+            (s "login"
+                </> string
+                <?> Query.map
+                        (parseRedirect url)
+                        (Query.string "redirect")
+            )
+        , Url.map (Login Nothing)
             (s "login"
                 <?> Query.map
                         (parseRedirect url)
@@ -329,8 +336,13 @@ routeToString route =
                     , queryBuilder routeToString maybeRedirect "redirect"
                     )
 
-                Login maybeRedirect ->
+                Login Nothing maybeRedirect ->
                     ( [ "login" ]
+                    , queryBuilder routeToString maybeRedirect "redirect"
+                    )
+
+                Login (Just invitation) maybeRedirect ->
+                    ( [ "login", invitation ]
                     , queryBuilder routeToString maybeRedirect "redirect"
                     )
 

--- a/src/elm/Session/Guest.elm
+++ b/src/elm/Session/Guest.elm
@@ -99,6 +99,7 @@ type alias Model =
     { shared : Shared
     , showLanguageNav : Bool
     , afterLoginRedirect : Maybe Route
+    , maybeInvitation : Maybe String
     , community : RemoteData (Graphql.Http.Error (Maybe Community.CommunityPreview)) Community.CommunityPreview
     , isLoggingIn : Bool
     , feedback : Feedback.Model
@@ -110,6 +111,7 @@ initModel shared =
     { shared = shared
     , showLanguageNav = False
     , afterLoginRedirect = Nothing
+    , maybeInvitation = Nothing
     , community = RemoteData.Loading
     , isLoggingIn = False
     , feedback = Feedback.Hidden
@@ -241,7 +243,7 @@ viewPageHeader model shared =
     in
     header
         [ class "flex items-center justify-between pl-4 md:pl-6 py-3 bg-white" ]
-        [ a [ Route.href (Route.Login Nothing) ]
+        [ a [ Route.href (Route.Login model.maybeInvitation model.afterLoginRedirect) ]
             [ case model.community of
                 RemoteData.Loading ->
                     loadingSpinner

--- a/src/elm/Session/LoggedIn.elm
+++ b/src/elm/Session/LoggedIn.elm
@@ -1294,7 +1294,7 @@ setCommunity community ({ shared } as model) =
 
     else if community.hasAutoInvite then
         ( { model | selectedCommunity = RemoteData.Success community, shared = sharedWithCommunity }
-        , Cmd.batch [ Route.pushUrl shared.navKey Route.Join, storeCommunityCmd ]
+        , Cmd.batch [ Route.pushUrl shared.navKey (Route.Join (List.head model.routeHistory)), storeCommunityCmd ]
         )
 
     else

--- a/src/index.js
+++ b/src/index.js
@@ -265,7 +265,7 @@ const getItem = (key) => {
 }
 
 const removeItem = (key) => {
-  document.cookie = `${cookieKey(key)}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; ${cookieDomain()}`
+  document.cookie = `${cookieKey(key)}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; ${cookieDomain()}; path=/; SameSite=Strict; Secure`
   window.localStorage.removeItem(key)
 }
 


### PR DESCRIPTION
## What issue does this PR close
Closes #512, closes #568 

## Changes Proposed ( a list of new changes introduced by this PR)
- Add `redirect` query parameter to the "Join community" page
- Pass the `redirect` query parameter from "Join community" to "Login" and "Register" pages
- Pass the `redirect` query parameter from the "Register" page to the "Login" page
- Add invitation parameter to the "Login" page, and use it in there (this means users who already have an account can now join communities via invitation)
- Pass the invitation parameter from the "Register" page to the "Login" page
- Fix slight issue with cookies' `path` parameter when removing them

## How to test ( a list of instructions on how to test this PR)
#512 and #568 have pretty good testing/replication instructions, you can follow those. The errors shouldn't happen anymore.

Since the given link on #568 points to staging, I've deployed this PR there. If you want, you can test it on the netlify deploy with [this equivalent link](https://bit.ly/2TAsmX6)