### PR TITLE
Enhancement/modal

### DIFF
--- a/src/elm/Profile/Summary.elm
+++ b/src/elm/Profile/Summary.elm
@@ -190,7 +190,7 @@ viewUserInfo profile =
                 [ ul [ class "text-sm text-gray-900" ]
                     [ li [ class "font-medium text-body-black text-2xl xs-max:text-xl" ]
                         [ text userName ]
-                    , li [] [ a [ href <| "mailto:" ++ email ] [ text email ] ]
+                    , li [] [ a [ href <| "mailto:" ++ email, class "hover:underline hover:text-orange-300 focus:outline-none focus:underline focus:text-orange-300" ] [ text email ] ]
                     , li [] [ text account ]
                     ]
                 ]

--- a/src/elm/Session/LoggedIn.elm
+++ b/src/elm/Session/LoggedIn.elm
@@ -39,7 +39,7 @@ import Graphql.Document
 import Graphql.Http
 import Graphql.Operation exposing (RootSubscription)
 import Graphql.SelectionSet exposing (SelectionSet)
-import Html exposing (Html, a, button, div, footer, img, nav, p, text)
+import Html exposing (Html, a, button, div, footer, img, li, nav, p, text, ul)
 import Html.Attributes exposing (class, classList, src, type_)
 import Html.Events exposing (onClick, onMouseEnter)
 import Http
@@ -604,12 +604,14 @@ communitySelectorModal model =
 
         viewCommunityItem : Profile.CommunityInfo -> Html Msg
         viewCommunityItem c =
-            div
-                [ class "flex items-center p-4 text-body cursor-pointer hover:text-black hover:bg-gray-100"
-                , onClick <| SelectedCommunity c
-                ]
-                [ img [ src c.logo, class "h-16 w-16 mr-5 object-scale-down" ] []
-                , text c.name
+            li [ class "flex" ]
+                [ button
+                    [ class "w-full flex items-center p-3 m-1 text-body rounded-sm hover:text-black hover:bg-gray-100 focus:outline-none focus:ring"
+                    , onClick <| SelectedCommunity c
+                    ]
+                    [ img [ src c.logo, class "h-16 w-16 mr-5 object-scale-down" ] []
+                    , text c.name
+                    ]
                 ]
     in
     if model.showCommunitySelector then
@@ -628,7 +630,7 @@ communitySelectorModal model =
                             [ p []
                                 [ text_ "menu.community_selector.body"
                                 ]
-                            , div [ class "w-full overflow-y-auto divide-y divide-gray-300" ]
+                            , ul [ class "w-full flex flex-col overflow-y-auto divide-y divide-gray-300" ]
                                 (List.map viewCommunityItem pro.communities)
                             ]
                         |> Modal.toHtml

--- a/src/elm/Session/LoggedIn.elm
+++ b/src/elm/Session/LoggedIn.elm
@@ -919,8 +919,7 @@ type BroadcastMsg
 
 
 type Msg
-    = NoOp
-    | CompletedLoadTranslation Translation.Language (Result Http.Error Translations)
+    = CompletedLoadTranslation Translation.Language (Result Http.Error Translations)
     | ClickedTryAgainTranslation
     | CompletedLoadProfile (RemoteData (Graphql.Http.Error (Maybe Profile.Model)) (Maybe Profile.Model))
     | CompletedLoadCommunity (RemoteData (Graphql.Http.Error (Maybe Community.Model)) (Maybe Community.Model))
@@ -957,9 +956,6 @@ update msg model =
             }
     in
     case msg of
-        NoOp ->
-            UR.init model
-
         GotTimeInternal time ->
             UR.init { model | shared = { shared | now = time } }
                 |> UR.addExt (GotTime time |> Broadcast)
@@ -1576,9 +1572,6 @@ jsAddressToMsg addr val =
 msgToString : Msg -> List String
 msgToString msg =
     case msg of
-        NoOp ->
-            [ "NoOp" ]
-
         GotTimeInternal _ ->
             [ "GotTimeInternal" ]
 

--- a/src/elm/Session/LoggedIn.elm
+++ b/src/elm/Session/LoggedIn.elm
@@ -28,7 +28,6 @@ import Api.Graphql
 import Auth
 import Avatar
 import Browser.Dom as Dom
-import Browser.Events
 import Cambiatus.Object
 import Cambiatus.Object.UnreadNotifications
 import Cambiatus.Subscription as Subscription
@@ -137,8 +136,7 @@ initLogin shared maybePrivateKey_ profile_ authToken =
 subscriptions : Model -> Sub Msg
 subscriptions model =
     Sub.batch
-        [ Sub.map KeyDown (Browser.Events.onKeyDown (Decode.field "key" Decode.string))
-        , Sub.map GotSearchMsg Search.subscriptions
+        [ Sub.map GotSearchMsg Search.subscriptions
         , Sub.map GotActionMsg (Action.subscriptions model.claimingAction)
         ]
 
@@ -914,7 +912,6 @@ type Msg
     | ClosedAuthModal
     | GotAuthMsg Auth.Msg
     | CompletedLoadUnread Value
-    | KeyDown String
     | OpenCommunitySelector
     | CloseCommunitySelector
     | SelectedCommunity Profile.CommunityInfo
@@ -1212,14 +1209,6 @@ update msg model =
                             { moduleName = "Session.LoggedIn", function = "update" }
                             []
                             err
-
-        KeyDown key ->
-            if key == "Esc" || key == "Escape" then
-                UR.init { closeAllModals | showUserNav = False }
-
-            else
-                model
-                    |> UR.init
 
         GotFeedbackMsg subMsg ->
             { model | feedback = Feedback.update subMsg model.feedback }
@@ -1627,9 +1616,6 @@ msgToString msg =
 
         CompletedLoadUnread _ ->
             [ "CompletedLoadUnread" ]
-
-        KeyDown _ ->
-            [ "KeyDown" ]
 
         OpenCommunitySelector ->
             [ "OpenCommunitySelector" ]

--- a/src/elm/View/Components.elm
+++ b/src/elm/View/Components.elm
@@ -2,7 +2,7 @@ module View.Components exposing
     ( loadingLogoAnimated, loadingLogoAnimatedFluid, loadingLogoWithCustomText
     , dialogBubble
     , tooltip, pdfViewer, dateViewer, infiniteList, ElementToTrack(..)
-    , bgNoScroll, PreventScroll(..)
+    , bgNoScroll, PreventScroll(..), keyListener, Key(..)
     )
 
 {-| This module exports some simple components that don't need to manage any
@@ -31,7 +31,7 @@ state or configuration, such as loading indicators and containers
 
 # Helpers
 
-@docs bgNoScroll, PreventScroll
+@docs bgNoScroll, PreventScroll, keyListener, Key
 
 -}
 
@@ -269,8 +269,67 @@ type PreventScroll
     | PreventScrollAlways
 
 
+type Key
+    = Escape
+
+
+{-| A node that attaches an event listener on the document to listen for keys.
+Useful when we want to listen for keypresses, but don't want to use
+subscriptions (because it would add a lot of complexity). Can be useful in
+"stateless" components, such as modals.
+-}
+keyListener :
+    { onKeyDown : { acceptedKeys : List Key, toMsg : Key -> msg, preventDefault : Bool } }
+    -> Html msg
+keyListener { onKeyDown } =
+    let
+        keyFromString : String -> Maybe Key
+        keyFromString rawKey =
+            case rawKey of
+                "Esc" ->
+                    Just Escape
+
+                "Escape" ->
+                    Just Escape
+
+                _ ->
+                    Nothing
+
+        keyDecoder : List Key -> (Key -> msg) -> Json.Decode.Decoder msg
+        keyDecoder acceptedKeys toMsg =
+            Json.Decode.at [ "detail", "key" ] Json.Decode.string
+                |> Json.Decode.andThen
+                    (\rawKey ->
+                        case keyFromString rawKey of
+                            Just key ->
+                                if List.member key acceptedKeys then
+                                    Json.Decode.succeed (toMsg key)
+
+                                else
+                                    Json.Decode.fail "This key is not being listened to"
+
+                            Nothing ->
+                                Json.Decode.fail "The given key is not registered as a Key that the keyListener can listen to"
+                    )
+    in
+    node "key-listener"
+        [ on "listener-keydown" (keyDecoder onKeyDown.acceptedKeys onKeyDown.toMsg)
+        , attribute "keydown-prevent-default" (boolToString onKeyDown.preventDefault)
+        ]
+        []
+
+
 
 -- INTERNALS
+
+
+boolToString : Bool -> String
+boolToString b =
+    if b then
+        "true"
+
+    else
+        "false"
 
 
 optionalAttr : String -> Maybe String -> Html.Attribute msg

--- a/src/elm/View/Components.elm
+++ b/src/elm/View/Components.elm
@@ -2,7 +2,7 @@ module View.Components exposing
     ( loadingLogoAnimated, loadingLogoAnimatedFluid, loadingLogoWithCustomText
     , dialogBubble
     , tooltip, pdfViewer, dateViewer, infiniteList, ElementToTrack(..)
-    , bgNoScroll, PreventScroll(..), keyListener, Key(..)
+    , bgNoScroll, PreventScroll(..), keyListener, Key(..), focusTrap
     )
 
 {-| This module exports some simple components that don't need to manage any
@@ -31,7 +31,7 @@ state or configuration, such as loading indicators and containers
 
 # Helpers
 
-@docs bgNoScroll, PreventScroll, keyListener, Key
+@docs bgNoScroll, PreventScroll, keyListener, Key, focusTrap
 
 -}
 
@@ -279,7 +279,7 @@ subscriptions (because it would add a lot of complexity). Can be useful in
 "stateless" components, such as modals.
 -}
 keyListener :
-    { onKeyDown : { acceptedKeys : List Key, toMsg : Key -> msg, preventDefault : Bool } }
+    { onKeyDown : { acceptedKeys : List Key, toMsg : Key -> msg, stopPropagation : Bool } }
     -> Html msg
 keyListener { onKeyDown } =
     let
@@ -314,9 +314,16 @@ keyListener { onKeyDown } =
     in
     node "key-listener"
         [ on "listener-keydown" (keyDecoder onKeyDown.acceptedKeys onKeyDown.toMsg)
-        , attribute "keydown-prevent-default" (boolToString onKeyDown.preventDefault)
+        , attribute "keydown-stop-propagation" (boolToString onKeyDown.stopPropagation)
         ]
         []
+
+
+focusTrap : { firstFocusContainer : Maybe String } -> List (Html.Attribute msg) -> List (Html msg) -> Html msg
+focusTrap { firstFocusContainer } attrs children =
+    node "focus-trap"
+        (optionalAttr "first-focus-container" firstFocusContainer :: attrs)
+        children
 
 
 

--- a/src/elm/View/Form/Select.elm
+++ b/src/elm/View/Form/Select.elm
@@ -19,7 +19,7 @@ module View.Form.Select exposing
 -}
 
 import Html exposing (Html, li, text, ul)
-import Html.Attributes exposing (class, classList, disabled, selected, value)
+import Html.Attributes exposing (class, classList, disabled, selected, tabindex, value)
 import Html.Events exposing (onInput)
 import View.Form
 
@@ -90,6 +90,13 @@ toHtml select =
             Html.option
                 [ value (select.valueToString option.value)
                 , selected (select.value == option.value)
+                , tabindex
+                    (if select.value == option.value then
+                        0
+
+                     else
+                        -1
+                    )
                 ]
                 [ text option.label ]
 

--- a/src/elm/View/Form/Select.elm
+++ b/src/elm/View/Form/Select.elm
@@ -19,7 +19,7 @@ module View.Form.Select exposing
 -}
 
 import Html exposing (Html, li, text, ul)
-import Html.Attributes exposing (class, classList, disabled, selected, tabindex, value)
+import Html.Attributes exposing (class, classList, disabled, selected, value)
 import Html.Events exposing (onInput)
 import View.Form
 
@@ -90,13 +90,6 @@ toHtml select =
             Html.option
                 [ value (select.valueToString option.value)
                 , selected (select.value == option.value)
-                , tabindex
-                    (if select.value == option.value then
-                        0
-
-                     else
-                        -1
-                    )
                 ]
                 [ text option.label ]
 

--- a/src/elm/View/MarkdownEditor.elm
+++ b/src/elm/View/MarkdownEditor.elm
@@ -17,7 +17,6 @@ module View.MarkdownEditor exposing
     , withSubscription
     )
 
-import Browser.Dom
 import Browser.Events
 import Dict
 import Html exposing (Html, a, button, div, node, p, text)
@@ -36,7 +35,6 @@ import Parser
 import Parser.Advanced
 import Ports
 import Session.Shared exposing (Translators)
-import Task
 import View.Form
 import View.Form.Input as Input
 import View.Modal as Modal
@@ -77,8 +75,7 @@ type LinkModalState
 
 
 type Msg
-    = Ignored
-    | KeyDown String
+    = KeyDown String
     | ClickedIncludeLink Link
     | ClosedLinkModal
     | EnteredLinkLabel String
@@ -96,9 +93,6 @@ type Msg
 update : Msg -> Model -> ( Model, Cmd Msg )
 update msg model =
     case msg of
-        Ignored ->
-            ( model, Cmd.none )
-
         KeyDown key ->
             if key == "Enter" then
                 update ClickedAcceptLink model
@@ -107,10 +101,7 @@ update msg model =
                 ( model, Cmd.none )
 
         ClickedIncludeLink link ->
-            ( { model | linkModalState = Editing link }
-            , Browser.Dom.focus "link-modal-label"
-                |> Task.attempt (\_ -> Ignored)
-            )
+            ( { model | linkModalState = Editing link }, Cmd.none )
 
         ClosedLinkModal ->
             ( { model | linkModalState = NotShowing }, Cmd.none )
@@ -146,9 +137,7 @@ update msg model =
                     ( model, Cmd.none )
 
         ChangedText result ->
-            ( { model | contents = quillOpsToMarkdown result }
-            , Cmd.none
-            )
+            ( { model | contents = quillOpsToMarkdown result }, Cmd.none )
 
         RequestedSetContents ->
             ( model
@@ -851,9 +840,6 @@ linkDecoder =
 msgToString : Msg -> List String
 msgToString msg =
     case msg of
-        Ignored ->
-            [ "Ignored" ]
-
         KeyDown _ ->
             [ "KeyDown" ]
 

--- a/src/elm/View/Modal.elm
+++ b/src/elm/View/Modal.elm
@@ -195,18 +195,22 @@ viewModalDetails options =
                 FullScreen ->
                     "modal-content modal-content-full"
     in
-    div
-        [ class "modal fade-in" ]
+    div [ class "modal fade-in" ]
         [ View.Components.bgNoScroll
             [ class "modal-bg"
             , onClickNoBubble options.closeMsg
             ]
             options.preventScrolling
-        , div
-            [ class content
-            ]
+        , div [ class content ]
             [ header
             , body
             , footer
             ]
+        , View.Components.keyListener
+            { onKeyDown =
+                { acceptedKeys = [ View.Components.Escape ]
+                , toMsg = \_ -> options.closeMsg
+                , preventDefault = True
+                }
+            }
         ]

--- a/src/elm/View/Modal.elm
+++ b/src/elm/View/Modal.elm
@@ -31,7 +31,7 @@ and call `toHtml` at the end of the pipeline:
 -}
 
 import Html exposing (Html, button, div, h3, text)
-import Html.Attributes exposing (class)
+import Html.Attributes exposing (class, tabindex)
 import Icons
 import Utils exposing (onClickNoBubble)
 import View.Components
@@ -159,17 +159,17 @@ viewModalDetails options =
                     case options.size of
                         Default ->
                             div
-                                [ class "modal-body" ]
+                                [ class "modal-body", tabindex -1 ]
                                 b
 
                         Large ->
                             div
-                                [ class "modal-body-lg" ]
+                                [ class "modal-body-lg", tabindex -1 ]
                                 b
 
                         FullScreen ->
                             div
-                                [ class "modal-body modal-body-full" ]
+                                [ class "modal-body modal-body-full", tabindex -1 ]
                                 b
 
                 Nothing ->
@@ -201,7 +201,7 @@ viewModalDetails options =
             , onClickNoBubble options.closeMsg
             ]
             options.preventScrolling
-        , View.Components.focusTrap { firstFocusContainer = Just ".modal-body" }
+        , View.Components.focusTrap { firstFocusContainer = Just ".modal-body, .modal-body-lg" }
             [ class content ]
             [ header
             , body

--- a/src/elm/View/Modal.elm
+++ b/src/elm/View/Modal.elm
@@ -146,7 +146,7 @@ viewModalDetails options =
                     Nothing ->
                         text ""
                 , button
-                    [ class "ml-auto text-gray-400 focus:text-red focus:outline-none"
+                    [ class "ml-auto text-gray-400 hover:text-red focus:text-red focus:outline-none"
                     , onClickNoBubble options.closeMsg
                     ]
                     [ Icons.close "fill-current"
@@ -201,7 +201,7 @@ viewModalDetails options =
             , onClickNoBubble options.closeMsg
             ]
             options.preventScrolling
-        , View.Components.focusTrap { firstFocusContainer = Just ".modal-body, .modal-body-lg" }
+        , View.Components.focusTrap { firstFocusContainer = Just ".modal-body, .modal-body-lg, .modal-footer" }
             [ class content ]
             [ header
             , body

--- a/src/elm/View/Modal.elm
+++ b/src/elm/View/Modal.elm
@@ -146,10 +146,10 @@ viewModalDetails options =
                     Nothing ->
                         text ""
                 , button
-                    [ class "ml-auto"
+                    [ class "ml-auto text-gray-400 focus:text-red focus:outline-none"
                     , onClickNoBubble options.closeMsg
                     ]
-                    [ Icons.close "text-gray-400 fill-current"
+                    [ Icons.close "fill-current"
                     ]
                 ]
 
@@ -201,7 +201,8 @@ viewModalDetails options =
             , onClickNoBubble options.closeMsg
             ]
             options.preventScrolling
-        , div [ class content ]
+        , View.Components.focusTrap { firstFocusContainer = Just ".modal-body" }
+            [ class content ]
             [ header
             , body
             , footer
@@ -210,7 +211,7 @@ viewModalDetails options =
             { onKeyDown =
                 { acceptedKeys = [ View.Components.Escape ]
                 , toMsg = \_ -> options.closeMsg
-                , preventDefault = True
+                , stopPropagation = True
                 }
             }
         ]

--- a/src/index.js
+++ b/src/index.js
@@ -54,11 +54,12 @@ window.customElements.define('focus-trap',
 
     connectedCallback () {
       let elementToFocus = this.focusables(this)[0]
-      const firstFocusableContainer = this.querySelector(this.getAttribute('first-focus-container'))
-      if (firstFocusableContainer !== null) {
-        const focusables = this.focusables(firstFocusableContainer)
+      const firstFocusableContainers = this.querySelectorAll(this.getAttribute('first-focus-container'))
+      for (const container of firstFocusableContainers) {
+        const focusables = this.focusables(container)
         if (focusables.length > 0) {
           elementToFocus = focusables[0]
+          break
         }
       }
 

--- a/src/index.js
+++ b/src/index.js
@@ -53,13 +53,19 @@ window.customElements.define('focus-trap',
     }
 
     connectedCallback () {
-      const firstFocusContainer = this.getAttribute('first-focus-container')
-      if (firstFocusContainer) {
-        const container = this.querySelector(firstFocusContainer)
-        this.focusables(container)[0].focus()
-      } else {
-        this.focusables(this)[0].focus()
+      let elementToFocus = this.focusables(this)[0]
+      const firstFocusableContainer = this.querySelector(this.getAttribute('first-focus-container'))
+      if (firstFocusableContainer !== null) {
+        const focusables = this.focusables(firstFocusableContainer)
+        if (focusables.length > 0) {
+          elementToFocus = focusables[0]
+        }
       }
+
+      if (elementToFocus) {
+        elementToFocus.focus()
+      }
+
       document.addEventListener('keydown', this._keydownListener)
     }
 
@@ -69,7 +75,18 @@ window.customElements.define('focus-trap',
     }
 
     focusables (parent) {
-      return parent.querySelectorAll('a[href]:not([disabled]), button:not([disabled]), textarea:not([disabled]), input[type="text"]:not([disabled]), input[type="radio"]:not([disabled]), input[type="checkbox"]:not([disabled]), select:not([disabled]), [contenteditable="true"]')
+      const tabbableElements = [
+        'a[href]',
+        'button',
+        'textarea',
+        'input[type="text"]',
+        'input[type="radio"]',
+        'input[type="checkbox"]',
+        'select',
+        '[contenteditable="true"]'
+      ].map((selector) => `${selector}:not([disabled]):not([tabindex="-1"])`)
+
+      return parent.querySelectorAll(tabbableElements.join(', '))
     }
   }
 )

--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,37 @@ pdfjsLib.GlobalWorkerOptions.workerSrc = '/pdf.worker.min.js'
 // =========================================
 /* global HTMLElement, CustomEvent */
 
+window.customElements.define('key-listener',
+  class KeyListener extends HTMLElement {
+    static get observedAttributes () { return ['keydown-prevent-default'] }
+
+    constructor () {
+      super()
+
+      this._keydownListener = (e) => {
+        if (this._keydownPreventDefault) {
+          e.preventDefault()
+        }
+        this.dispatchEvent(new CustomEvent('listener-keydown', { detail: { key: e.key } }))
+      }
+    }
+
+    attributeChangedCallback (name, oldValue, newValue) {
+      if (name === 'keydown-prevent-default') {
+        this._keydownPreventDefault = newValue === 'true'
+      }
+    }
+
+    connectedCallback () {
+      document.addEventListener('keydown', this._keydownListener)
+    }
+
+    disconnectedCallback () {
+      document.removeEventListener('keydown', this._keydownListener)
+    }
+  }
+)
+
 window.customElements.define('markdown-editor',
   class MarkdownEditor extends HTMLElement {
     static get observedAttributes () { return [ 'elm-edit-text', 'elm-remove-text', 'elm-disabled' ] }


### PR DESCRIPTION
## What issue does this PR close
Closes #618 

## Changes Proposed ( a list of new changes introduced by this PR)
- Fix overflowing issue with the "Add contact" modal
- Make the contact flag selection element and the user nav a lot more accessible
- Add a `keyListener` custom element. It's useful to listen for keys without the need for a subscription. It's very extensible, allowing us to listen to any event, such as `keydown`, `keypress` and `keyup`. It also allows for multiple (typed) keys to be listened to, and to `stopPropagation`. We use this element to listen for `Escape` on modals.
- Add a `focusTrap` custom element. It acts like a `div`, but won't let focus get outside of it. [We should be careful when using it though](https://developers.google.com/web/fundamentals/accessibility/focus/using-tabindex#modals_and_keyboard_traps)

## How to test ( a list of instructions on how to test this PR)
Testing modals:
1. Open up a modal
2. Press `Tab` a bunch of times. That should cycle the focus within the modal, but shouldn't focus elements outside of the modal. Do the same with `Shift+Tab` (to go in the opposite direction)
3. Make sure you can exit it by pressing `Esc` on your keyboard, clicking outside of it and by clicking on the "X" button on the top

Testing the contact flag selection:
1. Go to either the "Edit contact" page on your profile, or to the "Add contact" modal on the dashboard (it only shows up if you have no contact options)
2. Press `Tab` and notice how the select is only focused once. If you enter the select, you should see that pressing the up key or down key cycles through the options