### PR TITLE
Fix mouseEnter/Leave handler on profile.summary to be fired only on img hovering

### DIFF
--- a/src/elm/Profile/Summary.elm
+++ b/src/elm/Profile/Summary.elm
@@ -113,7 +113,8 @@ view shared loggedInAccount profile model =
 mobileView : Shared -> Eos.Name -> Profile.Basic profile -> Model -> Html Msg
 mobileView shared loggedInAccount profile model =
     div [ class "md:hidden cursor-auto" ]
-        [ viewUserImg shared loggedInAccount profile True model
+        [ viewUserImg profile True model
+        , viewUserNameTag shared loggedInAccount profile model
         , Modal.initWith { closeMsg = ClosedInfo, isVisible = model.isExpanded }
             |> Modal.withBody
                 [ div [ class "pt-14" ]
@@ -127,16 +128,28 @@ mobileView shared loggedInAccount profile model =
 desktopView : Shared -> Eos.Name -> Profile.Basic profile -> Model -> Html Msg
 desktopView shared loggedInAccount profile model =
     div
-        [ class "mx-auto hidden md:block"
-        , onMouseEnter OpenedInfo
-        , onMouseLeave ClosedInfo
-        ]
-        [ viewUserImg shared loggedInAccount profile False model
+        [ class "mx-auto hidden md:block" ]
+        [ div
+            [ onMouseEnter OpenedInfo
+            , onMouseLeave ClosedInfo
+            ]
+            [ viewUserImg profile False model ]
+        , viewUserNameTag shared loggedInAccount profile model
         ]
 
 
-viewUserImg : Shared -> Eos.Name -> Profile.Basic profile -> Bool -> Model -> Html Msg
-viewUserImg shared loggedInAccount profile isMobile model =
+viewUserNameTag : Shared -> Eos.Name -> Profile.Basic profile -> Model -> Html Msg
+viewUserNameTag shared loggedInAccount profile model =
+    if model.showNameTag then
+        div [ class "mt-2" ]
+            [ Profile.viewProfileNameTag shared loggedInAccount profile ]
+
+    else
+        text ""
+
+
+viewUserImg : Profile.Basic profile -> Bool -> Model -> Html Msg
+viewUserImg profile isMobile model =
     let
         container attrs =
             if isMobile then
@@ -159,12 +172,6 @@ viewUserImg shared loggedInAccount profile isMobile model =
               else
                 text ""
             ]
-        , if model.showNameTag then
-            div [ class "mt-2" ]
-                [ Profile.viewProfileNameTag shared loggedInAccount profile ]
-
-          else
-            text ""
         ]
 
 


### PR DESCRIPTION
## What issue does this PR close
Closes #593  

## Changes Proposed ( a list of new changes introduced by this PR)
Fix mouseEnter/Leave handler on profile.summary to be fired only when hovering the avatar image of user

## How to test ( a list of instructions on how to test this PR)
Go to any claim card
Find user avatar
Hover with mouse
