### PR TITLE
Fix detection for when user is in demo

### DIFF
--- a/src/elm/Session/Guest.elm
+++ b/src/elm/Session/Guest.elm
@@ -333,7 +333,7 @@ update msg ({ shared } as model) =
                 { currentUrl | host = "cambiatus.staging.localhost" }
                     |> Url.toString
 
-            else if String.endsWith "demo.cambiatus.io" (Url.toString currentUrl) then
+            else if String.endsWith "demo.cambiatus.io" currentUrl.host then
                 "https://www.cambiatus.com/welcome-demo"
 
             else


### PR DESCRIPTION
## What issue does this PR close
Closes N/A

## Changes Proposed ( a list of new changes introduced by this PR)
- How we detect if we're on demo

## How to test ( a list of instructions on how to test this PR)
This is deployed on demo, so you can test it like so:
1. If you're already logged in on demo, log out
2. Try to go to a community that doesn't exist (e.g. https://thisisntacommunity.demo.cambiatus.io)
3. Be redirected to https://www.cambiatus.com/welcome-demo