### PR TITLE
Enhancement/elm format before push

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "bundle": "NODE_ENV=production yarn webpack --color --mode=production --config config/webpack.config.prod.js",
     "start": "standard && GRAPHQL_SECRET=gAK2_Fdjyy8 node scripts/start.js",
     "review": "elm-review",
+    "check-format": "elm-format ./ --validate",
     "make": "elm make",
     "repl": "elm repl",
     "reactor": "elm reactor",
@@ -19,7 +20,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-push": "echo \"Checking JS with StandardJS...\" && standard && echo \"Checking Elm with elm-review...\" && yarn review"
+      "pre-push": "echo \"Checking JS with StandardJS...\" && standard && echo \"Checking Elm with elm-format...\" && yarn check-format && echo \"Checking Elm with elm-review...\" && yarn review"
     }
   },
   "standard": {

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -1,7 +1,8 @@
 module Tests exposing (..)
 
-import Test exposing (..)
 import Expect
+import Test exposing (..)
+
 
 
 -- Check out http://package.elm-lang.org/packages/elm-community/elm-test/latest to learn more about testing in Elm!


### PR DESCRIPTION
## What issue does this PR close
Closes #569 

## Changes Proposed ( a list of new changes introduced by this PR)
- Add `check-format` as a script in `package.json`
- Use `yarn check-format` in `husky.hooks.pre-push` in `package.json`

## How to test ( a list of instructions on how to test this PR)
1. Open the project
2. Modify one of the Elm files (under `src/elm`) in a way that's not formatted according to `elm-format`
3. Save that file without formatting with `elm-format`
4. Run `yarn check-format`. It should show the errors you introduced