### PR TITLE
Enhancement/responsive search

### DIFF
--- a/src/elm/Session/Guest.elm
+++ b/src/elm/Session/Guest.elm
@@ -30,7 +30,6 @@ import Html.Events exposing (onClick, onMouseEnter)
 import Http
 import I18Next exposing (Delims(..), Translations)
 import Icons
-import Json.Decode as Decode
 import Json.Encode as Encode
 import Log
 import Ports
@@ -42,6 +41,7 @@ import Task
 import Translation
 import UpdateResult as UR
 import Url
+import Utils
 import View.Feedback as Feedback
 
 
@@ -128,7 +128,7 @@ initModel shared =
 
 subscriptions : Model -> Sub Msg
 subscriptions _ =
-    Sub.map KeyDown (Browser.Events.onKeyDown (Decode.field "key" Decode.string))
+    Utils.escSubscription PressedEsc
 
 
 
@@ -334,7 +334,7 @@ type Msg
     | ClickedTryAgainTranslation
     | ShowLanguageNav Bool
     | ClickedLanguage Translation.Language
-    | KeyDown String
+    | PressedEsc
     | CompletedLoadCommunityPreview (RemoteData (Graphql.Http.Error (Maybe Community.CommunityPreview)) (Maybe Community.CommunityPreview))
     | GotFeedbackMsg Feedback.Msg
 
@@ -384,14 +384,9 @@ update msg ({ shared } as model) =
                 |> UR.init
                 |> UR.addCmd (fetchTranslations lang)
 
-        KeyDown key ->
-            if key == "Esc" || key == "Escape" then
-                { model | showLanguageNav = False }
-                    |> UR.init
-
-            else
-                model
-                    |> UR.init
+        PressedEsc ->
+            { model | showLanguageNav = False }
+                |> UR.init
 
         CompletedLoadCommunityPreview (RemoteData.Success (Just communityPreview)) ->
             { model | community = RemoteData.Success communityPreview }
@@ -506,8 +501,8 @@ msgToString msg =
         ClickedLanguage _ ->
             [ "ClickedLanguage" ]
 
-        KeyDown _ ->
-            [ "KeyDown" ]
+        PressedEsc ->
+            [ "PressedEsc" ]
 
         CompletedLoadCommunityPreview r ->
             [ "CompletedLoadCommunityPreview", UR.remoteDataToString r ]

--- a/src/elm/Session/Guest.elm
+++ b/src/elm/Session/Guest.elm
@@ -17,7 +17,6 @@ module Session.Guest exposing
 
 import Api.Graphql
 import Auth
-import Browser.Events
 import Browser.Navigation
 import Community
 import Dict

--- a/src/elm/Session/LoggedIn.elm
+++ b/src/elm/Session/LoggedIn.elm
@@ -27,7 +27,6 @@ import Api
 import Api.Graphql
 import Auth
 import Avatar
-import Browser.Events
 import Cambiatus.Object
 import Cambiatus.Object.UnreadNotifications
 import Cambiatus.Subscription as Subscription
@@ -62,6 +61,7 @@ import Task
 import Time
 import Translation
 import UpdateResult as UR
+import Utils
 import View.Components
 import View.Feedback as Feedback
 import View.Modal as Modal
@@ -79,7 +79,6 @@ init shared accountName authToken =
     , Cmd.batch
         [ Api.Graphql.query shared (Just authToken) (Profile.query accountName) CompletedLoadProfile
         , fetchCommunity shared authToken Nothing
-        , Ports.getRecentSearches () -- run on the page refresh, duplicated in `initLogin`
         , Task.perform GotTimeInternal Time.now
         ]
     )
@@ -121,8 +120,7 @@ initLogin shared maybePrivateKey_ profile_ authToken =
     in
     ( initModel shared maybePrivateKey_ profile_.account authToken
     , Cmd.batch
-        [ Ports.getRecentSearches () -- run on the passphrase login, duplicated in `init`
-        , loadedProfile
+        [ loadedProfile
         , fetchCommunity shared authToken Nothing
         , Task.perform GotTimeInternal Time.now
         ]
@@ -139,17 +137,7 @@ subscriptions model =
         [ Sub.map GotSearchMsg Search.subscriptions
         , Sub.map GotActionMsg (Action.subscriptions model.claimingAction)
         , if model.showUserNav then
-            Decode.field "key" Decode.string
-                |> Decode.andThen
-                    (\key ->
-                        if key == "Esc" || key == "Escape" then
-                            Decode.succeed ()
-
-                        else
-                            Decode.fail "Expecting Escape key"
-                    )
-                |> Browser.Events.onKeyDown
-                |> Sub.map (\_ -> ShowUserNav False)
+            Utils.escSubscription (ShowUserNav False)
 
           else
             Sub.none
@@ -482,7 +470,7 @@ viewHeader page ({ shared } as model) profile_ =
                 ]
         , div [ class "flex items-center float-right" ]
             [ a
-                [ class "outline-none relative mx-6"
+                [ class "outline-none relative mx-6 rounded focus:ring focus:ring-offset-4"
                 , Route.href Route.Notification
                 ]
                 [ Icons.notification "fill-current text-black"
@@ -495,7 +483,7 @@ viewHeader page ({ shared } as model) profile_ =
                 ]
             , div [ class "relative z-50" ]
                 [ button
-                    [ class "h-12 z-10 bg-gray-200 py-2 px-3 relative hidden lg:visible lg:flex"
+                    [ class "h-12 z-10 bg-gray-200 py-2 px-3 relative hidden lg:visible lg:flex focus:outline-none focus:ring"
                     , classList [ ( "rounded-tr-lg rounded-tl-lg", model.showUserNav ) ]
                     , classList [ ( "rounded-lg", not model.showUserNav ) ]
                     , type_ "button"
@@ -512,7 +500,7 @@ viewHeader page ({ shared } as model) profile_ =
                     , Icons.arrowDown "float-right"
                     ]
                 , button
-                    [ class "h-12 z-10 py-2 px-3 flex relative lg:hidden"
+                    [ class "h-8 z-10 my-1 ml-3 flex relative lg:hidden focus:outline-none focus:ring"
                     , classList [ ( "rounded-tr-lg rounded-tl-lg", model.showUserNav ) ]
                     , classList [ ( "rounded-lg", not model.showUserNav ) ]
                     , type_ "button"
@@ -1074,6 +1062,7 @@ update msg model =
             in
             UR.init newModel
                 |> UR.addCmd cmd
+                |> UR.addCmd (Ports.getRecentSearches ())
                 |> UR.addExt (CommunityLoaded community |> Broadcast)
                 |> UR.addBreadcrumb
                     { type_ = Log.DefaultBreadcrumb

--- a/src/elm/Utils.elm
+++ b/src/elm/Utils.elm
@@ -3,6 +3,7 @@ module Utils exposing
     , decodeEnterKeyDown
     , decodeTimestamp
     , errorToString
+    , escSubscription
     , formatFloat
     , fromDateTime
     , fromMaybeDateTime
@@ -11,6 +12,7 @@ module Utils exposing
     , previousDay
     )
 
+import Browser.Events
 import Cambiatus.Scalar exposing (DateTime(..))
 import Date
 import Graphql.Http
@@ -117,6 +119,21 @@ formatFloat number decimalCases useSeparator =
                                 "0"
                 in
                 String.join newSeparator [ addThousandsSeparator beforeSeparator, paddedSeparator ]
+
+
+escSubscription : msg -> Sub msg
+escSubscription toMsg =
+    Decode.field "key" Decode.string
+        |> Decode.andThen
+            (\key ->
+                if key == "Esc" || key == "Escape" then
+                    Decode.succeed ()
+
+                else
+                    Decode.fail "Expecting Escape key"
+            )
+        |> Browser.Events.onKeyDown
+        |> Sub.map (\_ -> toMsg)
 
 
 decodeTimestamp : Decode.Decoder Posix


### PR DESCRIPTION
## What issue does this PR close
Closes #617 

## Changes Proposed ( a list of new changes introduced by this PR)
- Get recent searches only when community is done loading (there were apparently some race conditions before)
- Adjust maximum number of recent searches (was 3, now it's 10)
- Improve accessibility (with tabindex and focus styles)
- Close search when pressing Esc
- Request search results as the user types

## How to test ( a list of instructions on how to test this PR)
1. Open the search bar
2. Make sure you can close it by pressing Esc.
3. Open the search bar again
4. Start typing something. Results should show up as you type. If you erase it, you should see your recent searches again.
5. Try navigating with Tab. It should be clear what element you're focusing, and it should follow a logical order (left-to-right, top-to-bottom)