### PR TITLE
Remove char max len. in action description & photo instruction

### DIFF
--- a/src/elm/Claim.elm
+++ b/src/elm/Claim.elm
@@ -458,7 +458,7 @@ viewClaimCard loggedIn profileSummaries claim =
                         text ""
                 ]
             , div [ class "mb-6" ]
-                [ p [ class "text-body overflow-ellipsis overflow-hidden mb-2" ]
+                [ p [ class "text-body truncate mb-2" ]
                     [ text claim.action.description ]
                 , div [ class "flex w-full" ]
                     [ p

--- a/src/elm/Page/Community.elm
+++ b/src/elm/Page/Community.elm
@@ -243,6 +243,29 @@ viewObjective loggedIn model metadata index objective =
             else
                 " "
 
+        objDescCharCount =
+            String.length objective.description
+
+        objDivStyle =
+            let
+                objMainClass =
+                    "px-3 py-4 bg-indigo-500 flex flex-col sm:flex-row sm:items-center cursor-pointer"
+            in
+            if isOpen && objDescCharCount > 40 then
+                class (objMainClass ++ "sm:h-auto")
+
+            else
+                class (objMainClass ++ "sm:h-10")
+
+        objTextStyle =
+            class
+                (if isOpen then
+                    "text-white font-medium text-sm sm:flex-grow-8 sm:leading-normal sm:text-lg"
+
+                 else
+                    "truncate overflow-hidden whitespace-nowrap text-white font-medium text-sm overflow-hidden sm:flex-grow-8 sm:leading-normal sm:text-lg"
+                )
+
         isDisabled =
             case loggedIn.claimingAction.status of
                 Action.ClaimInProgress _ _ ->
@@ -270,7 +293,7 @@ viewObjective loggedIn model metadata index objective =
     else
         div [ class "my-2" ]
             [ div
-                [ class "px-3 py-4 bg-indigo-500 flex flex-col sm:flex-row sm:items-center sm:h-10 cursor-pointer"
+                [ objDivStyle
                 , if isOpen then
                     onClick ClickedCloseObjective
 
@@ -279,7 +302,7 @@ viewObjective loggedIn model metadata index objective =
                 ]
                 [ div [ class "sm:flex-grow-7 sm:w-5/12" ]
                     [ div
-                        [ class "truncate overflow-hidden whitespace-nowrap text-white font-medium text-sm overflow-hidden sm:flex-grow-8 sm:leading-normal sm:text-lg"
+                        [ objTextStyle
                         ]
                         [ text objective.description ]
                     ]

--- a/src/elm/Page/Community.elm
+++ b/src/elm/Page/Community.elm
@@ -243,9 +243,6 @@ viewObjective loggedIn model metadata index objective =
             else
                 " "
 
-        objectiveDescriptionCharCount =
-            String.length objective.description
-
         isDisabled =
             case loggedIn.claimingAction.status of
                 Action.ClaimInProgress _ _ ->
@@ -273,22 +270,28 @@ viewObjective loggedIn model metadata index objective =
     else
         div [ class "my-2" ]
             [ div
-                [ class "px-3 py-4 bg-indigo-500 flex flex-col sm:flex-row sm:items-center cursor-pointer"
-                , classList [ ( "sm:h-auto", isOpen && objectiveDescriptionCharCount > 40 ), ( "sm:h-10", not isOpen || objectiveDescriptionCharCount < 40 ) ]
+                [ class "px-3 bg-indigo-500 flex flex-col sm:flex-row sm:items-center cursor-pointer"
+                , classList [ ( "py-4 sm:h-10", not isOpen ) ]
                 , if isOpen then
                     onClick ClickedCloseObjective
 
                   else
                     onClick (ClickedOpenObjective index)
                 ]
-                [ div [ class "sm:flex-grow-7 sm:w-5/12" ]
+                [ div
+                    [ class "sm:flex-grow-7 sm:w-5/12"
+                    , classList [ ( "my-4 sm:my-2", isOpen ) ]
+                    ]
                     [ div
-                        [ class "text-white font-medium text-sm sm:flex-grow-8 sm:leading-normal sm:text-lg"
+                        [ class "text-white font-medium text-sm sm:flex-grow-8 sm:leading-6 sm:text-lg"
                         , classList [ ( "truncate", not isOpen ) ]
                         ]
                         [ text objective.description ]
                     ]
-                , div [ class ("flex flex-row justify-end mt-5 sm:mt-0" ++ arrowStyle) ]
+                , div
+                    [ class ("flex flex-row justify-end" ++ arrowStyle)
+                    , classList [ ( "mt-1 sm:mt-0 pb-4 sm:pb-0", isOpen ), ( "mt-5 sm:mt-0", not isOpen ) ]
+                    ]
                     [ button
                         [ class ""
                         , if isOpen then

--- a/src/elm/Page/Community.elm
+++ b/src/elm/Page/Community.elm
@@ -243,28 +243,8 @@ viewObjective loggedIn model metadata index objective =
             else
                 " "
 
-        objDescCharCount =
+        objectiveDescriptionCharCount =
             String.length objective.description
-
-        objDivStyle =
-            let
-                objMainClass =
-                    "px-3 py-4 bg-indigo-500 flex flex-col sm:flex-row sm:items-center cursor-pointer"
-            in
-            if isOpen && objDescCharCount > 40 then
-                class (objMainClass ++ "sm:h-auto")
-
-            else
-                class (objMainClass ++ "sm:h-10")
-
-        objTextStyle =
-            class
-                (if isOpen then
-                    "text-white font-medium text-sm sm:flex-grow-8 sm:leading-normal sm:text-lg"
-
-                 else
-                    "truncate overflow-hidden whitespace-nowrap text-white font-medium text-sm overflow-hidden sm:flex-grow-8 sm:leading-normal sm:text-lg"
-                )
 
         isDisabled =
             case loggedIn.claimingAction.status of
@@ -293,7 +273,8 @@ viewObjective loggedIn model metadata index objective =
     else
         div [ class "my-2" ]
             [ div
-                [ objDivStyle
+                [ class "px-3 py-4 bg-indigo-500 flex flex-col sm:flex-row sm:items-center cursor-pointer"
+                , classList [ ( "sm:h-auto", isOpen && objectiveDescriptionCharCount > 40 ), ( "sm:h-10", not isOpen || objectiveDescriptionCharCount < 40 ) ]
                 , if isOpen then
                     onClick ClickedCloseObjective
 
@@ -302,7 +283,8 @@ viewObjective loggedIn model metadata index objective =
                 ]
                 [ div [ class "sm:flex-grow-7 sm:w-5/12" ]
                     [ div
-                        [ objTextStyle
+                        [ class "text-white font-medium text-sm sm:flex-grow-8 sm:leading-normal sm:text-lg"
+                        , classList [ ( "truncate", not isOpen ) ]
                         ]
                         [ text objective.description ]
                     ]

--- a/src/elm/Page/Community/ActionEditor.elm
+++ b/src/elm/Page/Community/ActionEditor.elm
@@ -26,7 +26,6 @@ import DataValidator
         , listErrors
         , longerThan
         , newValidator
-        , shorterThan
         , updateInput
         , validate
         )
@@ -57,7 +56,6 @@ import View.Feedback as Feedback
 import View.Form
 import View.Form.Checkbox as Checkbox
 import View.Form.Input as Input
-import View.Form.InputCounter
 import View.Form.Radio as Radio
 import View.Form.Toggle as Toggle
 
@@ -269,7 +267,6 @@ defaultDescription : Validator String
 defaultDescription =
     []
         |> longerThan 10
-        |> shorterThan 256
         |> newValidator "" (\v -> Just v) True
 
 
@@ -277,7 +274,6 @@ defaultInstructions : Validator String
 defaultInstructions =
     []
         |> longerThan 10
-        |> shorterThan 256
         |> newValidator "" (\v -> Just v) True
 
 
@@ -665,35 +661,19 @@ update msg model ({ shared } as loggedIn) =
                 |> UR.addCmd cmd
 
         EnteredDescription val ->
-            let
-                limitedDescription =
-                    if String.length val < 255 then
-                        val
-
-                    else
-                        String.slice 0 255 val
-            in
             { model
                 | form =
                     { oldForm
-                        | description = updateInput limitedDescription model.form.description
+                        | description = updateInput val model.form.description
                     }
             }
                 |> UR.init
 
         EnteredInstructions val ->
-            let
-                limitedInstructions =
-                    if String.length val < 255 then
-                        val
-
-                    else
-                        String.slice 0 255 val
-            in
             { model
                 | form =
                     { oldForm
-                        | instructions = updateInput limitedInstructions model.form.instructions
+                        | instructions = updateInput val model.form.instructions
                     }
             }
                 |> UR.init
@@ -1348,7 +1328,6 @@ viewDescription { shared } form =
             , value (getInput form.description)
             ]
             []
-        , View.Form.InputCounter.view shared.translators.tr 256 (getInput form.description)
         , viewFieldErrors (listErrors shared.translations form.description)
         ]
 
@@ -1714,7 +1693,6 @@ viewManualVerificationForm ({ shared } as loggedIn) model community =
                                     , value (getInput model.form.instructions)
                                     ]
                                     []
-                                , View.Form.InputCounter.view shared.translators.tr 256 (getInput model.form.instructions)
                                 , viewFieldErrors (listErrors shared.translations model.form.instructions)
                                 ]
                             ]

--- a/src/elm/Page/Community/ObjectiveEditor.elm
+++ b/src/elm/Page/Community/ObjectiveEditor.elm
@@ -12,7 +12,7 @@ import Graphql.Http
 import Graphql.Operation exposing (RootMutation)
 import Graphql.SelectionSet as SelectionSet exposing (SelectionSet, with)
 import Html exposing (Html, button, div, span, text, textarea)
-import Html.Attributes exposing (class, disabled, maxlength, placeholder, required, rows, style, type_, value)
+import Html.Attributes exposing (class, disabled, placeholder, required, rows, style, type_, value)
 import Html.Events exposing (onClick, onInput)
 import Json.Decode as Decode
 import Json.Encode as Encode exposing (Value)
@@ -249,7 +249,6 @@ viewForm { shared } formStatus =
                     , onInput EnteredDescription
                     , value objForm.description
                     , required True
-                    , maxlength 254
                     , placeholder (t "community.objectives.editor.description_placeholder")
                     ]
                     []

--- a/src/elm/Page/Community/Objectives.elm
+++ b/src/elm/Page/Community/Objectives.elm
@@ -147,8 +147,12 @@ viewObjective ({ shared } as loggedIn) model community index objective =
                 , classList [ ( "pb-0", isOpen ) ]
                 , onClick (OpenObjective index)
                 ]
-                [ div []
-                    [ p [ class "text-sm" ] [ text objective.description ]
+                [ div [ class "overflow-hidden" ]
+                    [ p
+                        [ class "text-sm"
+                        , classList [ ( "truncate", not isOpen ) ]
+                        ]
+                        [ text objective.description ]
                     , p [ class "text-gray-900 text-caption uppercase mt-2" ]
                         [ text
                             (shared.translators.tr
@@ -238,7 +242,7 @@ viewAction ({ shared } as loggedIn) model objectiveId action =
     div [ class "flex flex-wrap sm:flex-nowrap mt-8 mb-4 relative bg-purple-500 rounded-lg px-4 py-5" ]
         [ div [ class "absolute top-0 left-0 right-0 -mt-6" ] [ Icons.flag "w-full fill-current text-green" ]
         , div [ class "w-full" ]
-            [ p [ class "text-white" ] [ text action.description ]
+            [ p [ class "text-white truncate" ] [ text action.description ]
             , div [ class "flex flex-wrap my-6 -mx-2 items-center" ]
                 [ div [ class "mx-2 mb-2 text-white" ]
                     [ p [ class "input-label" ]

--- a/src/elm/Page/Shop/Editor.elm
+++ b/src/elm/Page/Shop/Editor.elm
@@ -20,7 +20,7 @@ import Eos.Account as Eos
 import File exposing (File)
 import Graphql.Http
 import Html exposing (Html, button, div, p, span, text)
-import Html.Attributes exposing (class, disabled, id, maxlength, required, rows, value)
+import Html.Attributes exposing (class, disabled, id, maxlength, required, value)
 import Html.Events exposing (onClick)
 import Http
 import Json.Decode as Decode
@@ -329,8 +329,7 @@ viewForm ({ shared } as loggedIn) imageStatus isEdit isDisabled deleteModal form
                     , problems = listErrors shared.translations form.description |> Just
                     , translators = shared.translators
                     }
-                    |> Input.withAttrs [ maxlength 255, required True, rows 5 ]
-                    |> Input.withCounter 255
+                    |> Input.withAttrs [ required True ]
                     |> Input.withInputType Input.TextArea
                     |> Input.toHtml
                 , Select.init
@@ -624,16 +623,12 @@ update msg model loggedIn =
                 |> UR.init
 
         EnteredDescription description ->
-            if String.length description > 255 then
-                UR.init model
-
-            else
-                model
-                    |> updateForm
-                        (\form ->
-                            { form | description = updateInput description form.description }
-                        )
-                    |> UR.init
+            model
+                |> updateForm
+                    (\form ->
+                        { form | description = updateInput description form.description }
+                    )
+                |> UR.init
 
         EnteredTrackStock trackStock ->
             model

--- a/src/elm/Page/Shop/Editor.elm
+++ b/src/elm/Page/Shop/Editor.elm
@@ -20,7 +20,7 @@ import Eos.Account as Eos
 import File exposing (File)
 import Graphql.Http
 import Html exposing (Html, button, div, p, span, text)
-import Html.Attributes exposing (class, disabled, id, maxlength, required, value)
+import Html.Attributes exposing (class, disabled, id, maxlength, required, rows, value)
 import Html.Events exposing (onClick)
 import Http
 import Json.Decode as Decode
@@ -329,7 +329,7 @@ viewForm ({ shared } as loggedIn) imageStatus isEdit isDisabled deleteModal form
                     , problems = listErrors shared.translations form.description |> Just
                     , translators = shared.translators
                     }
-                    |> Input.withAttrs [ required True ]
+                    |> Input.withAttrs [ required True, rows 5 ]
                     |> Input.withInputType Input.TextArea
                     |> Input.toHtml
                 , Select.init

--- a/src/elm/View/Form/InputCounter.elm
+++ b/src/elm/View/Form/InputCounter.elm
@@ -1,4 +1,4 @@
-module View.Form.InputCounter exposing (CounterType(..), view, viewWithAttrs)
+module View.Form.InputCounter exposing (CounterType(..), viewWithAttrs)
 
 {-| Creates a Cambiatus-style input counter.
 -}
@@ -6,11 +6,6 @@ module View.Form.InputCounter exposing (CounterType(..), view, viewWithAttrs)
 import Html exposing (Html, div, text)
 import Html.Attributes exposing (class)
 import I18Next
-
-
-view : (String -> I18Next.Replacements -> String) -> Int -> String -> Html msg
-view tr max str =
-    viewWithAttrs tr max str [] CountLetters
 
 
 viewWithAttrs : (String -> I18Next.Replacements -> String) -> Int -> String -> List (Html.Attribute msg) -> CounterType -> Html msg


### PR DESCRIPTION
## What issue does this PR close
Closes #592 

## Changes Proposed ( a list of new changes introduced by this PR)
Remove the character limit of 256 to accommodate the changes on the backend for the following fields:
- [x] [action] photo_proof_instructions
- [x] [action] description
- [x] [community] description
- [x] [objective] description
- [x] [product] description

Also changed the description display behavior for objective descriptions. When displayed in ```/community``` page extensive obj descriptions truncate when not toggled, and are fully displayed when toggled. 

## How to test ( a list of instructions on how to test this PR)

**CREATED** 
- Community
- Action
- Objective
- Offer

**As** comm admin
**Go to** ```action or objective or community or offer``` editor
**Click on** on edit description
**See** action description and photo instruction does not have char limits

**NEW**
- Community
- Action
- Objective
- Offer

**Go to** create button
**Fill out** form
**See** description field does not have char limits