### PR TITLE
Enhancement/redirect to welcome page

### DIFF
--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -765,8 +765,8 @@ statusToRoute status session =
         CommunitySettingsCurrency _ ->
             Just Route.CommunitySettingsCurrency
 
-        CommunitySelector _ ->
-            Just Route.CommunitySelector
+        CommunitySelector subModel ->
+            Just (Route.CommunitySelector subModel.maybeRedirect)
 
         Objectives _ ->
             Just Route.Objectives
@@ -1099,10 +1099,10 @@ changeRouteTo maybeRoute model =
                 >> updateStatusWith CommunitySettingsCurrency GotCommunitySettingsCurrencyMsg model
                 |> withLoggedIn Route.CommunitySettingsCurrency
 
-        Just Route.CommunitySelector ->
-            CommunitySelector.init
+        Just (Route.CommunitySelector maybeRedirect) ->
+            CommunitySelector.init maybeRedirect
                 >> updateStatusWith CommunitySelector (\_ -> Ignored) model
-                |> withLoggedIn Route.CommunitySelector
+                |> withLoggedIn (Route.CommunitySelector maybeRedirect)
 
         Just Route.NewCommunity ->
             CommunityEditor.init

--- a/src/elm/Page/Community/Selector.elm
+++ b/src/elm/Page/Community/Selector.elm
@@ -16,12 +16,12 @@ import Session.Shared exposing (Shared)
 
 
 type alias Model =
-    {}
+    { maybeRedirect : Maybe Route.Route }
 
 
-init : LoggedIn.Model -> ( Model, Cmd msg )
-init _ =
-    ( {}
+init : Maybe Route.Route -> LoggedIn.Model -> ( Model, Cmd msg )
+init maybeRedirect _ =
+    ( { maybeRedirect = maybeRedirect }
     , Cmd.none
     )
 
@@ -32,7 +32,7 @@ init _ =
 
 
 view : LoggedIn.Model -> Model -> { title : String, content : Html msg }
-view loggedIn _ =
+view loggedIn model =
     let
         title =
             "Select community"
@@ -49,15 +49,15 @@ view loggedIn _ =
                     Page.fullPageGraphQLError title err
 
                 RemoteData.Success profile ->
-                    view_ loggedIn.shared profile
+                    view_ loggedIn.shared model profile
     in
     { title = title
     , content = content
     }
 
 
-view_ : Shared -> Profile.Model -> Html msg
-view_ shared profile =
+view_ : Shared -> Model -> Profile.Model -> Html msg
+view_ shared model profile =
     div [ class "flex-grow flex flex-col" ]
         [ div [ class "flex flex-col items-center" ]
             [ img [ src "/images/map.svg" ] []
@@ -66,16 +66,16 @@ view_ shared profile =
             ]
         , div [ class "bg-white flex-grow mt-8" ]
             [ div [ class "container mx-auto px-4 divide-y divide-solid divide-gray-500" ]
-                (List.map (viewCommunity shared) profile.communities)
+                (List.map (viewCommunity shared model) profile.communities)
             ]
         ]
 
 
-viewCommunity : Shared -> Profile.CommunityInfo -> Html msg
-viewCommunity shared community =
+viewCommunity : Shared -> Model -> Profile.CommunityInfo -> Html msg
+viewCommunity shared model community =
     a
         [ class "flex justify-between items-center py-6 text-black hover:text-orange-300"
-        , Route.externalHref shared community Route.Dashboard
+        , Route.externalHref shared community (model.maybeRedirect |> Maybe.withDefault Route.Dashboard)
         ]
         [ div [ class "flex items-center" ]
             [ img

--- a/src/elm/Route.elm
+++ b/src/elm/Route.elm
@@ -42,7 +42,7 @@ type Route
     | CommunitySettingsFeatures
     | CommunitySettingsInfo
     | CommunitySettingsCurrency
-    | CommunitySelector
+    | CommunitySelector (Maybe Route)
     | Objectives
     | NewObjective
     | EditObjective Int
@@ -107,7 +107,13 @@ parser url =
         , Url.map CommunitySettingsFeatures (s "community" </> s "settings" </> s "features")
         , Url.map CommunitySettingsInfo (s "community" </> s "settings" </> s "info")
         , Url.map CommunitySettingsCurrency (s "community" </> s "settings" </> s "currency")
-        , Url.map CommunitySelector (s "community" </> s "selector")
+        , Url.map CommunitySelector
+            (s "community"
+                </> s "selector"
+                <?> Query.map
+                        (parseRedirect url)
+                        (Query.string "redirect")
+            )
         , Url.map Objectives (s "community" </> s "objectives")
         , Url.map NewObjective (s "community" </> s "objectives" </> s "new")
         , Url.map EditObjective (s "community" </> s "objectives" </> int </> s "edit")
@@ -391,8 +397,10 @@ routeToString route =
                 CommunitySettingsCurrency ->
                     ( [ "community", "settings", "currency" ], [] )
 
-                CommunitySelector ->
-                    ( [ "community", "selector" ], [] )
+                CommunitySelector maybeRedirect ->
+                    ( [ "community", "selector" ]
+                    , queryBuilder routeToString maybeRedirect "redirect"
+                    )
 
                 NewCommunity ->
                     ( [ "community", "new" ], [] )

--- a/src/elm/Session/Guest.elm
+++ b/src/elm/Session/Guest.elm
@@ -333,8 +333,11 @@ update msg ({ shared } as model) =
                 { currentUrl | host = "cambiatus.staging.localhost" }
                     |> Url.toString
 
+            else if String.endsWith "demo.cambiatus.io" (Url.toString currentUrl) then
+                "https://www.cambiatus.com/welcome-demo"
+
             else
-                "https://cambiatus.com"
+                "https://www.cambiatus.com/welcome"
     in
     case msg of
         CompletedLoadTranslation lang (Ok transl) ->

--- a/src/elm/Session/LoggedIn.elm
+++ b/src/elm/Session/LoggedIn.elm
@@ -1145,7 +1145,11 @@ update msg model =
                     else
                         let
                             ( newModel, cmd ) =
-                                selectCommunity model newCommunity Route.Dashboard
+                                selectCommunity model
+                                    newCommunity
+                                    (List.head model.routeHistory
+                                        |> Maybe.withDefault Route.Dashboard
+                                    )
                         in
                         UR.init { newModel | showCommunitySelector = False }
                             |> UR.addCmd cmd

--- a/src/elm/Session/LoggedIn.elm
+++ b/src/elm/Session/LoggedIn.elm
@@ -1006,7 +1006,7 @@ update msg model =
 
         CompletedLoadCommunity (RemoteData.Success Nothing) ->
             UR.init model
-                |> UR.addCmd (Route.pushUrl shared.navKey Route.CommunitySelector)
+                |> UR.addCmd (Route.pushUrl shared.navKey (Route.CommunitySelector (List.head model.routeHistory)))
 
         CompletedLoadCommunity (RemoteData.Failure e) ->
             let
@@ -1019,7 +1019,7 @@ update msg model =
                         identity
 
                     else
-                        UR.addCmd (Route.pushUrl shared.navKey Route.CommunitySelector)
+                        UR.addCmd (Route.pushUrl shared.navKey (Route.CommunitySelector (List.head model.routeHistory)))
                    )
 
         CompletedLoadCommunity RemoteData.NotAsked ->
@@ -1299,7 +1299,7 @@ setCommunity community ({ shared } as model) =
 
     else
         ( { model | selectedCommunity = RemoteData.Success community, shared = sharedWithCommunity }
-        , Cmd.batch [ Route.pushUrl shared.navKey Route.CommunitySelector, storeCommunityCmd ]
+        , Cmd.batch [ Route.pushUrl shared.navKey (Route.CommunitySelector (List.head model.routeHistory)), storeCommunityCmd ]
         )
 
 


### PR DESCRIPTION
## What issue does this PR close
Closes #571 

## Changes Proposed ( a list of new changes introduced by this PR)
- Add redirect query parameter to `/community/selector`, so that users can change communities and stay on the same page
- Community selector modal now redirects to the same page the user is in, but in another community
- If a `Guest` tries to access a community that doesn't exist, they're redirected to the welcome page (https://www.cambiatus.com/welcome or https://www.cambiatus.com/welcome-demo)

## How to test ( a list of instructions on how to test this PR)
Testing the redirection on `/community/selector`:
1. Log in to a community
2. Now try going to a community that doesn't exist, in a specific page (e.g. https://thisisntacommunity.staging.cambiatus.io/shop)
3. You should be redirected to `/community/selector`
4. Choose a community
5. You should land in the community you chose, in the page you chose (`/shop`)

Testing the redirection on the community selector modal:
1. Log in to a community
2. Go to some page (e.g. `/shop`)
3. Click on the community selector icon on the top left
4. Choose another community
5. Be redirected to that community, on the page you chose (`/shop`)

Testing the redirection to the welcome page:
Since this depends on the URL, we could only test this if it was deployed on demo :slightly_frowning_face:, so look through the code and see if it makes sense