### PR TITLE
Dynamically load script

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -28,7 +28,6 @@
     <meta name="theme-color" content="#ffffff">
     <link href="https://fonts.googleapis.com/css2?family=Nunito:ital,wght@0,300;0,400;0,600;0,700;1,300;1,400;1,600;1,700&display=swap" rel="stylesheet">
 
-    <script async defer data-domain="muda.cambiatus.io" src="https://plausible.io/js/plausible.js"></script>
     <script src="%PUBLIC_URL%/env-config.js"></script>
 
     <!--

--- a/src/elm/Page.elm
+++ b/src/elm/Page.elm
@@ -57,7 +57,7 @@ import View.Components
 init : Flags -> Nav.Key -> Url -> UpdateResult
 init flags navKey url =
     let
-        shared =
+        ( shared, sharedCmd ) =
             Shared.init flags navKey url
     in
     case ( shared.maybeAccount, flags.authToken ) of
@@ -70,6 +70,7 @@ init flags navKey url =
                 |> UR.addCmd (Cmd.map GotLoggedInMsg cmd)
                 |> UR.addCmd (fetchTranslations shared.language)
                 |> UR.addCmd fetchTimezone
+                |> UR.addCmd sharedCmd
                 |> UR.addBreadcrumb
                     { type_ = Log.DebugBreadcrumb
                     , category = Ignored
@@ -89,6 +90,7 @@ init flags navKey url =
                 |> UR.addCmd (fetchTranslations shared.language)
                 |> UR.addCmd fetchTimezone
                 |> UR.addCmd signedInCmd
+                |> UR.addCmd sharedCmd
                 |> UR.addBreadcrumb
                     { type_ = Log.DebugBreadcrumb
                     , category = Ignored
@@ -106,6 +108,7 @@ init flags navKey url =
                 |> UR.addCmd (Cmd.map GotGuestMsg cmd)
                 |> UR.addCmd (fetchTranslations shared.language)
                 |> UR.addCmd fetchTimezone
+                |> UR.addCmd sharedCmd
                 |> UR.addBreadcrumb
                     { type_ = Log.DebugBreadcrumb
                     , category = Ignored

--- a/src/elm/Ports.elm
+++ b/src/elm/Ports.elm
@@ -1,6 +1,7 @@
 port module Ports exposing
     ( JavascriptOut
     , JavascriptOutModel
+    , addPlausibleScript
     , getRecentSearches
     , gotRecentSearches
     , javascriptInPort
@@ -85,6 +86,22 @@ port storeAuthToken : String -> Cmd msg
 `USE_SUBDOMAIN = false`
 -}
 port storeSelectedCommunitySymbol : String -> Cmd msg
+
+
+{-| Add a Plausible script so we can track usage metrics. We have it here so we
+can dynamically tell plausible which community we're in (and if we're not in
+production, we don't even need to include it)
+-}
+addPlausibleScript : { domain : String, src : String } -> Cmd msg
+addPlausibleScript { domain, src } =
+    Encode.object
+        [ ( "domain", Encode.string domain )
+        , ( "src", Encode.string src )
+        ]
+        |> addPlausibleScriptPort
+
+
+port addPlausibleScriptPort : Value -> Cmd msg
 
 
 

--- a/src/elm/Session/Shared.elm
+++ b/src/elm/Session/Shared.elm
@@ -26,6 +26,7 @@ import Html.Attributes exposing (class, src)
 import Html.Events exposing (onClick)
 import Http
 import I18Next exposing (Translations, initialTranslations)
+import Ports
 import Time exposing (Posix)
 import Translation
 import Url exposing (Url)
@@ -54,39 +55,50 @@ type alias Shared =
     }
 
 
-init : Flags -> Nav.Key -> Url -> Shared
+init : Flags -> Nav.Key -> Url -> ( Shared, Cmd msg )
 init ({ maybeAccount, endpoints, allowCommunityCreation, tokenContract, communityContract } as flags) navKey url =
-    { navKey = navKey
-    , language =
-        -- We need to try parsing with `fromLanguageCode` first for
-        -- backwards-compatiblity. In some time, we should switch to just trying
-        -- with `languageFromLocale`
-        case flags.language |> Translation.languageFromLanguageCode of
-            Just lang ->
-                lang
+    let
+        environment =
+            environmentFromUrl url
+    in
+    ( { navKey = navKey
+      , language =
+            -- We need to try parsing with `fromLanguageCode` first for
+            -- backwards-compatiblity. In some time, we should switch to just trying
+            -- with `languageFromLocale`
+            case flags.language |> Translation.languageFromLanguageCode of
+                Just lang ->
+                    lang
 
-            Nothing ->
-                flags.language
-                    |> Translation.languageFromLocale
-                    |> Maybe.withDefault Translation.defaultLanguage
-    , translations = initialTranslations
-    , translators = makeTranslators initialTranslations
-    , translationsStatus = LoadingTranslation
-    , environment = environmentFromUrl url
-    , maybeAccount = maybeAccount
-    , endpoints = endpoints
-    , logo = flags.logo
-    , logoMobile = flags.logoMobile
-    , now = Time.millisToPosix flags.now
-    , timezone = Time.utc
-    , allowCommunityCreation = allowCommunityCreation
-    , url = url
-    , contracts = { token = tokenContract, community = communityContract }
-    , graphqlSecret = flags.graphqlSecret
-    , canReadClipboard = flags.canReadClipboard
-    , useSubdomain = flags.useSubdomain
-    , selectedCommunity = flags.selectedCommunity
-    }
+                Nothing ->
+                    flags.language
+                        |> Translation.languageFromLocale
+                        |> Maybe.withDefault Translation.defaultLanguage
+      , translations = initialTranslations
+      , translators = makeTranslators initialTranslations
+      , translationsStatus = LoadingTranslation
+      , environment = environment
+      , maybeAccount = maybeAccount
+      , endpoints = endpoints
+      , logo = flags.logo
+      , logoMobile = flags.logoMobile
+      , now = Time.millisToPosix flags.now
+      , timezone = Time.utc
+      , allowCommunityCreation = allowCommunityCreation
+      , url = url
+      , contracts = { token = tokenContract, community = communityContract }
+      , graphqlSecret = flags.graphqlSecret
+      , canReadClipboard = flags.canReadClipboard
+      , useSubdomain = flags.useSubdomain
+      , selectedCommunity = flags.selectedCommunity
+      }
+    , case environment of
+        Production ->
+            Ports.addPlausibleScript { domain = url.host, src = "https://plausible.io/js/plausible.js" }
+
+        _ ->
+            Cmd.none
+    )
 
 
 type TranslationStatus

--- a/src/index.js
+++ b/src/index.js
@@ -714,6 +714,14 @@ app.ports.storeSelectedCommunitySymbol.subscribe(symbol => {
   })
 })
 
+app.ports.addPlausibleScriptPort.subscribe(({ domain, src }) => {
+  const plausibleScript = document.createElement('script')
+  plausibleScript.setAttribute('src', src)
+  plausibleScript.dataset.domain = domain
+
+  document.head.appendChild(plausibleScript)
+})
+
 // STORE PIN
 
 function storePin (data, pin) {


### PR DESCRIPTION
## What issue does this PR close
Closes #513

## Changes Proposed ( a list of new changes introduced by this PR)
- Dynamically load the plausible script. We check if we're in production (with the new `Environment` type from #623), and then just include a script with `data-domain` set to `url.host` (which will be `muda.cambiatus.io` or `verdes.cambiatus.io`)
- Remove the plausible script in `index.html`

## How to test ( a list of instructions on how to test this PR)
We can't really test on Netlify, because it's considered staging, and it won't add the script. However, if you really want to test it, you can clone this branch, go into `src/elm/Session/Shared.elm`, and change the case statement on the `init` function to something like
```elm
Ports.addPlausibleScript { domain = "verdes.cambiatus.io", src = "https://plausible.io/js/plausible.js" }
```

I've already done that, and here's a screenshot showing it works:
![image](https://user-images.githubusercontent.com/39280468/130128600-9c75e7dd-1f4d-494b-8668-9804a7ed67a6.png)


And here's one for Muda (note there's one access to `/zzzz`, that was me on localhost, but with the script with `data-domain=muda.cambiatus.io`)
![2021-08-19-154047_835x130_scrot](https://user-images.githubusercontent.com/39280468/130128724-2bbf5d64-556c-45c5-bfc3-32c586252fc8.png)
