### PR TITLE
Fix no-one tag bug

### DIFF
--- a/src/elm/Claim.elm
+++ b/src/elm/Claim.elm
@@ -728,7 +728,7 @@ viewClaimModal { shared, accountName } profileSummaries claim =
                 [ class claimVerifiersSectionClass ]
                 [ p [ class greenTextTitleClass ] [ text (t "claim.approved_by") ]
                 , div []
-                    [ if List.filter (\check -> check.isApproved) claim.checks |> List.isEmpty then
+                    [ if List.any .isApproved claim.checks |> not then
                         profileSummaryEmpty
 
                       else

--- a/src/elm/Claim.elm
+++ b/src/elm/Claim.elm
@@ -728,7 +728,7 @@ viewClaimModal { shared, accountName } profileSummaries claim =
                 [ class claimVerifiersSectionClass ]
                 [ p [ class greenTextTitleClass ] [ text (t "claim.approved_by") ]
                 , div []
-                    [ if List.isEmpty claim.checks then
+                    [ if List.filter (\check -> check.isApproved) claim.checks |> List.isEmpty then
                         profileSummaryEmpty
 
                       else


### PR DESCRIPTION
## What issue does this PR close
Closes #588 

## Changes Proposed ( a list of new changes introduced by this PR)
Fixes non-apparent no-one tag when approval list is empty in claim modal.

## How to test ( a list of instructions on how to test this PR)
**Go to** `/claims`
**Click on** a claim that does not have an approved vote
**See fix**

