### PR TITLE
Fix/auth modal callback

### DIFF
--- a/src/elm/Page/Community/ActionEditor.elm
+++ b/src/elm/Page/Community/ActionEditor.elm
@@ -1039,7 +1039,10 @@ update msg model ({ shared } as loggedIn) =
             case loggedIn.selectedCommunity of
                 RemoteData.Success community ->
                     upsertAction loggedIn community newModel isoDate
-                        |> LoggedIn.withAuthentication loggedIn model msg
+                        |> LoggedIn.withAuthentication loggedIn
+                            model
+                            -- TODO - Check this
+                            { successMsg = msg, errorMsg = msg }
 
                 _ ->
                     UR.init newModel

--- a/src/elm/Page/Community/ActionEditor.elm
+++ b/src/elm/Page/Community/ActionEditor.elm
@@ -454,6 +454,7 @@ type alias UpdateResult =
 
 type Msg
     = CompletedLoadCommunity Community.Model
+    | ClosedAuthModal
     | OnSelectVerifier (Maybe Profile.Minimal)
     | OnRemoveVerifier Profile.Minimal
     | SelectMsg (Select.Msg Profile.Minimal)
@@ -597,6 +598,10 @@ update msg model ({ shared } as loggedIn) =
             else
                 { model | status = Unauthorized }
                     |> UR.init
+
+        ClosedAuthModal ->
+            { model | form = { oldForm | saveStatus = NotAsked } }
+                |> UR.init
 
         OnSelectVerifier maybeProfile ->
             let
@@ -1041,8 +1046,7 @@ update msg model ({ shared } as loggedIn) =
                     upsertAction loggedIn community newModel isoDate
                         |> LoggedIn.withAuthentication loggedIn
                             model
-                            -- TODO - Check this
-                            { successMsg = msg, errorMsg = msg }
+                            { successMsg = msg, errorMsg = ClosedAuthModal }
 
                 _ ->
                     UR.init newModel
@@ -1860,6 +1864,9 @@ msgToString msg =
     case msg of
         CompletedLoadCommunity _ ->
             [ "CompletedLoadCommunity" ]
+
+        ClosedAuthModal ->
+            [ "ClosedAuthModal" ]
 
         OnSelectVerifier _ ->
             [ "OnSelectVerifier" ]

--- a/src/elm/Page/Community/ActionEditor.elm
+++ b/src/elm/Page/Community/ActionEditor.elm
@@ -1038,16 +1038,8 @@ update msg model ({ shared } as loggedIn) =
             in
             case loggedIn.selectedCommunity of
                 RemoteData.Success community ->
-                    if LoggedIn.hasPrivateKey loggedIn then
-                        upsertAction loggedIn community newModel isoDate
-
-                    else
-                        newModel
-                            |> UR.init
-                            |> UR.addExt
-                                (Just (SaveAction isoDate)
-                                    |> RequiredAuthentication
-                                )
+                    upsertAction loggedIn community newModel isoDate
+                        |> LoggedIn.withAuthentication loggedIn model msg
 
                 _ ->
                     UR.init newModel

--- a/src/elm/Page/Community/New.elm
+++ b/src/elm/Page/Community/New.elm
@@ -767,34 +767,27 @@ update msg model loggedIn =
         GotDomainAvailableResponse (RemoteData.Success True) ->
             case validateModel loggedIn.shared loggedIn.accountName model of
                 Ok ( createCommunityData, createTokenData ) ->
-                    if LoggedIn.hasPrivateKey loggedIn then
-                        let
-                            subscriptionDoc =
-                                Community.newCommunitySubscription createCommunityData.cmmAsset.symbol
-                                    |> Graphql.Document.serializeSubscription
-                        in
-                        { model | isDisabled = True }
-                            |> UR.init
-                            |> UR.addPort
-                                { responseAddress = GotDomainAvailableResponse (RemoteData.Success True)
-                                , responseData =
-                                    Encode.object
-                                        [ ( "createCommunityData", Community.encodeCreateCommunityData createCommunityData )
-                                        , ( "createTokenData", Token.encodeCreateTokenData createTokenData )
-                                        ]
-                                , data =
-                                    Encode.object
-                                        [ ( "name", Encode.string "subscribeToNewCommunity" )
-                                        , ( "subscription", Encode.string subscriptionDoc )
-                                        ]
-                                }
-
-                    else
-                        UR.init model
-                            |> UR.addExt
-                                (Just SubmittedForm
-                                    |> RequiredAuthentication
-                                )
+                    let
+                        subscriptionDoc =
+                            Community.newCommunitySubscription createCommunityData.cmmAsset.symbol
+                                |> Graphql.Document.serializeSubscription
+                    in
+                    { model | isDisabled = True }
+                        |> UR.init
+                        |> UR.addPort
+                            { responseAddress = GotDomainAvailableResponse (RemoteData.Success True)
+                            , responseData =
+                                Encode.object
+                                    [ ( "createCommunityData", Community.encodeCreateCommunityData createCommunityData )
+                                    , ( "createTokenData", Token.encodeCreateTokenData createTokenData )
+                                    ]
+                            , data =
+                                Encode.object
+                                    [ ( "name", Encode.string "subscribeToNewCommunity" )
+                                    , ( "subscription", Encode.string subscriptionDoc )
+                                    ]
+                            }
+                        |> LoggedIn.withAuthentication loggedIn model msg
 
                 Err withError ->
                     UR.init withError

--- a/src/elm/Page/Community/New.elm
+++ b/src/elm/Page/Community/New.elm
@@ -787,7 +787,10 @@ update msg model loggedIn =
                                     , ( "subscription", Encode.string subscriptionDoc )
                                     ]
                             }
-                        |> LoggedIn.withAuthentication loggedIn model msg
+                        |> LoggedIn.withAuthentication loggedIn
+                            model
+                            -- TODO - Check this
+                            { successMsg = msg, errorMsg = msg }
 
                 Err withError ->
                     UR.init withError

--- a/src/elm/Page/Community/New.elm
+++ b/src/elm/Page/Community/New.elm
@@ -672,6 +672,7 @@ type Msg
     | GotCreateCommunityResponse (Result Value ( Eos.Symbol, String ))
     | Redirect Community.CreateCommunityData
     | PressedEnter Bool
+    | ClosedAuthModal
 
 
 update : Msg -> Model -> LoggedIn.Model -> UpdateResult
@@ -789,8 +790,7 @@ update msg model loggedIn =
                             }
                         |> LoggedIn.withAuthentication loggedIn
                             model
-                            -- TODO - Check this
-                            { successMsg = msg, errorMsg = msg }
+                            { successMsg = msg, errorMsg = ClosedAuthModal }
 
                 Err withError ->
                     UR.init withError
@@ -881,6 +881,10 @@ update msg model loggedIn =
 
             else
                 UR.init model
+
+        ClosedAuthModal ->
+            { model | isDisabled = False }
+                |> UR.init
 
 
 jsAddressToMsg : List String -> Value -> Maybe Msg
@@ -987,3 +991,6 @@ msgToString msg =
 
         PressedEnter _ ->
             [ "PressedEnter" ]
+
+        ClosedAuthModal ->
+            [ "ClosedAuthModal" ]

--- a/src/elm/Page/Community/ObjectiveEditor.elm
+++ b/src/elm/Page/Community/ObjectiveEditor.elm
@@ -482,22 +482,18 @@ update msg model loggedIn =
                         _ ->
                             newModel
             in
-            if LoggedIn.hasPrivateKey loggedIn then
-                case ( loggedIn.selectedCommunity, model.status ) of
-                    ( RemoteData.Success community, Authorized (NewObjective objForm) ) ->
-                        save objForm Nothing (Eos.getSymbolPrecision community.symbol)
+            case ( loggedIn.selectedCommunity, model.status ) of
+                ( RemoteData.Success community, Authorized (NewObjective objForm) ) ->
+                    save objForm Nothing (Eos.getSymbolPrecision community.symbol)
+                        |> LoggedIn.withAuthentication loggedIn model msg
 
-                    ( RemoteData.Success community, Authorized (EditObjective objectiveId objForm) ) ->
-                        save objForm (Just objectiveId) (Eos.getSymbolPrecision community.symbol)
+                ( RemoteData.Success community, Authorized (EditObjective objectiveId objForm) ) ->
+                    save objForm (Just objectiveId) (Eos.getSymbolPrecision community.symbol)
+                        |> LoggedIn.withAuthentication loggedIn model msg
 
-                    _ ->
-                        newModel
-                            |> UR.logImpossible msg []
-
-            else
-                newModel
-                    |> UR.addExt
-                        (Just ClickedSaveObjective |> RequiredAuthentication)
+                _ ->
+                    newModel
+                        |> UR.logImpossible msg []
 
         GotSaveObjectiveResponse (Ok _) ->
             UR.init model

--- a/src/elm/Page/Community/ObjectiveEditor.elm
+++ b/src/elm/Page/Community/ObjectiveEditor.elm
@@ -485,11 +485,17 @@ update msg model loggedIn =
             case ( loggedIn.selectedCommunity, model.status ) of
                 ( RemoteData.Success community, Authorized (NewObjective objForm) ) ->
                     save objForm Nothing (Eos.getSymbolPrecision community.symbol)
-                        |> LoggedIn.withAuthentication loggedIn model msg
+                        |> LoggedIn.withAuthentication loggedIn
+                            model
+                            -- TODO - Check this
+                            { successMsg = msg, errorMsg = msg }
 
                 ( RemoteData.Success community, Authorized (EditObjective objectiveId objForm) ) ->
                     save objForm (Just objectiveId) (Eos.getSymbolPrecision community.symbol)
-                        |> LoggedIn.withAuthentication loggedIn model msg
+                        |> LoggedIn.withAuthentication loggedIn
+                            model
+                            -- TODO - Check this
+                            { successMsg = msg, errorMsg = msg }
 
                 _ ->
                     newModel

--- a/src/elm/Page/Community/ObjectiveEditor.elm
+++ b/src/elm/Page/Community/ObjectiveEditor.elm
@@ -103,6 +103,7 @@ type alias UpdateResult =
 
 type Msg
     = CompletedLoadCommunity Community.Model
+    | ClosedAuthModal
     | EnteredDescription String
     | ClickedSaveObjective
     | ClickedCompleteObjective
@@ -385,6 +386,13 @@ update msg model loggedIn =
                 { model | status = Unauthorized }
                     |> UR.init
 
+        ClosedAuthModal ->
+            { model
+                | isMarkAsCompletedConfirmationModalLoading = False
+                , showMarkAsCompletedConfirmationModal = False
+            }
+                |> UR.init
+
         EnteredDescription val ->
             UR.init model
                 |> updateObjective msg (\o -> { o | description = val })
@@ -405,6 +413,9 @@ update msg model loggedIn =
                                 (completeObjectiveSelectionSet id)
                                 GotCompleteObjectiveResponse
                             )
+                        |> LoggedIn.withAuthentication loggedIn
+                            model
+                            { successMsg = msg, errorMsg = ClosedAuthModal }
 
                 _ ->
                     UR.init model
@@ -487,15 +498,13 @@ update msg model loggedIn =
                     save objForm Nothing (Eos.getSymbolPrecision community.symbol)
                         |> LoggedIn.withAuthentication loggedIn
                             model
-                            -- TODO - Check this
-                            { successMsg = msg, errorMsg = msg }
+                            { successMsg = msg, errorMsg = ClosedAuthModal }
 
                 ( RemoteData.Success community, Authorized (EditObjective objectiveId objForm) ) ->
                     save objForm (Just objectiveId) (Eos.getSymbolPrecision community.symbol)
                         |> LoggedIn.withAuthentication loggedIn
                             model
-                            -- TODO - Check this
-                            { successMsg = msg, errorMsg = msg }
+                            { successMsg = msg, errorMsg = ClosedAuthModal }
 
                 _ ->
                     newModel
@@ -554,6 +563,9 @@ msgToString msg =
     case msg of
         CompletedLoadCommunity _ ->
             [ "CompletedLoadCommunity" ]
+
+        ClosedAuthModal ->
+            [ "ClosedAuthModal" ]
 
         EnteredDescription _ ->
             [ "EnteredDescription" ]

--- a/src/elm/Page/Community/Settings/Currency.elm
+++ b/src/elm/Page/Community/Settings/Currency.elm
@@ -120,17 +120,10 @@ update msg model ({ shared } as loggedIn) =
                 RemoteData.Success community ->
                     case validateModel community.symbol model of
                         Ok ( validUpdateTokenData, validExpiryOptsData ) ->
-                            if LoggedIn.hasPrivateKey loggedIn then
-                                { model | isLoading = True }
-                                    |> UR.init
-                                    |> UR.addPort (savePort validUpdateTokenData validExpiryOptsData loggedIn)
-
-                            else
-                                UR.init model
-                                    |> UR.addExt
-                                        (Just ClickedSubmit
-                                            |> LoggedIn.RequiredAuthentication
-                                        )
+                            { model | isLoading = True }
+                                |> UR.init
+                                |> UR.addPort (savePort validUpdateTokenData validExpiryOptsData loggedIn)
+                                |> LoggedIn.withAuthentication loggedIn model msg
 
                         Err withError ->
                             UR.init withError

--- a/src/elm/Page/Community/Settings/Currency.elm
+++ b/src/elm/Page/Community/Settings/Currency.elm
@@ -69,6 +69,7 @@ init loggedIn =
 
 type Msg
     = Ignored
+    | ClosedAuthModal
     | EnteredMinimumBalance String
     | EnteredMaximumSupply String
     | EnteredNaturalExpirationPeriod String
@@ -89,6 +90,10 @@ update msg model ({ shared } as loggedIn) =
     case msg of
         Ignored ->
             UR.init model
+
+        ClosedAuthModal ->
+            { model | isLoading = False }
+                |> UR.init
 
         EnteredMinimumBalance minimumBalance ->
             { model | minimumBalance = minimumBalance }
@@ -125,8 +130,7 @@ update msg model ({ shared } as loggedIn) =
                                 |> UR.addPort (savePort validUpdateTokenData validExpiryOptsData loggedIn)
                                 |> LoggedIn.withAuthentication loggedIn
                                     model
-                                    -- TODO - Check this
-                                    { successMsg = msg, errorMsg = msg }
+                                    { successMsg = msg, errorMsg = ClosedAuthModal }
 
                         Err withError ->
                             UR.init withError
@@ -680,6 +684,9 @@ msgToString msg =
     case msg of
         Ignored ->
             [ "Ignored" ]
+
+        ClosedAuthModal ->
+            [ "ClosedAuthModal" ]
 
         EnteredMinimumBalance _ ->
             [ "EnteredMinimumBalance" ]

--- a/src/elm/Page/Community/Settings/Currency.elm
+++ b/src/elm/Page/Community/Settings/Currency.elm
@@ -123,7 +123,10 @@ update msg model ({ shared } as loggedIn) =
                             { model | isLoading = True }
                                 |> UR.init
                                 |> UR.addPort (savePort validUpdateTokenData validExpiryOptsData loggedIn)
-                                |> LoggedIn.withAuthentication loggedIn model msg
+                                |> LoggedIn.withAuthentication loggedIn
+                                    model
+                                    -- TODO - Check this
+                                    { successMsg = msg, errorMsg = msg }
 
                         Err withError ->
                             UR.init withError

--- a/src/elm/Page/Community/Settings/Features.elm
+++ b/src/elm/Page/Community/Settings/Features.elm
@@ -162,13 +162,19 @@ update msg model loggedIn =
             { model | hasShop = state }
                 |> UR.init
                 |> saveFeaturePort loggedIn Shop model.status state
-                |> LoggedIn.withAuthentication loggedIn model msg
+                |> LoggedIn.withAuthentication loggedIn
+                    model
+                    -- TODO - Check this
+                    { successMsg = msg, errorMsg = msg }
 
         ToggleObjectives state ->
             { model | hasObjectives = state }
                 |> UR.init
                 |> saveFeaturePort loggedIn Objectives model.status state
-                |> LoggedIn.withAuthentication loggedIn model msg
+                |> LoggedIn.withAuthentication loggedIn
+                    model
+                    -- TODO - Check this
+                    { successMsg = msg, errorMsg = msg }
 
         ToggleKyc ->
             model

--- a/src/elm/Page/Community/Settings/Features.elm
+++ b/src/elm/Page/Community/Settings/Features.elm
@@ -53,6 +53,7 @@ type Feature
 
 type Msg
     = CompletedLoadCommunity Community.Model
+    | ClosedAuthModal
     | ToggleShop Bool
     | ToggleObjectives Bool
     | ToggleKyc
@@ -158,14 +159,16 @@ update msg model loggedIn =
                     , hasKyc = community.hasKyc
                 }
 
+        ClosedAuthModal ->
+            UR.init model
+
         ToggleShop state ->
             { model | hasShop = state }
                 |> UR.init
                 |> saveFeaturePort loggedIn Shop model.status state
                 |> LoggedIn.withAuthentication loggedIn
                     model
-                    -- TODO - Check this
-                    { successMsg = msg, errorMsg = msg }
+                    { successMsg = msg, errorMsg = ClosedAuthModal }
 
         ToggleObjectives state ->
             { model | hasObjectives = state }
@@ -173,8 +176,7 @@ update msg model loggedIn =
                 |> saveFeaturePort loggedIn Objectives model.status state
                 |> LoggedIn.withAuthentication loggedIn
                     model
-                    -- TODO - Check this
-                    { successMsg = msg, errorMsg = msg }
+                    { successMsg = msg, errorMsg = ClosedAuthModal }
 
         ToggleKyc ->
             model
@@ -308,6 +310,9 @@ msgToString msg =
     case msg of
         CompletedLoadCommunity _ ->
             [ "CompletedLoadCommunity" ]
+
+        ClosedAuthModal ->
+            [ "ClosedAuthModal" ]
 
         ToggleShop _ ->
             [ "ToggleShop" ]

--- a/src/elm/Page/Community/Settings/Info.elm
+++ b/src/elm/Page/Community/Settings/Info.elm
@@ -342,7 +342,10 @@ update msg model ({ shared } as loggedIn) =
                                 Nothing ->
                                     Cmd.none
                             )
-                        |> LoggedIn.withAuthentication loggedIn model msg
+                        |> LoggedIn.withAuthentication loggedIn
+                            model
+                            -- TODO - Check this
+                            { successMsg = msg, errorMsg = msg }
 
                 _ ->
                     UR.init model

--- a/src/elm/Page/Community/Settings/Info.elm
+++ b/src/elm/Page/Community/Settings/Info.elm
@@ -92,6 +92,7 @@ init loggedIn =
 
 type Msg
     = CompletedLoadCommunity Community.Model
+    | ClosedAuthModal
     | EnteredLogo (List File)
     | CompletedLogoUpload (Result Http.Error String)
     | EnteredName String
@@ -139,6 +140,10 @@ update msg model ({ shared } as loggedIn) =
                 , isLoading = False
                 , websiteInput = Maybe.withDefault "" community.website
             }
+                |> UR.init
+
+        ClosedAuthModal ->
+            { model | isLoading = False }
                 |> UR.init
 
         EnteredLogo (file :: _) ->
@@ -344,8 +349,7 @@ update msg model ({ shared } as loggedIn) =
                             )
                         |> LoggedIn.withAuthentication loggedIn
                             model
-                            -- TODO - Check this
-                            { successMsg = msg, errorMsg = msg }
+                            { successMsg = msg, errorMsg = ClosedAuthModal }
 
                 _ ->
                     UR.init model
@@ -992,6 +996,9 @@ msgToString msg =
     case msg of
         CompletedLoadCommunity _ ->
             [ "CompletedLoadCommunity" ]
+
+        ClosedAuthModal ->
+            [ "ClosedAuthModal" ]
 
         EnteredLogo _ ->
             [ "EnteredLogo" ]

--- a/src/elm/Page/Community/Settings/Info.elm
+++ b/src/elm/Page/Community/Settings/Info.elm
@@ -253,12 +253,11 @@ update msg model ({ shared } as loggedIn) =
 
         GotDomainAvailableResponse (RemoteData.Success True) ->
             case
-                ( LoggedIn.hasPrivateKey loggedIn
-                , isModelValid (RemoteData.toMaybe loggedIn.selectedCommunity) model
+                ( isModelValid (RemoteData.toMaybe loggedIn.selectedCommunity) model
                 , loggedIn.selectedCommunity
                 )
             of
-                ( True, True, RemoteData.Success community ) ->
+                ( True, RemoteData.Success community ) ->
                     let
                         authorization =
                             { actor = loggedIn.accountName
@@ -343,10 +342,7 @@ update msg model ({ shared } as loggedIn) =
                                 Nothing ->
                                     Cmd.none
                             )
-
-                ( False, True, RemoteData.Success _ ) ->
-                    UR.init model
-                        |> UR.addExt (Just ClickedSave |> LoggedIn.RequiredAuthentication)
+                        |> LoggedIn.withAuthentication loggedIn model msg
 
                 _ ->
                     UR.init model

--- a/src/elm/Page/Community/Transfer.elm
+++ b/src/elm/Page/Community/Transfer.elm
@@ -339,6 +339,7 @@ type alias UpdateResult =
 
 type Msg
     = CompletedLoadCommunity Community.Model
+    | ClosedAuthModal
     | OnSelect (Maybe Profile.Minimal)
     | SelectMsg (Select.Msg Profile.Minimal)
     | EnteredAmount String
@@ -378,6 +379,21 @@ update msg model ({ shared } as loggedIn) =
     case msg of
         CompletedLoadCommunity community ->
             UR.init { model | transferStatus = getProfile model.maybeTo community }
+
+        ClosedAuthModal ->
+            let
+                form =
+                    case model.transferStatus of
+                        EditingTransfer form_ ->
+                            form_
+
+                        CreatingSubscription form_ ->
+                            form_
+
+                        SendingTransfer form_ ->
+                            form_
+            in
+            UR.init { model | transferStatus = EditingTransfer form }
 
         OnSelect maybeProfile ->
             case model.transferStatus of
@@ -520,7 +536,9 @@ update msg model ({ shared } as loggedIn) =
                                       }
                                     ]
                             }
-                        |> LoggedIn.withAuthentication loggedIn model msg
+                        |> LoggedIn.withAuthentication loggedIn
+                            model
+                            { successMsg = msg, errorMsg = ClosedAuthModal }
 
                 _ ->
                     onlyLogImpossible []
@@ -639,6 +657,9 @@ msgToString msg =
     case msg of
         CompletedLoadCommunity _ ->
             [ "CompletedLoadCommunity" ]
+
+        ClosedAuthModal ->
+            [ "ClosedAuthModal" ]
 
         OnSelect _ ->
             [ "OnSelect" ]

--- a/src/elm/Page/Community/Transfer.elm
+++ b/src/elm/Page/Community/Transfer.elm
@@ -485,8 +485,8 @@ update msg model ({ shared } as loggedIn) =
                     model |> UR.init
 
         PushTransaction ->
-            case ( model.transferStatus, LoggedIn.hasPrivateKey loggedIn, loggedIn.selectedCommunity ) of
-                ( CreatingSubscription form, True, RemoteData.Success community ) ->
+            case ( model.transferStatus, loggedIn.selectedCommunity ) of
+                ( CreatingSubscription form, RemoteData.Success community ) ->
                     let
                         account =
                             Maybe.map .account form.selectedProfile
@@ -520,13 +520,7 @@ update msg model ({ shared } as loggedIn) =
                                       }
                                     ]
                             }
-
-                ( CreatingSubscription _, False, _ ) ->
-                    UR.init model
-                        |> UR.addExt
-                            (Just PushTransaction
-                                |> RequiredAuthentication
-                            )
+                        |> LoggedIn.withAuthentication loggedIn model msg
 
                 _ ->
                     onlyLogImpossible []

--- a/src/elm/Page/Dashboard.elm
+++ b/src/elm/Page/Dashboard.elm
@@ -841,7 +841,10 @@ update msg model ({ shared, accountName } as loggedIn) =
                                       }
                                     ]
                             }
-                        |> LoggedIn.withAuthentication loggedIn model msg
+                        |> LoggedIn.withAuthentication loggedIn
+                            model
+                            -- TODO - Check this
+                            { successMsg = msg, errorMsg = msg }
 
                 _ ->
                     model

--- a/src/elm/Page/Dashboard.elm
+++ b/src/elm/Page/Dashboard.elm
@@ -841,7 +841,7 @@ update msg model ({ shared, accountName } as loggedIn) =
                                       }
                                     ]
                             }
-                        |> LoggedIn.withAuthentication loggedIn newModel msg
+                        |> LoggedIn.withAuthentication loggedIn model msg
 
                 _ ->
                     model

--- a/src/elm/Page/Dashboard.elm
+++ b/src/elm/Page/Dashboard.elm
@@ -825,27 +825,23 @@ update msg model ({ shared, accountName } as loggedIn) =
                                 , claimModalStatus = Claim.Closed
                             }
                     in
-                    if LoggedIn.hasPrivateKey loggedIn then
-                        UR.init newModel
-                            |> UR.addPort
-                                { responseAddress = msg
-                                , responseData = Encode.null
-                                , data =
-                                    Eos.encodeTransaction
-                                        [ { accountName = loggedIn.shared.contracts.community
-                                          , name = "verifyclaim"
-                                          , authorization =
-                                                { actor = loggedIn.accountName
-                                                , permissionName = Eos.samplePermission
-                                                }
-                                          , data = Claim.encodeVerification claimId loggedIn.accountName vote
-                                          }
-                                        ]
-                                }
-
-                    else
-                        UR.init newModel
-                            |> UR.addExt (Just (VoteClaim claimId vote) |> LoggedIn.RequiredAuthentication)
+                    UR.init newModel
+                        |> UR.addPort
+                            { responseAddress = msg
+                            , responseData = Encode.null
+                            , data =
+                                Eos.encodeTransaction
+                                    [ { accountName = loggedIn.shared.contracts.community
+                                      , name = "verifyclaim"
+                                      , authorization =
+                                            { actor = loggedIn.accountName
+                                            , permissionName = Eos.samplePermission
+                                            }
+                                      , data = Claim.encodeVerification claimId loggedIn.accountName vote
+                                      }
+                                    ]
+                            }
+                        |> LoggedIn.withAuthentication loggedIn newModel msg
 
                 _ ->
                     model

--- a/src/elm/Page/Dashboard.elm
+++ b/src/elm/Page/Dashboard.elm
@@ -691,6 +691,7 @@ type alias UpdateResult =
 
 type Msg
     = NoOp
+    | ClosedAuthModal
     | CompletedLoadCommunity Community.Model
     | CompletedLoadProfile Profile.Model
     | CompletedLoadBalance (Result Http.Error (Maybe Balance))
@@ -714,6 +715,10 @@ update msg model ({ shared, accountName } as loggedIn) =
     case msg of
         NoOp ->
             UR.init model
+
+        ClosedAuthModal ->
+            { model | claimModalStatus = Claim.Closed }
+                |> UR.init
 
         CompletedLoadCommunity community ->
             UR.init
@@ -843,8 +848,7 @@ update msg model ({ shared, accountName } as loggedIn) =
                             }
                         |> LoggedIn.withAuthentication loggedIn
                             model
-                            -- TODO - Check this
-                            { successMsg = msg, errorMsg = msg }
+                            { successMsg = msg, errorMsg = ClosedAuthModal }
 
                 _ ->
                     model
@@ -1208,6 +1212,9 @@ msgToString msg =
     case msg of
         NoOp ->
             [ "NoOp" ]
+
+        ClosedAuthModal ->
+            [ "ClosedAuthModal" ]
 
         CompletedLoadCommunity _ ->
             [ "CompletedLoadCommunity" ]

--- a/src/elm/Page/Dashboard/Analysis.elm
+++ b/src/elm/Page/Dashboard/Analysis.elm
@@ -415,27 +415,23 @@ update msg model loggedIn =
                                 | claimModalStatus = Claim.Loading claimId vote
                             }
                     in
-                    if LoggedIn.hasPrivateKey loggedIn then
-                        UR.init newModel
-                            |> UR.addPort
-                                { responseAddress = msg
-                                , responseData = Encode.null
-                                , data =
-                                    Eos.encodeTransaction
-                                        [ { accountName = loggedIn.shared.contracts.community
-                                          , name = "verifyclaim"
-                                          , authorization =
-                                                { actor = loggedIn.accountName
-                                                , permissionName = Eos.samplePermission
-                                                }
-                                          , data = Claim.encodeVerification claimId loggedIn.accountName vote
-                                          }
-                                        ]
-                                }
-
-                    else
-                        UR.init newModel
-                            |> UR.addExt (Just (VoteClaim claimId vote) |> LoggedIn.RequiredAuthentication)
+                    UR.init newModel
+                        |> UR.addPort
+                            { responseAddress = msg
+                            , responseData = Encode.null
+                            , data =
+                                Eos.encodeTransaction
+                                    [ { accountName = loggedIn.shared.contracts.community
+                                      , name = "verifyclaim"
+                                      , authorization =
+                                            { actor = loggedIn.accountName
+                                            , permissionName = Eos.samplePermission
+                                            }
+                                      , data = Claim.encodeVerification claimId loggedIn.accountName vote
+                                      }
+                                    ]
+                            }
+                        |> LoggedIn.withAuthentication loggedIn model msg
 
                 _ ->
                     model

--- a/src/elm/Page/Dashboard/Analysis.elm
+++ b/src/elm/Page/Dashboard/Analysis.elm
@@ -315,6 +315,7 @@ type alias UpdateResult =
 
 type Msg
     = ClaimsLoaded (RemoteData (Graphql.Http.Error (Maybe Claim.Paginated)) (Maybe Claim.Paginated))
+    | ClosedAuthModal
     | CompletedLoadCommunity Community.Model
     | ClaimMsg Int Claim.Msg
     | VoteClaim Claim.ClaimId Bool
@@ -372,6 +373,10 @@ update msg model loggedIn =
 
         ClaimsLoaded _ ->
             UR.init model
+
+        ClosedAuthModal ->
+            { model | claimModalStatus = Claim.Closed }
+                |> UR.init
 
         CompletedLoadCommunity community ->
             UR.init model
@@ -433,8 +438,7 @@ update msg model loggedIn =
                             }
                         |> LoggedIn.withAuthentication loggedIn
                             model
-                            -- TODO - Check this
-                            { successMsg = msg, errorMsg = msg }
+                            { successMsg = msg, errorMsg = ClosedAuthModal }
 
                 _ ->
                     model
@@ -794,6 +798,9 @@ msgToString msg =
     case msg of
         ClaimsLoaded r ->
             [ "ClaimsLoaded", UR.remoteDataToString r ]
+
+        ClosedAuthModal ->
+            [ "ClosedAuthModal" ]
 
         CompletedLoadCommunity _ ->
             [ "CompletedLoadCommunity" ]

--- a/src/elm/Page/Dashboard/Analysis.elm
+++ b/src/elm/Page/Dashboard/Analysis.elm
@@ -431,7 +431,10 @@ update msg model loggedIn =
                                       }
                                     ]
                             }
-                        |> LoggedIn.withAuthentication loggedIn model msg
+                        |> LoggedIn.withAuthentication loggedIn
+                            model
+                            -- TODO - Check this
+                            { successMsg = msg, errorMsg = msg }
 
                 _ ->
                     model

--- a/src/elm/Page/Dashboard/Claim.elm
+++ b/src/elm/Page/Dashboard/Claim.elm
@@ -460,6 +460,7 @@ type alias UpdateResult =
 
 type Msg
     = ClaimLoaded (RemoteData (Graphql.Http.Error Claim.Model) Claim.Model)
+    | ClosedAuthModal
     | VoteClaim Claim.ClaimId Bool
     | GotVoteResult (Result (Maybe Value) String)
     | ClaimMsg Claim.Msg
@@ -519,6 +520,10 @@ update msg model loggedIn =
         ClaimLoaded _ ->
             UR.init model
 
+        ClosedAuthModal ->
+            { model | claimModalStatus = Claim.Closed }
+                |> UR.init
+
         ClaimMsg m ->
             Claim.updateClaimModalStatus m model
                 |> UR.init
@@ -550,8 +555,7 @@ update msg model loggedIn =
                             }
                         |> LoggedIn.withAuthentication loggedIn
                             model
-                            -- TODO - Check this
-                            { successMsg = msg, errorMsg = msg }
+                            { successMsg = msg, errorMsg = ClosedAuthModal }
 
                 _ ->
                     model
@@ -673,6 +677,9 @@ msgToString msg =
     case msg of
         ClaimLoaded r ->
             [ "ClaimLoaded", UR.remoteDataToString r ]
+
+        ClosedAuthModal ->
+            [ "ClosedAuthModal" ]
 
         VoteClaim claimId _ ->
             [ "VoteClaim", String.fromInt claimId ]

--- a/src/elm/Page/Dashboard/Claim.elm
+++ b/src/elm/Page/Dashboard/Claim.elm
@@ -548,7 +548,10 @@ update msg model loggedIn =
                                       }
                                     ]
                             }
-                        |> LoggedIn.withAuthentication loggedIn model msg
+                        |> LoggedIn.withAuthentication loggedIn
+                            model
+                            -- TODO - Check this
+                            { successMsg = msg, errorMsg = msg }
 
                 _ ->
                     model

--- a/src/elm/Page/Dashboard/Claim.elm
+++ b/src/elm/Page/Dashboard/Claim.elm
@@ -532,27 +532,23 @@ update msg model loggedIn =
                                 | claimModalStatus = Claim.Loading claimId vote
                             }
                     in
-                    if LoggedIn.hasPrivateKey loggedIn then
-                        UR.init newModel
-                            |> UR.addPort
-                                { responseAddress = msg
-                                , responseData = Encode.null
-                                , data =
-                                    Eos.encodeTransaction
-                                        [ { accountName = loggedIn.shared.contracts.community
-                                          , name = "verifyclaim"
-                                          , authorization =
-                                                { actor = loggedIn.accountName
-                                                , permissionName = Eos.samplePermission
-                                                }
-                                          , data = Claim.encodeVerification claimId loggedIn.accountName vote
-                                          }
-                                        ]
-                                }
-
-                    else
-                        UR.init newModel
-                            |> UR.addExt (Just (VoteClaim claimId vote) |> LoggedIn.RequiredAuthentication)
+                    UR.init newModel
+                        |> UR.addPort
+                            { responseAddress = msg
+                            , responseData = Encode.null
+                            , data =
+                                Eos.encodeTransaction
+                                    [ { accountName = loggedIn.shared.contracts.community
+                                      , name = "verifyclaim"
+                                      , authorization =
+                                            { actor = loggedIn.accountName
+                                            , permissionName = Eos.samplePermission
+                                            }
+                                      , data = Claim.encodeVerification claimId loggedIn.accountName vote
+                                      }
+                                    ]
+                            }
+                        |> LoggedIn.withAuthentication loggedIn model msg
 
                 _ ->
                     model

--- a/src/elm/Page/Profile.elm
+++ b/src/elm/Page/Profile.elm
@@ -689,7 +689,10 @@ update msg model loggedIn =
                     (Dom.focus "pinInput"
                         |> Task.attempt (\_ -> Ignored)
                     )
-                |> LoggedIn.withAuthentication loggedIn model msg
+                |> LoggedIn.withAuthentication loggedIn
+                    model
+                    -- TODO - Check this
+                    { successMsg = msg, errorMsg = msg }
 
         ChangePinSubmitted newPin ->
             let
@@ -712,7 +715,10 @@ update msg model loggedIn =
                             , ( "newPin", Encode.string newPin )
                             ]
                     }
-                |> LoggedIn.withAuthentication loggedIn model msg
+                |> LoggedIn.withAuthentication loggedIn
+                    model
+                    -- TODO - Check this
+                    { successMsg = msg, errorMsg = msg }
 
         GotPinMsg subMsg ->
             let
@@ -737,7 +743,10 @@ update msg model loggedIn =
             model
                 |> UR.init
                 |> downloadPdfPort loggedIn.auth.pinModel.pin
-                |> LoggedIn.withAuthentication loggedIn model msg
+                |> LoggedIn.withAuthentication loggedIn
+                    model
+                    -- TODO - Check this
+                    { successMsg = msg, errorMsg = msg }
 
         DownloadPdf pin ->
             model

--- a/src/elm/Page/Profile.elm
+++ b/src/elm/Page/Profile.elm
@@ -691,8 +691,7 @@ update msg model loggedIn =
                     )
                 |> LoggedIn.withAuthentication loggedIn
                     model
-                    -- TODO - Check this
-                    { successMsg = msg, errorMsg = msg }
+                    { successMsg = msg, errorMsg = Ignored }
 
         ChangePinSubmitted newPin ->
             let
@@ -717,8 +716,7 @@ update msg model loggedIn =
                     }
                 |> LoggedIn.withAuthentication loggedIn
                     model
-                    -- TODO - Check this
-                    { successMsg = msg, errorMsg = msg }
+                    { successMsg = msg, errorMsg = Ignored }
 
         GotPinMsg subMsg ->
             let
@@ -745,8 +743,7 @@ update msg model loggedIn =
                 |> downloadPdfPort loggedIn.auth.pinModel.pin
                 |> LoggedIn.withAuthentication loggedIn
                     model
-                    -- TODO - Check this
-                    { successMsg = msg, errorMsg = msg }
+                    { successMsg = msg, errorMsg = Ignored }
 
         DownloadPdf pin ->
             model

--- a/src/elm/Page/Profile.elm
+++ b/src/elm/Page/Profile.elm
@@ -684,47 +684,35 @@ update msg model loggedIn =
                     UR.init model
 
         ClickedChangePin ->
-            if LoggedIn.hasPrivateKey loggedIn then
-                UR.init { model | isNewPinModalVisible = True }
-                    |> UR.addCmd
-                        (Dom.focus "pinInput"
-                            |> Task.attempt (\_ -> Ignored)
-                        )
-
-            else
-                UR.init model
-                    |> UR.addExt (Just ClickedChangePin |> RequiredAuthentication)
-                    |> UR.addCmd
-                        (Dom.focus "pinInput"
-                            |> Task.attempt (\_ -> Ignored)
-                        )
+            UR.init { model | isNewPinModalVisible = True }
+                |> UR.addCmd
+                    (Dom.focus "pinInput"
+                        |> Task.attempt (\_ -> Ignored)
+                    )
+                |> LoggedIn.withAuthentication loggedIn model msg
 
         ChangePinSubmitted newPin ->
-            if LoggedIn.hasPrivateKey loggedIn then
-                let
-                    currentPin =
-                        case model.currentPin of
-                            Just pin ->
-                                pin
+            let
+                currentPin =
+                    case model.currentPin of
+                        Just pin ->
+                            pin
 
-                            Nothing ->
-                                loggedIn.auth.pinModel.pin
-                in
-                UR.init model
-                    |> UR.addPort
-                        { responseAddress = PinChanged
-                        , responseData = Encode.null
-                        , data =
-                            Encode.object
-                                [ ( "name", Encode.string "changePin" )
-                                , ( "currentPin", Encode.string currentPin )
-                                , ( "newPin", Encode.string newPin )
-                                ]
-                        }
-
-            else
-                UR.init model
-                    |> UR.addExt (Just ClickedChangePin |> RequiredAuthentication)
+                        Nothing ->
+                            loggedIn.auth.pinModel.pin
+            in
+            UR.init model
+                |> UR.addPort
+                    { responseAddress = PinChanged
+                    , responseData = Encode.null
+                    , data =
+                        Encode.object
+                            [ ( "name", Encode.string "changePin" )
+                            , ( "currentPin", Encode.string currentPin )
+                            , ( "newPin", Encode.string newPin )
+                            ]
+                    }
+                |> LoggedIn.withAuthentication loggedIn model msg
 
         GotPinMsg subMsg ->
             let
@@ -746,22 +734,10 @@ update msg model loggedIn =
                 |> UR.addExt (ShowFeedback Feedback.Success (t "profile.pin.successMsg"))
 
         ClickedViewPrivateKeyAuth ->
-            case LoggedIn.maybePrivateKey loggedIn of
-                Nothing ->
-                    UR.init model
-                        |> UR.addExt
-                            (Just ClickedViewPrivateKeyAuth
-                                |> RequiredAuthentication
-                            )
-                        |> UR.addCmd
-                            (Dom.focus "pinInput"
-                                |> Task.attempt (\_ -> Ignored)
-                            )
-
-                Just _ ->
-                    model
-                        |> UR.init
-                        |> downloadPdfPort loggedIn.auth.pinModel.pin
+            model
+                |> UR.init
+                |> downloadPdfPort loggedIn.auth.pinModel.pin
+                |> LoggedIn.withAuthentication loggedIn model msg
 
         DownloadPdf pin ->
             model

--- a/src/elm/Page/Profile/Claims.elm
+++ b/src/elm/Page/Profile/Claims.elm
@@ -265,7 +265,10 @@ update msg model loggedIn =
                                       }
                                     ]
                             }
-                        |> LoggedIn.withAuthentication loggedIn model msg
+                        |> LoggedIn.withAuthentication loggedIn
+                            model
+                            -- TODO - Check this
+                            { successMsg = msg, errorMsg = msg }
 
                 _ ->
                     model

--- a/src/elm/Page/Profile/Claims.elm
+++ b/src/elm/Page/Profile/Claims.elm
@@ -249,27 +249,23 @@ update msg model loggedIn =
                                 | claimModalStatus = Claim.Loading claimId vote
                             }
                     in
-                    if LoggedIn.hasPrivateKey loggedIn then
-                        UR.init newModel
-                            |> UR.addPort
-                                { responseAddress = msg
-                                , responseData = Encode.null
-                                , data =
-                                    Eos.encodeTransaction
-                                        [ { accountName = loggedIn.shared.contracts.community
-                                          , name = "verifyclaim"
-                                          , authorization =
-                                                { actor = loggedIn.accountName
-                                                , permissionName = Eos.samplePermission
-                                                }
-                                          , data = Claim.encodeVerification claimId loggedIn.accountName vote
-                                          }
-                                        ]
-                                }
-
-                    else
-                        UR.init newModel
-                            |> UR.addExt (Just (VoteClaim claimId vote) |> LoggedIn.RequiredAuthentication)
+                    UR.init newModel
+                        |> UR.addPort
+                            { responseAddress = msg
+                            , responseData = Encode.null
+                            , data =
+                                Eos.encodeTransaction
+                                    [ { accountName = loggedIn.shared.contracts.community
+                                      , name = "verifyclaim"
+                                      , authorization =
+                                            { actor = loggedIn.accountName
+                                            , permissionName = Eos.samplePermission
+                                            }
+                                      , data = Claim.encodeVerification claimId loggedIn.accountName vote
+                                      }
+                                    ]
+                            }
+                        |> LoggedIn.withAuthentication loggedIn model msg
 
                 _ ->
                     model

--- a/src/elm/Page/Profile/Claims.elm
+++ b/src/elm/Page/Profile/Claims.elm
@@ -174,6 +174,7 @@ type alias UpdateResult =
 
 type Msg
     = ClaimsLoaded (RemoteData (Graphql.Http.Error (Maybe ProfileClaims)) (Maybe ProfileClaims))
+    | ClosedAuthModal
     | CompletedLoadCommunity Community.Model
     | ClaimMsg Int Claim.Msg
     | VoteClaim Claim.ClaimId Bool
@@ -204,6 +205,10 @@ update msg model loggedIn =
 
         ClaimsLoaded _ ->
             UR.init model
+
+        ClosedAuthModal ->
+            { model | claimModalStatus = Claim.Closed }
+                |> UR.init
 
         CompletedLoadCommunity community ->
             UR.init model
@@ -267,8 +272,7 @@ update msg model loggedIn =
                             }
                         |> LoggedIn.withAuthentication loggedIn
                             model
-                            -- TODO - Check this
-                            { successMsg = msg, errorMsg = msg }
+                            { successMsg = msg, errorMsg = ClosedAuthModal }
 
                 _ ->
                     model
@@ -377,6 +381,9 @@ msgToString msg =
     case msg of
         ClaimsLoaded r ->
             [ "ClaimsLoaded", UR.remoteDataToString r ]
+
+        ClosedAuthModal ->
+            [ "ClosedAuthModal" ]
 
         CompletedLoadCommunity _ ->
             [ "CompletedLoadCommunity" ]

--- a/src/elm/Page/Shop/Editor.elm
+++ b/src/elm/Page/Shop/Editor.elm
@@ -689,7 +689,10 @@ update msg model loggedIn =
                             loggedIn
                             "createsale"
                             (encodeCreateForm loggedIn form)
-                            |> LoggedIn.withAuthentication loggedIn model msg
+                            |> LoggedIn.withAuthentication loggedIn
+                                model
+                                -- TODO - Check this
+                                { successMsg = msg, errorMsg = msg }
 
                     else
                         validatedModel
@@ -703,7 +706,10 @@ update msg model loggedIn =
                             loggedIn
                             "createsale"
                             (encodeCreateForm loggedIn form)
-                            |> LoggedIn.withAuthentication loggedIn model msg
+                            |> LoggedIn.withAuthentication loggedIn
+                                model
+                                -- TODO - Check this
+                                { successMsg = msg, errorMsg = msg }
 
                     else
                         validatedModel
@@ -717,7 +723,10 @@ update msg model loggedIn =
                             loggedIn
                             "createsale"
                             (encodeCreateForm loggedIn form)
-                            |> LoggedIn.withAuthentication loggedIn model msg
+                            |> LoggedIn.withAuthentication loggedIn
+                                model
+                                -- TODO - Check this
+                                { successMsg = msg, errorMsg = msg }
 
                     else
                         validatedModel
@@ -733,7 +742,10 @@ update msg model loggedIn =
                                     loggedIn
                                     "updatesale"
                                     (encodeUpdateForm sale form community.symbol)
-                                    |> LoggedIn.withAuthentication loggedIn model msg
+                                    |> LoggedIn.withAuthentication loggedIn
+                                        model
+                                        -- TODO - Check this
+                                        { successMsg = msg, errorMsg = msg }
 
                             else
                                 validatedModel
@@ -810,7 +822,10 @@ update msg model loggedIn =
                         loggedIn
                         "deletesale"
                         (encodeDeleteForm sale)
-                        |> LoggedIn.withAuthentication loggedIn model msg
+                        |> LoggedIn.withAuthentication loggedIn
+                            model
+                            -- TODO - Check this
+                            { successMsg = msg, errorMsg = msg }
 
                 EditingUpdate balances sale (RemoteData.Failure error) _ form ->
                     performRequest
@@ -819,7 +834,10 @@ update msg model loggedIn =
                         loggedIn
                         "deletesale"
                         (encodeDeleteForm sale)
-                        |> LoggedIn.withAuthentication loggedIn model msg
+                        |> LoggedIn.withAuthentication loggedIn
+                            model
+                            -- TODO - Check this
+                            { successMsg = msg, errorMsg = msg }
 
                 EditingUpdate balances sale RemoteData.NotAsked _ form ->
                     performRequest
@@ -828,7 +846,10 @@ update msg model loggedIn =
                         loggedIn
                         "deletesale"
                         (encodeDeleteForm sale)
-                        |> LoggedIn.withAuthentication loggedIn model msg
+                        |> LoggedIn.withAuthentication loggedIn
+                            model
+                            -- TODO - Check this
+                            { successMsg = msg, errorMsg = msg }
 
                 _ ->
                     model

--- a/src/elm/Page/Shop/Editor.elm
+++ b/src/elm/Page/Shop/Editor.elm
@@ -675,115 +675,113 @@ update msg model loggedIn =
                 |> UR.init
 
         ClickedSave ->
-            if LoggedIn.hasPrivateKey loggedIn then
-                let
-                    validatedModel =
-                        model
-                            |> updateForm validateForm
-                in
-                case validatedModel of
-                    EditingCreate balances (RemoteData.Success url) form ->
-                        if isValidForm form then
-                            performRequest
-                                ClickedSave
-                                (Creating balances (RemoteData.Success url) form)
-                                loggedIn
-                                "createsale"
-                                (encodeCreateForm loggedIn form)
+            let
+                validatedModel =
+                    model
+                        |> updateForm validateForm
+            in
+            case validatedModel of
+                EditingCreate balances (RemoteData.Success url) form ->
+                    if isValidForm form then
+                        performRequest
+                            ClickedSave
+                            (Creating balances (RemoteData.Success url) form)
+                            loggedIn
+                            "createsale"
+                            (encodeCreateForm loggedIn form)
+                            |> LoggedIn.withAuthentication loggedIn model msg
 
-                        else
-                            validatedModel
-                                |> UR.init
-
-                    EditingCreate balances (RemoteData.Failure error) form ->
-                        if isValidForm form then
-                            performRequest
-                                ClickedSave
-                                (Creating balances (RemoteData.Failure error) form)
-                                loggedIn
-                                "createsale"
-                                (encodeCreateForm loggedIn form)
-
-                        else
-                            validatedModel
-                                |> UR.init
-
-                    EditingCreate balances RemoteData.NotAsked form ->
-                        if isValidForm form then
-                            performRequest
-                                ClickedSave
-                                (Creating balances RemoteData.NotAsked form)
-                                loggedIn
-                                "createsale"
-                                (encodeCreateForm loggedIn form)
-
-                        else
-                            validatedModel
-                                |> UR.init
-
-                    EditingUpdate balances sale (RemoteData.Success url) _ form ->
-                        case loggedIn.selectedCommunity of
-                            RemoteData.Success community ->
-                                if isValidForm form then
-                                    performRequest
-                                        ClickedSave
-                                        (Saving balances sale (RemoteData.Success url) form)
-                                        loggedIn
-                                        "updatesale"
-                                        (encodeUpdateForm sale form community.symbol)
-
-                                else
-                                    validatedModel
-                                        |> UR.init
-
-                            _ ->
-                                validatedModel |> UR.init
-
-                    EditingUpdate balances sale (RemoteData.Failure error) _ form ->
-                        case loggedIn.selectedCommunity of
-                            RemoteData.Success community ->
-                                if isValidForm form then
-                                    performRequest
-                                        ClickedSave
-                                        (Saving balances sale (RemoteData.Failure error) form)
-                                        loggedIn
-                                        "updatesale"
-                                        (encodeUpdateForm sale form community.symbol)
-
-                                else
-                                    validatedModel
-                                        |> UR.init
-
-                            _ ->
-                                validatedModel |> UR.init
-
-                    EditingUpdate balances sale RemoteData.NotAsked _ form ->
-                        case loggedIn.selectedCommunity of
-                            RemoteData.Success community ->
-                                if isValidForm form then
-                                    performRequest
-                                        ClickedSave
-                                        (Saving balances sale RemoteData.NotAsked form)
-                                        loggedIn
-                                        "updatesale"
-                                        (encodeUpdateForm sale form community.symbol)
-
-                                else
-                                    validatedModel
-                                        |> UR.init
-
-                            _ ->
-                                validatedModel |> UR.init
-
-                    _ ->
+                    else
                         validatedModel
                             |> UR.init
-                            |> UR.logImpossible msg []
 
-            else
-                model
-                    |> UR.init
-                    |> UR.addExt (RequiredAuthentication (Just ClickedSave))
+                EditingCreate balances (RemoteData.Failure error) form ->
+                    if isValidForm form then
+                        performRequest
+                            ClickedSave
+                            (Creating balances (RemoteData.Failure error) form)
+                            loggedIn
+                            "createsale"
+                            (encodeCreateForm loggedIn form)
+                            |> LoggedIn.withAuthentication loggedIn model msg
+
+                    else
+                        validatedModel
+                            |> UR.init
+
+                EditingCreate balances RemoteData.NotAsked form ->
+                    if isValidForm form then
+                        performRequest
+                            ClickedSave
+                            (Creating balances RemoteData.NotAsked form)
+                            loggedIn
+                            "createsale"
+                            (encodeCreateForm loggedIn form)
+                            |> LoggedIn.withAuthentication loggedIn model msg
+
+                    else
+                        validatedModel
+                            |> UR.init
+
+                EditingUpdate balances sale (RemoteData.Success url) _ form ->
+                    case loggedIn.selectedCommunity of
+                        RemoteData.Success community ->
+                            if isValidForm form then
+                                performRequest
+                                    ClickedSave
+                                    (Saving balances sale (RemoteData.Success url) form)
+                                    loggedIn
+                                    "updatesale"
+                                    (encodeUpdateForm sale form community.symbol)
+                                    |> LoggedIn.withAuthentication loggedIn model msg
+
+                            else
+                                validatedModel
+                                    |> UR.init
+
+                        _ ->
+                            validatedModel |> UR.init
+
+                EditingUpdate balances sale (RemoteData.Failure error) _ form ->
+                    case loggedIn.selectedCommunity of
+                        RemoteData.Success community ->
+                            if isValidForm form then
+                                performRequest
+                                    ClickedSave
+                                    (Saving balances sale (RemoteData.Failure error) form)
+                                    loggedIn
+                                    "updatesale"
+                                    (encodeUpdateForm sale form community.symbol)
+
+                            else
+                                validatedModel
+                                    |> UR.init
+
+                        _ ->
+                            validatedModel |> UR.init
+
+                EditingUpdate balances sale RemoteData.NotAsked _ form ->
+                    case loggedIn.selectedCommunity of
+                        RemoteData.Success community ->
+                            if isValidForm form then
+                                performRequest
+                                    ClickedSave
+                                    (Saving balances sale RemoteData.NotAsked form)
+                                    loggedIn
+                                    "updatesale"
+                                    (encodeUpdateForm sale form community.symbol)
+
+                            else
+                                validatedModel
+                                    |> UR.init
+
+                        _ ->
+                            validatedModel |> UR.init
+
+                _ ->
+                    validatedModel
+                        |> UR.init
+                        |> UR.logImpossible msg []
 
         ClickedDelete ->
             case model of
@@ -804,41 +802,38 @@ update msg model loggedIn =
                     UR.init model
 
         ClickedDeleteConfirm ->
-            if LoggedIn.hasPrivateKey loggedIn then
-                case model of
-                    EditingUpdate balances sale (RemoteData.Success url) _ form ->
-                        performRequest
-                            ClickedDeleteConfirm
-                            (Deleting balances sale (RemoteData.Success url) form)
-                            loggedIn
-                            "deletesale"
-                            (encodeDeleteForm sale)
+            case model of
+                EditingUpdate balances sale (RemoteData.Success url) _ form ->
+                    performRequest
+                        ClickedDeleteConfirm
+                        (Deleting balances sale (RemoteData.Success url) form)
+                        loggedIn
+                        "deletesale"
+                        (encodeDeleteForm sale)
+                        |> LoggedIn.withAuthentication loggedIn model msg
 
-                    EditingUpdate balances sale (RemoteData.Failure error) _ form ->
-                        performRequest
-                            ClickedDeleteConfirm
-                            (Deleting balances sale (RemoteData.Failure error) form)
-                            loggedIn
-                            "deletesale"
-                            (encodeDeleteForm sale)
+                EditingUpdate balances sale (RemoteData.Failure error) _ form ->
+                    performRequest
+                        ClickedDeleteConfirm
+                        (Deleting balances sale (RemoteData.Failure error) form)
+                        loggedIn
+                        "deletesale"
+                        (encodeDeleteForm sale)
+                        |> LoggedIn.withAuthentication loggedIn model msg
 
-                    EditingUpdate balances sale RemoteData.NotAsked _ form ->
-                        performRequest
-                            ClickedDeleteConfirm
-                            (Deleting balances sale RemoteData.NotAsked form)
-                            loggedIn
-                            "deletesale"
-                            (encodeDeleteForm sale)
+                EditingUpdate balances sale RemoteData.NotAsked _ form ->
+                    performRequest
+                        ClickedDeleteConfirm
+                        (Deleting balances sale RemoteData.NotAsked form)
+                        loggedIn
+                        "deletesale"
+                        (encodeDeleteForm sale)
+                        |> LoggedIn.withAuthentication loggedIn model msg
 
-                    _ ->
-                        model
-                            |> UR.init
-                            |> UR.logImpossible msg []
-
-            else
-                model
-                    |> UR.init
-                    |> UR.addExt (RequiredAuthentication (Just ClickedDeleteConfirm))
+                _ ->
+                    model
+                        |> UR.init
+                        |> UR.logImpossible msg []
 
         GotSaveResponse (Ok _) ->
             UR.init model

--- a/src/elm/Page/Shop/Editor.elm
+++ b/src/elm/Page/Shop/Editor.elm
@@ -466,6 +466,7 @@ type Msg
     | GotSaveResponse (Result Value String)
     | GotDeleteResponse (Result Value String)
     | PressedEnter Bool
+    | ClosedAuthModal
 
 
 update : Msg -> Model -> LoggedIn.Model -> UpdateResult
@@ -691,8 +692,7 @@ update msg model loggedIn =
                             (encodeCreateForm loggedIn form)
                             |> LoggedIn.withAuthentication loggedIn
                                 model
-                                -- TODO - Check this
-                                { successMsg = msg, errorMsg = msg }
+                                { successMsg = msg, errorMsg = ClosedAuthModal }
 
                     else
                         validatedModel
@@ -708,8 +708,7 @@ update msg model loggedIn =
                             (encodeCreateForm loggedIn form)
                             |> LoggedIn.withAuthentication loggedIn
                                 model
-                                -- TODO - Check this
-                                { successMsg = msg, errorMsg = msg }
+                                { successMsg = msg, errorMsg = ClosedAuthModal }
 
                     else
                         validatedModel
@@ -725,8 +724,7 @@ update msg model loggedIn =
                             (encodeCreateForm loggedIn form)
                             |> LoggedIn.withAuthentication loggedIn
                                 model
-                                -- TODO - Check this
-                                { successMsg = msg, errorMsg = msg }
+                                { successMsg = msg, errorMsg = ClosedAuthModal }
 
                     else
                         validatedModel
@@ -744,8 +742,7 @@ update msg model loggedIn =
                                     (encodeUpdateForm sale form community.symbol)
                                     |> LoggedIn.withAuthentication loggedIn
                                         model
-                                        -- TODO - Check this
-                                        { successMsg = msg, errorMsg = msg }
+                                        { successMsg = msg, errorMsg = ClosedAuthModal }
 
                             else
                                 validatedModel
@@ -764,6 +761,9 @@ update msg model loggedIn =
                                     loggedIn
                                     "updatesale"
                                     (encodeUpdateForm sale form community.symbol)
+                                    |> LoggedIn.withAuthentication loggedIn
+                                        model
+                                        { successMsg = msg, errorMsg = ClosedAuthModal }
 
                             else
                                 validatedModel
@@ -782,6 +782,9 @@ update msg model loggedIn =
                                     loggedIn
                                     "updatesale"
                                     (encodeUpdateForm sale form community.symbol)
+                                    |> LoggedIn.withAuthentication loggedIn
+                                        model
+                                        { successMsg = msg, errorMsg = ClosedAuthModal }
 
                             else
                                 validatedModel
@@ -824,8 +827,7 @@ update msg model loggedIn =
                         (encodeDeleteForm sale)
                         |> LoggedIn.withAuthentication loggedIn
                             model
-                            -- TODO - Check this
-                            { successMsg = msg, errorMsg = msg }
+                            { successMsg = msg, errorMsg = ClosedAuthModal }
 
                 EditingUpdate balances sale (RemoteData.Failure error) _ form ->
                     performRequest
@@ -836,8 +838,7 @@ update msg model loggedIn =
                         (encodeDeleteForm sale)
                         |> LoggedIn.withAuthentication loggedIn
                             model
-                            -- TODO - Check this
-                            { successMsg = msg, errorMsg = msg }
+                            { successMsg = msg, errorMsg = ClosedAuthModal }
 
                 EditingUpdate balances sale RemoteData.NotAsked _ form ->
                     performRequest
@@ -848,8 +849,7 @@ update msg model loggedIn =
                         (encodeDeleteForm sale)
                         |> LoggedIn.withAuthentication loggedIn
                             model
-                            -- TODO - Check this
-                            { successMsg = msg, errorMsg = msg }
+                            { successMsg = msg, errorMsg = ClosedAuthModal }
 
                 _ ->
                     model
@@ -934,6 +934,15 @@ update msg model loggedIn =
 
             else
                 UR.init model
+
+        ClosedAuthModal ->
+            case model of
+                EditingUpdate balances sale imageStatus _ form ->
+                    EditingUpdate balances sale imageStatus Closed form
+                        |> UR.init
+
+                _ ->
+                    UR.init model
 
 
 performRequest : Msg -> Status -> LoggedIn.Model -> String -> Value -> UpdateResult
@@ -1221,3 +1230,6 @@ msgToString msg =
 
         PressedEnter _ ->
             [ "PressedEnter" ]
+
+        ClosedAuthModal ->
+            [ "ClosedAuthModal" ]

--- a/src/elm/Page/Shop/Viewer.elm
+++ b/src/elm/Page/Shop/Viewer.elm
@@ -299,7 +299,10 @@ update msg model loggedIn =
                                   }
                                 ]
                         }
-                    |> LoggedIn.withAuthentication loggedIn model msg
+                    |> LoggedIn.withAuthentication loggedIn
+                        model
+                        -- TODO - Check this
+                        { successMsg = msg, errorMsg = msg }
 
             else
                 { model | form = validatedForm }

--- a/src/elm/Page/Shop/Viewer.elm
+++ b/src/elm/Page/Shop/Viewer.elm
@@ -157,6 +157,7 @@ type Validation
 
 type Msg
     = Ignored
+    | ClosedAuthModal
     | CompletedSaleLoad (RemoteData (Graphql.Http.Error (Maybe Product)) (Maybe Product))
     | CompletedLoadBalances (Result Http.Error (List Balance))
     | ClickedBuy
@@ -179,6 +180,9 @@ update msg model loggedIn =
     in
     case msg of
         Ignored ->
+            UR.init model
+
+        ClosedAuthModal ->
             UR.init model
 
         CompletedSaleLoad (RemoteData.Success maybeSale) ->
@@ -301,8 +305,7 @@ update msg model loggedIn =
                         }
                     |> LoggedIn.withAuthentication loggedIn
                         model
-                        -- TODO - Check this
-                        { successMsg = msg, errorMsg = msg }
+                        { successMsg = msg, errorMsg = ClosedAuthModal }
 
             else
                 { model | form = validatedForm }
@@ -757,6 +760,9 @@ msgToString msg =
     case msg of
         Ignored ->
             [ "Ignored" ]
+
+        ClosedAuthModal ->
+            [ "ClosedAuthModal" ]
 
         CompletedSaleLoad _ ->
             [ "CompletedSaleLoad" ]

--- a/src/elm/Page/Shop/Viewer.elm
+++ b/src/elm/Page/Shop/Viewer.elm
@@ -243,68 +243,63 @@ update msg model loggedIn =
                     validateForm sale model.form
             in
             if isFormValid validatedForm then
-                if LoggedIn.hasPrivateKey loggedIn then
-                    let
-                        authorization =
-                            { actor = loggedIn.accountName
-                            , permissionName = Eos.samplePermission
-                            }
+                let
+                    authorization =
+                        { actor = loggedIn.accountName
+                        , permissionName = Eos.samplePermission
+                        }
 
-                        requiredUnits =
-                            case String.toInt model.form.units of
-                                Just rU ->
-                                    rU
+                    requiredUnits =
+                        case String.toInt model.form.units of
+                            Just rU ->
+                                rU
 
-                                Nothing ->
-                                    1
+                            Nothing ->
+                                1
 
-                        value =
-                            { amount = sale.price * toFloat requiredUnits
-                            , symbol = sale.symbol
-                            }
+                    value =
+                        { amount = sale.price * toFloat requiredUnits
+                        , symbol = sale.symbol
+                        }
 
-                        unitPrice =
-                            { amount = sale.price
-                            , symbol = sale.symbol
-                            }
-                    in
-                    model
-                        |> UR.init
-                        |> UR.addPort
-                            { responseAddress = ClickedTransfer sale
-                            , responseData = Encode.null
-                            , data =
-                                Eos.encodeTransaction
-                                    [ { accountName = loggedIn.shared.contracts.token
-                                      , name = "transfer"
-                                      , authorization = authorization
-                                      , data =
-                                            { from = loggedIn.accountName
-                                            , to = sale.creatorId
-                                            , value = value
-                                            , memo = model.form.memo
-                                            }
-                                                |> Transfer.encodeEosActionData
-                                      }
-                                    , { accountName = loggedIn.shared.contracts.community
-                                      , name = "transfersale"
-                                      , authorization = authorization
-                                      , data =
-                                            { id = sale.id
-                                            , from = loggedIn.accountName
-                                            , to = sale.creatorId
-                                            , quantity = unitPrice
-                                            , units = requiredUnits
-                                            }
-                                                |> Shop.encodeTransferSale
-                                      }
-                                    ]
-                            }
-
-                else
-                    model
-                        |> UR.init
-                        |> UR.addExt (Just (ClickedTransfer sale) |> RequiredAuthentication)
+                    unitPrice =
+                        { amount = sale.price
+                        , symbol = sale.symbol
+                        }
+                in
+                model
+                    |> UR.init
+                    |> UR.addPort
+                        { responseAddress = ClickedTransfer sale
+                        , responseData = Encode.null
+                        , data =
+                            Eos.encodeTransaction
+                                [ { accountName = loggedIn.shared.contracts.token
+                                  , name = "transfer"
+                                  , authorization = authorization
+                                  , data =
+                                        { from = loggedIn.accountName
+                                        , to = sale.creatorId
+                                        , value = value
+                                        , memo = model.form.memo
+                                        }
+                                            |> Transfer.encodeEosActionData
+                                  }
+                                , { accountName = loggedIn.shared.contracts.community
+                                  , name = "transfersale"
+                                  , authorization = authorization
+                                  , data =
+                                        { id = sale.id
+                                        , from = loggedIn.accountName
+                                        , to = sale.creatorId
+                                        , quantity = unitPrice
+                                        , units = requiredUnits
+                                        }
+                                            |> Shop.encodeTransferSale
+                                  }
+                                ]
+                        }
+                    |> LoggedIn.withAuthentication loggedIn model msg
 
             else
                 { model | form = validatedForm }

--- a/src/elm/Session/LoggedIn.elm
+++ b/src/elm/Session/LoggedIn.elm
@@ -724,7 +724,7 @@ type External msg
     | CreatedCommunity Eos.Symbol String
     | ExternalBroadcast BroadcastMsg
     | ReloadResource Resource
-    | RequiredAuthentication msg
+    | RequiredAuthentication { successMsg : msg, errorMsg : msg }
     | ShowFeedback Feedback.Status String
     | HideFeedback
 
@@ -743,7 +743,7 @@ updateExternal :
         , cmd : Cmd Msg
         , externalCmd : Cmd msg
         , broadcastMsg : Maybe BroadcastMsg
-        , afterAuthMsg : Maybe msg
+        , afterAuthMsg : Maybe { successMsg : msg, errorMsg : msg }
         }
 updateExternal externalMsg ({ shared } as model) =
     let
@@ -849,6 +849,7 @@ type alias UpdateResult =
 -}
 type ExternalMsg
     = AuthenticationSucceed
+    | AuthenticationFailed
     | Broadcast BroadcastMsg
 
 
@@ -1067,6 +1068,7 @@ update msg model =
 
         ClosedAuthModal ->
             UR.init closeAllModals
+                |> UR.addExt AuthenticationFailed
 
         GotAuthMsg authMsg ->
             Auth.update authMsg shared model.auth
@@ -1225,7 +1227,7 @@ again
 withAuthentication :
     Model
     -> subModel
-    -> subMsg
+    -> { successMsg : subMsg, errorMsg : subMsg }
     -> UR.UpdateResult subModel subMsg (External subMsg)
     -> UR.UpdateResult subModel subMsg (External subMsg)
 withAuthentication loggedIn subModel subMsg successfulUR =

--- a/src/elm/Session/LoggedIn.elm
+++ b/src/elm/Session/LoggedIn.elm
@@ -6,7 +6,6 @@ module Session.LoggedIn exposing
     , Msg(..)
     , Page(..)
     , Resource(..)
-    , hasPrivateKey
     , init
     , initLogin
     , isAccount

--- a/src/elm/Session/LoggedIn.elm
+++ b/src/elm/Session/LoggedIn.elm
@@ -19,6 +19,7 @@ module Session.LoggedIn exposing
     , update
     , updateExternal
     , view
+    , withAuthentication
     )
 
 import Action
@@ -1215,6 +1216,21 @@ handleActionMsg ({ shared } as model) actionMsg =
 
         _ ->
             UR.init model
+
+
+withAuthentication :
+    Model
+    -> subModel
+    -> subMsg
+    -> UR.UpdateResult subModel subMsg (External subMsg)
+    -> UR.UpdateResult subModel subMsg (External subMsg)
+withAuthentication loggedIn subModel subMsg successfulUR =
+    if hasPrivateKey loggedIn then
+        successfulUR
+
+    else
+        UR.init subModel
+            |> UR.addExt (Just subMsg |> RequiredAuthentication)
 
 
 isCommunityMember : Model -> Bool


### PR DESCRIPTION
## What issue does this PR close
Closes #529 

## Changes Proposed ( a list of new changes introduced by this PR)
- Add a reliable way of requiring authentication (`LoggedIn.withAuthentication`) which enforces the need of a msg to handle the case where the user closes the auth modal
- Use it instead of directly using `LoggedIn.RequiredAuthentication` and `LoggedIn.hasPrivateKey`
- Pages that were forever in a loading state after the user closed the authentication modal shouldn't be like that anymore

## How to test ( a list of instructions on how to test this PR)
Follow the steps described in #529. Here's the list of all affected pages:
- Action Editor (`/community/objectives/:objective_id/action/new` and `/community/objectives/:objective_id/action/:action_id/edit`)
- Objective Editor (`/community/objectives/:objective_id/edit` and `/community/objectives/new`)
- New Community (`/community/new`)
- Community Currency (`/community/settings/currency`)
- Community Features (`/community/settings/features`)
- Community Info (`/community/settings/info`)
- Transfer (`/community/transfer`)
- Dashboard (`/dashboard`) (when voting on a claim)
- Analysis (`/analysis`) (when voting on a claim)
- Claim (`/objectives/:objective_id/action/:action_id/claim/:claim_id`) (when voting on the claim)
- My Claims (`/profile/henriquebuss/claims`) (when voting on a claim)
- Profile (`/profile`) (when changing PIN or downloading 12 words)
- Shop Editor (`/shop/new/sell` and `/shop/:sale_id/edit`)
- Shop Viewer (`/shop/:sale_id`) (when buying something)