### PR TITLE
Enhancement/pin hidden

### DIFF
--- a/src/elm/Flags.elm
+++ b/src/elm/Flags.elm
@@ -26,6 +26,7 @@ type alias Flags =
     , canReadClipboard : Bool
     , useSubdomain : Bool
     , selectedCommunity : Maybe Eos.Symbol
+    , pinVisibility : Bool
     }
 
 
@@ -45,6 +46,7 @@ default =
     , canReadClipboard = False
     , useSubdomain = True
     , selectedCommunity = Nothing
+    , pinVisibility = False
     }
 
 
@@ -72,6 +74,7 @@ decode =
         |> required "canReadClipboard" Decode.bool
         |> required "useSubdomain" Decode.bool
         |> required "selectedCommunity" (Decode.nullable Eos.symbolDecoder)
+        |> required "pinVisibility" Decode.bool
 
 
 type alias Endpoints =

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -747,6 +747,11 @@ updateGuestUResult toStatus toMsg model uResult =
                             ( { m | session = Page.Guest { guest | feedback = feedback } }
                             , cmds_
                             )
+
+                        Guest.UpdatedShared newShared ->
+                            ( { m | session = Page.Guest { guest | shared = newShared } }
+                            , cmds_
+                            )
         )
         ( { model | status = toStatus uResult.model }
         , []

--- a/src/elm/Page/Login.elm
+++ b/src/elm/Page/Login.elm
@@ -63,8 +63,8 @@ initPassphraseModel =
     }
 
 
-initPinModel : String -> PinModel
-initPinModel passphrase =
+initPinModel : Bool -> String -> PinModel
+initPinModel pinVisibility passphrase =
     { isSigningIn = False
     , passphrase = passphrase
     , pinModel =
@@ -74,6 +74,7 @@ initPinModel passphrase =
             , withConfirmation = True
             , submitLabel = "auth.login.submit"
             , submittingLabel = "auth.login.submitting"
+            , pinVisibility = pinVisibility
             }
     }
 
@@ -349,7 +350,7 @@ update msg model guest =
         ( WentToPin validPassphrase, EnteringPassphrase _ ) ->
             Validate.fromValid validPassphrase
                 |> .passphrase
-                |> initPinModel
+                |> initPinModel guest.shared.pinVisibility
                 |> EnteringPin
                 |> UR.init
                 |> UR.addCmd
@@ -608,10 +609,14 @@ updateWithPin msg model ({ shared } as guest) =
             let
                 ( pinModel, submitStatus ) =
                     Pin.update subMsg model.pinModel
+
+                ( newShared, submitCmd ) =
+                    Pin.postSubmitAction pinModel submitStatus shared SubmittedPinWithSuccess
             in
             { model | pinModel = pinModel }
                 |> UR.init
-                |> UR.addCmd (Pin.maybeSubmitCmd submitStatus SubmittedPinWithSuccess)
+                |> UR.addCmd submitCmd
+                |> UR.addExt (PinGuestExternal (Guest.UpdatedShared newShared))
 
 
 

--- a/src/elm/Ports.elm
+++ b/src/elm/Ports.elm
@@ -9,6 +9,7 @@ port module Ports exposing
     , mapAddress
     , storeAuthToken
     , storeLanguage
+    , storePinVisibility
     , storeRecentSearches
     , storeSelectedCommunitySymbol
     )
@@ -66,12 +67,12 @@ port javascriptInPort : (Value -> msg) -> Sub msg
 port storeLanguage : String -> Cmd msg
 
 
-{-| Store recent searches to the `localStorage`.
+{-| Store recent searches
 -}
 port storeRecentSearches : String -> Cmd msg
 
 
-{-| Ping JS to send back the recent searches from the `localStorage`.
+{-| Ping JS to send back the recent searches
 -}
 port getRecentSearches : () -> Cmd msg
 
@@ -85,6 +86,11 @@ port storeAuthToken : String -> Cmd msg
 `USE_SUBDOMAIN = false`
 -}
 port storeSelectedCommunitySymbol : String -> Cmd msg
+
+
+{-| Store whether to show or hide the pin by default
+-}
+port storePinVisibility : Bool -> Cmd msg
 
 
 

--- a/src/elm/Session/Guest.elm
+++ b/src/elm/Session/Guest.elm
@@ -318,6 +318,7 @@ viewPageHeader model shared =
 type External
     = LoggedIn Eos.PrivateKey Auth.SignInResponse
     | SetFeedback Feedback.Model
+    | UpdatedShared Shared
 
 
 type BroadcastMsg

--- a/src/elm/Session/LoggedIn.elm
+++ b/src/elm/Session/LoggedIn.elm
@@ -183,7 +183,7 @@ initModel shared maybePrivateKey_ accountName authToken =
     , notification = Notification.init
     , unreadCount = 0
     , showAuthModal = False
-    , auth = Auth.init maybePrivateKey_
+    , auth = Auth.init shared.pinVisibility maybePrivateKey_
     , feedback = Feedback.Hidden
     , showCommunitySelector = False
     , searchModel = Search.init
@@ -1186,6 +1186,10 @@ update msg model =
                                         , data = Dict.fromList [ ( "username", Eos.encodeName user.account ) ]
                                         , level = Log.Info
                                         }
+
+                            Auth.UpdatedShared newShared ->
+                                uResult
+                                    |> UR.mapModel (\m -> { m | shared = newShared })
                     )
 
         CompletedLoadUnread payload ->

--- a/src/elm/Session/Shared.elm
+++ b/src/elm/Session/Shared.elm
@@ -51,6 +51,7 @@ type alias Shared =
     , canReadClipboard : Bool
     , useSubdomain : Bool
     , selectedCommunity : Maybe Eos.Symbol
+    , pinVisibility : Bool
     }
 
 
@@ -86,6 +87,7 @@ init ({ maybeAccount, endpoints, allowCommunityCreation, tokenContract, communit
     , canReadClipboard = flags.canReadClipboard
     , useSubdomain = flags.useSubdomain
     , selectedCommunity = flags.selectedCommunity
+    , pinVisibility = flags.pinVisibility
     }
 
 

--- a/src/elm/View/Pin.elm
+++ b/src/elm/View/Pin.elm
@@ -5,8 +5,8 @@ module View.Pin exposing
     , RequiredOptions
     , SubmitStatus(..)
     , init
-    , maybeSubmitCmd
     , msgToString
+    , postSubmitAction
     , update
     , view
     , withAttrs
@@ -25,7 +25,8 @@ import Html exposing (Html, button, div, text)
 import Html.Attributes exposing (attribute, autocomplete, class, classList, disabled, maxlength, required, type_)
 import Html.Events exposing (keyCode, onClick, preventDefaultOn)
 import Json.Decode as Decode
-import Session.Shared exposing (Translators)
+import Ports
+import Session.Shared exposing (Shared, Translators)
 import Task
 import Validate
 import View.Form.Input
@@ -70,13 +71,14 @@ type alias RequiredOptions =
     , withConfirmation : Bool
     , submitLabel : String
     , submittingLabel : String
+    , pinVisibility : Bool
     }
 
 
 {-| Initializes a `Model` with some initial `RequiredOptions`
 -}
 init : RequiredOptions -> Model
-init { label, id, withConfirmation, submitLabel, submittingLabel } =
+init { label, id, withConfirmation, submitLabel, submittingLabel, pinVisibility } =
     { label = label
     , disabled = False
     , id = id
@@ -89,8 +91,8 @@ init { label, id, withConfirmation, submitLabel, submittingLabel } =
             Nothing
     , placeholder = String.repeat pinLength "*"
     , problems = []
-    , isPinVisible = True
-    , isPinConfirmationVisible = True
+    , isPinVisible = pinVisibility
+    , isPinConfirmationVisible = pinVisibility
     , isSubmitting = False
     , submitLabel = submitLabel
     , submittingLabel = submittingLabel
@@ -306,18 +308,23 @@ update msg model =
 -- UTILS
 
 
-maybeSubmitCmd : SubmitStatus -> (String -> msg) -> Cmd msg
-maybeSubmitCmd status toMsg =
+postSubmitAction : Model -> SubmitStatus -> Shared -> (String -> msg) -> ( Shared, Cmd msg )
+postSubmitAction model status shared toMsg =
     case status of
         NotAsked ->
-            Cmd.none
+            ( shared, Cmd.none )
 
         WithError ->
-            Cmd.none
+            ( shared, Cmd.none )
 
         Success pin ->
-            Task.succeed pin
-                |> Task.perform toMsg
+            ( { shared | pinVisibility = model.isPinVisible }
+            , Cmd.batch
+                [ Task.succeed pin
+                    |> Task.perform toMsg
+                , Ports.storePinVisibility model.isPinVisible
+                ]
+            )
 
 
 withDisabled : Bool -> Model -> Model

--- a/src/index.js
+++ b/src/index.js
@@ -349,6 +349,7 @@ const PUSH_PREF = 'bespiral.push.pref'
 const AUTH_TOKEN = 'bespiral.auth_token'
 const RECENT_SEARCHES = 'bespiral.recent_search'
 const SELECTED_COMMUNITY_KEY = 'bespiral.selected_community'
+const PIN_VISIBILITY_KEY = 'bespiral.pin_visibility'
 const env = process.env.NODE_ENV || 'development'
 const graphqlSecret = process.env.GRAPHQL_SECRET || ''
 const useSubdomain = process.env.USE_SUBDOMAIN === undefined ? true : process.env.USE_SUBDOMAIN !== 'false'
@@ -615,7 +616,8 @@ function flags () {
     communityContract: config.communityContract,
     canReadClipboard: canReadClipboard(),
     useSubdomain: useSubdomain,
-    selectedCommunity: getItem(SELECTED_COMMUNITY_KEY)
+    selectedCommunity: getItem(SELECTED_COMMUNITY_KEY),
+    pinVisibility: JSON.parse(getItem(PIN_VISIBILITY_KEY)) || false
   }
 }
 
@@ -709,6 +711,18 @@ app.ports.storeSelectedCommunitySymbol.subscribe(symbol => {
     category: 'storeSelectedCommunitySymbol',
     message: 'Stored selected community\'s symbol',
     data: { symbol },
+    localData: {},
+    level: 'debug'
+  })
+})
+
+app.ports.storePinVisibility.subscribe(pinVisibility => {
+  setItem(PIN_VISIBILITY_KEY, pinVisibility)
+  addBreadcrumb({
+    type: 'info',
+    category: 'storePinVisibility',
+    message: 'Stored pin visibility',
+    data: { pinVisibility },
     localData: {},
     level: 'debug'
   })

--- a/src/index.js
+++ b/src/index.js
@@ -652,7 +652,7 @@ const getItem = (key) => {
 
 const removeItem = (key) => {
   document.cookie = `${cookieKey(key)}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; ${cookieDomain()}; path=/; SameSite=Strict; Secure`
-  window.localStorage.removeItem(key)
+  window.localStorage.removeItem(cookieKey(key))
 }
 
 const setItem = (key, value) => {


### PR DESCRIPTION
## What issue does this PR close
Closes #589 

## Changes Proposed ( a list of new changes introduced by this PR)
- Default the PIN to hidden
- Use localStorage when the `USE_SUBDOMAIN` flag is set to `false`. This way we can actually have some persistence, especially on Netlify deploys
- When the user submits their PIN, save (on localStorage/cookies) if it should be hidden or shown on the next time their PIN is requested

## How to test ( a list of instructions on how to test this PR)
1. Be logged out
2. When you enter your PIN, it should be hidden. If you change it to visible, the next time you enter your pin anywhere on the app, it should be visible, etc. That should work with any PIN request.

Your PIN may be requested on login, when you're changing your PIN on your profile page, or when you're signing blockchain transactions (such as approving a claim, buying a product, transferring to a friend, etc.). Note that if you're logged in, we remember your PIN from the first time you enter it, and don't ask for it again until you refresh the page.