### PR TITLE
Feature/block explorer link

### DIFF
--- a/public/translations/amh-ETH.json
+++ b/public/translations/amh-ETH.json
@@ -619,6 +619,7 @@
     "edit_success": "መገለጫ በትክክል ተቀምጧል",
     "locations": "መገኛ",
     "interests": "ወለድ",
+    "block_explorer": "በብሎክ አሳሽ ውስጥ ይመልከቱ",
     "12words": {
       "title": "የእኔ 12 ቃላት",
       "button": "አዉርድ"

--- a/public/translations/amh-ETH.json
+++ b/public/translations/amh-ETH.json
@@ -619,7 +619,6 @@
     "edit_success": "መገለጫ በትክክል ተቀምጧል",
     "locations": "መገኛ",
     "interests": "ወለድ",
-    "block_explorer": "በብሎክ አሳሽ ውስጥ ይመልከቱ",
     "12words": {
       "title": "የእኔ 12 ቃላት",
       "button": "አዉርድ"
@@ -1068,5 +1067,8 @@
       "cancel": "አይ",
       "accept": "አዎ"
     }
+  },
+  "block_explorer": {
+    "see": "በብሎክ አሳሽ ውስጥ ይመልከቱ"
   }
 }

--- a/public/translations/cat-CAT.json
+++ b/public/translations/cat-CAT.json
@@ -662,7 +662,6 @@
     "edit_success": "El perfil s'ha desat correctament",
     "locations": "Localització",
     "interests": "Interessos",
-    "block_explorer": "Veure a explorador de blocs",
     "12words": {
       "title": "Les meves 12 paraules",
       "button": "Descarregar"
@@ -1109,5 +1108,8 @@
       "cancel": "No",
       "accept": "Sí"
     }
+  },
+  "block_explorer": {
+    "see": "Veure a explorador de blocs"
   }
 }

--- a/public/translations/cat-CAT.json
+++ b/public/translations/cat-CAT.json
@@ -662,6 +662,7 @@
     "edit_success": "El perfil s'ha desat correctament",
     "locations": "Localització",
     "interests": "Interessos",
+    "block_explorer": "Veure a explorador de blocs",
     "12words": {
       "title": "Les meves 12 paraules",
       "button": "Descarregar"

--- a/public/translations/en-US.json
+++ b/public/translations/en-US.json
@@ -658,7 +658,6 @@
     "edit_success": "Profile saved successfully",
     "locations": "Location",
     "interests": "Interests",
-    "block_explorer": "See on block explorer",
     "12words": {
       "title": "My 12 words",
       "button": "Download"
@@ -1107,5 +1106,8 @@
       "cancel": "No",
       "accept": "Yes"
     }
+  },
+  "block_explorer": {
+    "see": "See on block explorer"
   }
 }

--- a/public/translations/en-US.json
+++ b/public/translations/en-US.json
@@ -658,6 +658,7 @@
     "edit_success": "Profile saved successfully",
     "locations": "Location",
     "interests": "Interests",
+    "block_explorer": "See on block explorer",
     "12words": {
       "title": "My 12 words",
       "button": "Download"

--- a/public/translations/es-ES.json
+++ b/public/translations/es-ES.json
@@ -662,6 +662,7 @@
     "edit_success": "Perfil guardado con éxito",
     "locations": "Localización",
     "interests": "Intereses",
+    "block_explorer": "Ver en el explorador de bloques",
     "12words": {
       "title": "Mis 12 palabras",
       "button": "Descargar"

--- a/public/translations/es-ES.json
+++ b/public/translations/es-ES.json
@@ -662,7 +662,6 @@
     "edit_success": "Perfil guardado con éxito",
     "locations": "Localización",
     "interests": "Intereses",
-    "block_explorer": "Ver en el explorador de bloques",
     "12words": {
       "title": "Mis 12 palabras",
       "button": "Descargar"
@@ -1110,5 +1109,8 @@
       "cancel": "No",
       "accept": "Sí"
     }
+  },
+  "block_explorer": {
+    "see": "Ver en el explorador de bloques"
   }
 }

--- a/public/translations/pt-BR.json
+++ b/public/translations/pt-BR.json
@@ -666,7 +666,6 @@
     "edit_success": "Perfil salvo com sucesso",
     "locations": "Localização",
     "interests": "Interesses",
-    "block_explorer": "Ver no explorador de blocos",
     "12words": {
       "title": "Minhas 12 palavras",
       "button": "Baixar"
@@ -1113,5 +1112,8 @@
       "cancel": "Não",
       "accept": "Sim"
     }
+  },
+  "block_explorer": {
+    "see": "Ver no explorador de blocos"
   }
 }

--- a/public/translations/pt-BR.json
+++ b/public/translations/pt-BR.json
@@ -666,6 +666,7 @@
     "edit_success": "Perfil salvo com sucesso",
     "locations": "Localização",
     "interests": "Interesses",
+    "block_explorer": "Ver no explorador de blocos",
     "12words": {
       "title": "Minhas 12 palavras",
       "button": "Baixar"

--- a/src/elm/Emoji.elm
+++ b/src/elm/Emoji.elm
@@ -3,13 +3,15 @@ module Emoji exposing (encode)
 import Dict exposing (Dict)
 import Hashids
 import Murmur3
+import Transfer
 
 
 {-| Convert Transfer identifier (64 symbols) to emoji sequence (8 symbols)
 -}
-encode : String -> String
+encode : Transfer.CreatedTx -> String
 encode transferId =
     transferId
+        |> Transfer.createdTxToString
         |> Murmur3.hashString salt
         -- make 32 bit number
         |> Hashids.encode hashidsCtx

--- a/src/elm/Eos/Explorer.elm
+++ b/src/elm/Eos/Explorer.elm
@@ -1,0 +1,76 @@
+module Eos.Explorer exposing (Subject(..), link)
+
+import Eos.Account
+import Session.Shared as Shared
+import Transfer
+import Url.Builder
+
+
+
+-- BUILDING A LINK
+
+
+type Subject
+    = Profile Eos.Account.Name
+    | Transfer Transfer.CreatedTx
+
+
+link : Shared.Environment -> Subject -> String
+link environment subject =
+    Url.Builder.crossOrigin baseUrl
+        (path subject)
+        [ Url.Builder.string "nodeUrl" (nodeUrl environment)
+        , Url.Builder.string "systemDomain" "eosio"
+        , Url.Builder.string "coreSymbol" (coreSymbol environment)
+        ]
+
+
+
+-- INTERNAL HELPERS
+
+
+baseUrl : String
+baseUrl =
+    "https://local.bloks.io"
+
+
+path : Subject -> List String
+path subject =
+    case subject of
+        Profile accountName ->
+            [ "account", Eos.Account.nameToString accountName ]
+
+        Transfer createdTx ->
+            [ "transaction", Transfer.createdTxToString createdTx ]
+
+
+nodeUrl : Shared.Environment -> String
+nodeUrl environment =
+    case environment of
+        Shared.Development ->
+            "https://staging.cambiatus.io"
+
+        Shared.Staging ->
+            "https://staging.cambiatus.io"
+
+        Shared.Demo ->
+            "https://demo.cambiatus.io"
+
+        Shared.Production ->
+            "https://app.cambiatus.io"
+
+
+coreSymbol : Shared.Environment -> String
+coreSymbol environment =
+    case environment of
+        Shared.Development ->
+            "SYS"
+
+        Shared.Staging ->
+            "SYS"
+
+        Shared.Demo ->
+            "SYS"
+
+        Shared.Production ->
+            "EOS"

--- a/src/elm/Flags.elm
+++ b/src/elm/Flags.elm
@@ -1,6 +1,5 @@
 module Flags exposing
     ( Endpoints
-    , Environment(..)
     , Flags
     , decode
     , default
@@ -13,8 +12,7 @@ import Json.Decode.Pipeline as DecodePipeline exposing (optional, required)
 
 
 type alias Flags =
-    { environment : Environment
-    , language : String
+    { language : String
     , maybeAccount : Maybe ( Eos.Name, Bool )
     , endpoints : Endpoints
     , logo : String
@@ -33,8 +31,7 @@ type alias Flags =
 
 default : Flags
 default =
-    { environment = Development
-    , language = "en-US"
+    { language = "en-US"
     , maybeAccount = Nothing
     , endpoints = defaultEndpoints
     , logo = "/images/logo-cambiatus.png"
@@ -54,7 +51,6 @@ default =
 decode : Decoder Flags
 decode =
     Decode.succeed Flags
-        |> required "env" decodeEnvironment
         |> required "language" Decode.string
         |> DecodePipeline.custom
             (Decode.succeed
@@ -99,21 +95,3 @@ decodeEndpoints =
         |> required "eosio" Decode.string
         |> required "api" Decode.string
         |> required "graphql" Decode.string
-
-
-type Environment
-    = Development
-    | Production
-
-
-decodeEnvironment : Decoder Environment
-decodeEnvironment =
-    Decode.map
-        (\env ->
-            if env == "development" then
-                Development
-
-            else
-                Production
-        )
-        Decode.string

--- a/src/elm/Page/Profile.elm
+++ b/src/elm/Page/Profile.elm
@@ -23,6 +23,7 @@ import Cambiatus.Query
 import Community
 import Eos
 import Eos.Account as Eos
+import Eos.Explorer
 import Graphql.Http
 import Graphql.Operation exposing (RootQuery)
 import Graphql.OptionalArgument as OptionalArgument exposing (OptionalArgument(..))
@@ -732,27 +733,6 @@ viewProfile loggedIn profile =
         text_ =
             text << loggedIn.shared.translators.t
 
-        blockExplorerNodeUrl =
-            case loggedIn.shared.environment of
-                Shared.Production ->
-                    "https://app.cambiatus.io"
-
-                Shared.Demo ->
-                    "https://demo.cambiatus.io"
-
-                Shared.Staging ->
-                    "https://staging.cambiatus.io"
-
-                Shared.Development ->
-                    "https://staging.cambiatus.io"
-
-        blockExplorerUrl =
-            Url.Builder.crossOrigin "https://local.bloks.io"
-                [ "account", Eos.nameToString profile.account ]
-                [ Url.Builder.string "nodeUrl" blockExplorerNodeUrl
-                , Url.Builder.string "systemDomain" "eosio"
-                ]
-
         blockExplorerButton =
             a
                 [ class "button w-full mt-4"
@@ -761,9 +741,12 @@ viewProfile loggedIn profile =
                     , ( "button-secondary", not isProfileOwner )
                     ]
                 , target "_blank"
-                , href blockExplorerUrl
+                , profile.account
+                    |> Eos.Explorer.Profile
+                    |> Eos.Explorer.link loggedIn.shared.environment
+                    |> href
                 ]
-                [ text_ "profile.block_explorer" ]
+                [ text_ "block_explorer.see" ]
     in
     div [ class "p-4 bg-white border-white border-r w-full flex md:border-gray-500" ]
         [ div [ class "w-full container mx-auto self-center md:max-w-lg" ]

--- a/src/elm/Page/Profile.elm
+++ b/src/elm/Page/Profile.elm
@@ -46,11 +46,10 @@ import Profile.Summary
 import RemoteData exposing (RemoteData)
 import Route
 import Session.LoggedIn as LoggedIn
-import Session.Shared as Shared exposing (Shared, Translators)
+import Session.Shared exposing (Shared, Translators)
 import Time
 import Transfer exposing (QueryTransfers)
 import UpdateResult as UR
-import Url.Builder
 import Utils
 import View.Components
 import View.Feedback as Feedback

--- a/src/elm/Page/Profile.elm
+++ b/src/elm/Page/Profile.elm
@@ -763,7 +763,7 @@ viewProfile loggedIn profile =
                 , target "_blank"
                 , href blockExplorerUrl
                 ]
-                [ text "See on block explorer" ]
+                [ text_ "profile.block_explorer" ]
     in
     div [ class "p-4 bg-white border-white border-r w-full flex md:border-gray-500" ]
         [ div [ class "w-full container mx-auto self-center md:max-w-lg" ]

--- a/src/elm/Page/ViewTransfer.elm
+++ b/src/elm/Page/ViewTransfer.elm
@@ -5,9 +5,10 @@ import Cambiatus.Enum.TransferDirectionValue as TransferDirectionValue exposing 
 import Cambiatus.Scalar exposing (DateTime(..))
 import Emoji
 import Eos
+import Eos.Explorer
 import Graphql.Http
 import Html exposing (Html, a, div, h2, h5, img, p, span, text)
-import Html.Attributes exposing (class, src)
+import Html.Attributes exposing (class, href, src, target)
 import Icons
 import Page
 import Profile.Summary
@@ -183,7 +184,15 @@ viewDetails ({ shared } as loggedIn) transfer profileSummaries direction =
 
                     Nothing ->
                         text ""
-                , a [ class "button button-secondary w-full mt-10", Route.href Route.Dashboard ]
+                , a
+                    [ class "button button-primary w-full mt-10"
+                    , Eos.Explorer.Transfer transfer.createdTx
+                        |> Eos.Explorer.link shared.environment
+                        |> href
+                    , target "_blank"
+                    ]
+                    [ text (t "block_explorer.see") ]
+                , a [ class "button button-secondary w-full mt-4", Route.href Route.Dashboard ]
                     [ text (t "transfer_result.my_balance") ]
                 ]
             ]

--- a/src/elm/Session/Shared.elm
+++ b/src/elm/Session/Shared.elm
@@ -1,8 +1,10 @@
 module Session.Shared exposing
-    ( Shared
+    ( Environment(..)
+    , Shared
     , TranslationStatus(..)
     , Translators
     , communityDomain
+    , environmentFromUrl
     , init
     , langFlag
     , loadTranslation
@@ -17,7 +19,7 @@ module Session.Shared exposing
 import Browser.Navigation as Nav
 import Eos
 import Eos.Account as Eos
-import Flags exposing (Endpoints, Environment, Flags)
+import Flags exposing (Endpoints, Flags)
 import Graphql.Http
 import Html exposing (Html, button, div, img, p, text)
 import Html.Attributes exposing (class, src)
@@ -53,7 +55,7 @@ type alias Shared =
 
 
 init : Flags -> Nav.Key -> Url -> Shared
-init ({ environment, maybeAccount, endpoints, allowCommunityCreation, tokenContract, communityContract } as flags) navKey url =
+init ({ maybeAccount, endpoints, allowCommunityCreation, tokenContract, communityContract } as flags) navKey url =
     { navKey = navKey
     , language =
         -- We need to try parsing with `fromLanguageCode` first for
@@ -70,7 +72,7 @@ init ({ environment, maybeAccount, endpoints, allowCommunityCreation, tokenContr
     , translations = initialTranslations
     , translators = makeTranslators initialTranslations
     , translationsStatus = LoadingTranslation
-    , environment = environment
+    , environment = environmentFromUrl url
     , maybeAccount = maybeAccount
     , endpoints = endpoints
     , logo = flags.logo
@@ -123,13 +125,38 @@ makeTranslators translations =
     }
 
 
-
--- INFO
-
-
 translationStatus : Shared -> TranslationStatus
 translationStatus shared =
     shared.translationsStatus
+
+
+
+-- ENVIRONMENT
+
+
+type Environment
+    = Development
+    | Staging
+    | Demo
+    | Production
+
+
+environmentFromUrl : Url -> Environment
+environmentFromUrl url =
+    if String.endsWith ".localhost" url.host then
+        Development
+
+    else if String.endsWith ".staging.cambiatus.io" url.host then
+        Staging
+
+    else if String.endsWith ".demo.cambiatus.io" url.host then
+        Demo
+
+    else if String.endsWith ".cambiatus.io" url.host then
+        Production
+
+    else
+        Staging
 
 
 {-| Get the community subdomain and the current environment, based on current
@@ -147,38 +174,40 @@ communitySubdomainParts url environment =
     let
         allParts =
             url.host |> String.split "."
+
+        isStaging =
+            case environmentFromUrl url of
+                Development ->
+                    True
+
+                Staging ->
+                    True
+
+                _ ->
+                    False
+
+        addStaging parts =
+            if isStaging then
+                parts ++ [ "staging" ]
+
+            else
+                parts
     in
-    case environment of
-        Flags.Development ->
-            case allParts of
-                [] ->
-                    [ "cambiatus", "staging" ]
+    case allParts of
+        [] ->
+            addStaging [ "cambiatus" ]
 
-                [ subdomain ] ->
-                    [ subdomain, "staging" ]
+        [ subdomain ] ->
+            addStaging [ subdomain ]
 
-                subdomain :: "localhost" :: _ ->
-                    [ subdomain, "staging" ]
+        subdomain :: "localhost" :: _ ->
+            [ subdomain, "staging" ]
 
-                subdomain :: "cambiatus" :: _ ->
-                    [ subdomain ]
+        subdomain :: "cambiatus" :: _ ->
+            [ subdomain ]
 
-                subdomain :: env :: _ ->
-                    [ subdomain, env ]
-
-        Flags.Production ->
-            case allParts of
-                [] ->
-                    [ "cambiatus" ]
-
-                [ subdomain ] ->
-                    [ subdomain ]
-
-                subdomain :: "cambiatus" :: _ ->
-                    [ subdomain ]
-
-                subdomain :: env :: _ ->
-                    [ subdomain, env ]
+        subdomain :: env :: _ ->
+            [ subdomain, env ]
 
 
 {-| Returns the full `subdomain` of a community based on the current url

--- a/src/elm/Transfer.elm
+++ b/src/elm/Transfer.elm
@@ -1,9 +1,11 @@
 module Transfer exposing
     ( ConnectionTransfer
+    , CreatedTx
     , EdgeTransfer
     , ProfileSummaries
     , QueryTransfers
     , Transfer
+    , createdTxToString
     , encodeEosActionData
     , getTransfers
     , transferConnectionSelectionSet
@@ -47,8 +49,17 @@ type alias Transfer =
     , communityId : CommunityId
     , community : Cmm
     , blockTime : DateTime
-    , createdTx : String
+    , createdTx : CreatedTx
     }
+
+
+type CreatedTx
+    = CreatedTx String
+
+
+createdTxToString : CreatedTx -> String
+createdTxToString (CreatedTx tx) =
+    tx
 
 
 type alias CommunityId =
@@ -110,7 +121,7 @@ transferItemSelectionSet =
             )
         |> with (Cambiatus.Object.Transfer.community communitySelectionSet)
         |> with Cambiatus.Object.Transfer.createdAt
-        |> with Cambiatus.Object.Transfer.createdTx
+        |> with (SelectionSet.map CreatedTx Cambiatus.Object.Transfer.createdTx)
 
 
 communitySelectionSet : SelectionSet Cmm Cambiatus.Object.Community

--- a/src/index.js
+++ b/src/index.js
@@ -601,7 +601,6 @@ function flags () {
   }
 
   return {
-    env: env,
     graphqlSecret: graphqlSecret,
     endpoints: config.endpoints,
     language: getUserLanguage(),

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -25,7 +25,7 @@ body {
 
 @layer components {
   .button {
-    @apply uppercase text-sm flex items-center justify-center leading-none w-40 h-10 px-2;
+    @apply uppercase text-sm flex items-center justify-center text-center leading-none w-40 h-10 px-2;
   }
 
   .button:disabled {

--- a/tests/Session/SharedTests.elm
+++ b/tests/Session/SharedTests.elm
@@ -1,7 +1,6 @@
 module Session.SharedTests exposing (all)
 
 import Expect
-import Flags
 import Session.Shared as Shared
 import Test exposing (..)
 import TestHelpers.Fuzz as Fuzz

--- a/tests/Session/SharedTests.elm
+++ b/tests/Session/SharedTests.elm
@@ -10,7 +10,10 @@ import Url
 
 all : Test
 all =
-    describe "Session.Shared" [ communityDomain ]
+    describe "Session.Shared"
+        [ communityDomain
+        , deploymentEnvironment
+        ]
 
 
 
@@ -39,7 +42,7 @@ communityDomainOnProduction =
             }
 
         makeInput url =
-            { url = url, environment = Flags.Production }
+            { url = url, environment = Shared.Production }
     in
     describe "when environment is production"
         [ describe "when on production"
@@ -104,7 +107,7 @@ communityDomainOnDevelopment =
             }
 
         makeInput url =
-            { url = url, environment = Flags.Development }
+            { url = url, environment = Shared.Staging }
     in
     describe "when environment is development"
         [ describe "when on production"
@@ -181,5 +184,89 @@ communityDomainOnDevelopment =
                         |> makeInput
                         |> Shared.communityDomain
                         |> Expect.equal "somecommunity.staging.cambiatus.io"
+            ]
+        ]
+
+
+
+-- DEPLOYMENT ENVIRONMENT
+
+
+deploymentEnvironment : Test
+deploymentEnvironment =
+    let
+        makeUrl : String -> Url.Url
+        makeUrl host =
+            { protocol = Url.Https
+            , host = host
+            , port_ = Nothing
+            , path = "/"
+            , query = Nothing
+            , fragment = Nothing
+            }
+    in
+    describe "deploymentEnvironment"
+        [ describe "when on production"
+            [ test "correctly identifies muda" <|
+                \() ->
+                    makeUrl "muda.cambiatus.io"
+                        |> Shared.environmentFromUrl
+                        |> Expect.equal Shared.Production
+            , test "correctly identifies verdes" <|
+                \() ->
+                    makeUrl "verdes.cambiatus.io"
+                        |> Shared.environmentFromUrl
+                        |> Expect.equal Shared.Production
+            , fuzz (Fuzz.cambiatusUrl (Just ".cambiatus.io")) "correctly identifies prod communities" <|
+                \urlFuzz ->
+                    Shared.environmentFromUrl urlFuzz
+                        |> Expect.equal Shared.Production
+            ]
+        , describe "when on demo"
+            [ test "correctly identifies cmbx" <|
+                \() ->
+                    makeUrl "cmbx.demo.cambiatus.io"
+                        |> Shared.environmentFromUrl
+                        |> Expect.equal Shared.Demo
+            , test "correctly identifies cmbgo" <|
+                \() ->
+                    makeUrl "cmbgo.demo.cambiatus.io"
+                        |> Shared.environmentFromUrl
+                        |> Expect.equal Shared.Demo
+            , fuzz (Fuzz.cambiatusUrl (Just ".demo.cambiatus.io")) "correctly identifies demo communities" <|
+                \urlFuzz ->
+                    Shared.environmentFromUrl urlFuzz
+                        |> Expect.equal Shared.Demo
+            ]
+        , describe "when on staging"
+            [ test "correctly identifies buss" <|
+                \() ->
+                    makeUrl "buss.staging.cambiatus.io"
+                        |> Shared.environmentFromUrl
+                        |> Expect.equal Shared.Staging
+            , test "correctly identifies mizu" <|
+                \() ->
+                    makeUrl "mizu.staging.cambiatus.io"
+                        |> Shared.environmentFromUrl
+                        |> Expect.equal Shared.Staging
+            , fuzz (Fuzz.cambiatusUrl (Just ".staging.cambiatus.io")) "correctly identifies staging communities" <|
+                \urlFuzz ->
+                    Shared.environmentFromUrl urlFuzz
+                        |> Expect.equal Shared.Staging
+            ]
+        , fuzz (Fuzz.cambiatusUrl (Just ".netlify.app")) "correctly identifies netlify links as staging" <|
+            \urlFuzz ->
+                Shared.environmentFromUrl urlFuzz
+                    |> Expect.equal Shared.Staging
+        , describe "when on localhost"
+            [ test "correctly identifies buss" <|
+                \() ->
+                    makeUrl "buss.staging.localhost"
+                        |> Shared.environmentFromUrl
+                        |> Expect.equal Shared.Development
+            , fuzz (Fuzz.cambiatusUrl (Just ".staging.localhost")) "correctly identifies localhost communities" <|
+                \urlFuzz ->
+                    Shared.environmentFromUrl urlFuzz
+                        |> Expect.equal Shared.Development
             ]
         ]


### PR DESCRIPTION
## What issue does this PR close
Closes #611

## Changes Proposed ( a list of new changes introduced by this PR)
- Change the `Environment` type to be more aware of where we are: `Development` (localhost), `Staging`, `Demo` or `Production`. We can extract all that information just by looking at the current URL.
- Add a "See on block explorer" button on the profile page

## How to test ( a list of instructions on how to test this PR)
1. Go to someone's profile page
2. See if the "See on block explorer" button is there and if it redirects you to the correct page
3. Do the same for your own profile