### PR TITLE
Fix register page styles on small screens

### DIFF
--- a/src/elm/Page/Register.elm
+++ b/src/elm/Page/Register.elm
@@ -470,7 +470,7 @@ viewTitleForStep { t, tr } s =
                     "2"
     in
     p
-        [ class "md:ml-4 py-4 mb-4 text-body border-b border-dotted text-grey border-grey-500" ]
+        [ class "ml-4 py-4 mb-4 text-body border-b border-dotted text-grey border-grey-500 md:ml-6" ]
         [ text (tr "register.form.step" [ ( "stepNum", stepNum ) ])
         , text " / "
         , strong

--- a/src/elm/Page/Register.elm
+++ b/src/elm/Page/Register.elm
@@ -192,7 +192,7 @@ viewCreateAccount guest model =
             guest.shared
 
         formClasses =
-            "flex flex-grow flex-col bg-white px-4 px-0 md:max-w-sm sf-wrapper self-center w-full"
+            "flex flex-grow flex-col bg-white px-4 md:px-0 md:max-w-sm sf-wrapper self-center w-full"
 
         backgroundColor =
             case model.step of
@@ -470,7 +470,7 @@ viewTitleForStep { t, tr } s =
                     "2"
     in
     p
-        [ class "ml-4 py-4 mb-4 text-body border-b border-dotted text-grey border-grey-500" ]
+        [ class "md:ml-4 py-4 mb-4 text-body border-b border-dotted text-grey border-grey-500" ]
         [ text (tr "register.form.step" [ ( "stepNum", stepNum ) ])
         , text " / "
         , strong


### PR DESCRIPTION
## What issue does this PR close
Closes #630 

## Changes Proposed ( a list of new changes introduced by this PR)
- Fix spacing

## How to test ( a list of instructions on how to test this PR)
1. Go to the register page on a small screen (< 768px) (you might need to log in, switch to a community that doesn't require invites, and log out to be able to access the register page)
2. Check if there is a space between the form fields and the sides of the screen