### PR TITLE
Fix/join with invitation

### DIFF
--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -641,15 +641,24 @@ updateGuestUResult toStatus toMsg model uResult =
 
                                 ( session, cmd ) =
                                     LoggedIn.initLogin shared (Just privateKey) userWithCommunity token
+
+                                redirectRoute =
+                                    case guest.afterLoginRedirect of
+                                        Just (Route.Invite _) ->
+                                            Route.Dashboard
+
+                                        Just route ->
+                                            route
+
+                                        Nothing ->
+                                            Route.Dashboard
                             in
                             ( { m
                                 | session =
                                     Page.LoggedIn session
                               }
                             , Cmd.map (Page.GotLoggedInMsg >> GotPageMsg) cmd
-                                :: (Maybe.withDefault Route.Dashboard guest.afterLoginRedirect
-                                        |> Route.pushUrl guest.shared.navKey
-                                   )
+                                :: Route.pushUrl guest.shared.navKey redirectRoute
                                 :: cmds_
                             )
 

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -1015,7 +1015,7 @@ changeRouteTo maybeRoute model =
                         Route.replaceUrl shared.navKey (Route.Join (Just route))
                     )
 
-        withSession : Route -> (Page.Session -> ( Model, Cmd Msg )) -> ( Model, Cmd Msg )
+        withSession : Route -> (Session -> ( Model, Cmd Msg )) -> ( Model, Cmd Msg )
         withSession route fn =
             let
                 ( newModel, newCmd ) =

--- a/src/elm/Page/Community/Invite.elm
+++ b/src/elm/Page/Community/Invite.elm
@@ -522,11 +522,25 @@ update session msg model =
                             , hasActions = community.hasObjectives
                             , hasKyc = community.hasKyc
                             }
+
+                        navKey =
+                            Page.toShared session
+                                |> .navKey
+
+                        redirectRoute =
+                            case session of
+                                LoggedIn _ ->
+                                    Route.Dashboard
+
+                                Guest guest ->
+                                    guest.afterLoginRedirect
+                                        |> Maybe.withDefault Route.Dashboard
                     in
                     model
                         |> UR.init
                         |> UR.addExt ({ loggedIn | authToken = token } |> LoggedIn.UpdatedLoggedIn)
                         |> UR.addExt (LoggedIn.AddedCommunity communityInfo)
+                        |> UR.addCmd (Route.pushUrl navKey redirectRoute)
 
                 Nothing ->
                     model

--- a/src/elm/Page/Community/Invite.elm
+++ b/src/elm/Page/Community/Invite.elm
@@ -524,7 +524,7 @@ update session msg model =
                             }
 
                         navKey =
-                            Page.toShared session
+                            toShared session
                                 |> .navKey
 
                         redirectRoute =


### PR DESCRIPTION
## What issue does this PR close
Closes #590 

## Changes Proposed ( a list of new changes introduced by this PR)
- After a user signs up through an invite link, redirect them directly to the dashboard instead of back to the invite page
- Make it easier to have a page that can be accessed either by a logged in user or a guest user
- Prevent user being redirected to the community selector when they follow an invitation link

## How to test ( a list of instructions on how to test this PR)
1. Log into a community
2. Follow an invite link for a community that only allows for invited users and that you're not a part of (you can use http://test.staging.cambiatus.io/invite/Zrdow9)
2. See invitation page, where you can choose to join the community, in which case you should be redirected to the dashboard