### PR TITLE
Enhancement/incremental community fields

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -26,7 +26,7 @@
             "elm/svg": "1.0.1",
             "elm/time": "1.0.0",
             "elm/url": "1.0.0",
-            "elm-community/list-extra": "8.2.4",
+            "elm-community/list-extra": "8.5.1",
             "elm-community/maybe-extra": "5.2.0",
             "elm-community/string-extra": "4.0.1",
             "jfmengels/elm-review": "2.3.2",

--- a/public/translations/amh-ETH.json
+++ b/public/translations/amh-ETH.json
@@ -471,6 +471,7 @@
       "action_count": "{{actions}} ተግባራት",
       "complete": "ተጠናቅቋል",
       "edit": "አርትእ ዓላማዎችን",
+      "error_loading": "ግቦቹን ሲጭኑ አንድ የተሳሳተ ነገር ተከሰተ",
       "editor": {
         "not_found": "አልተገኘም",
         "error": "ዉይ የሆነ ችግር ተከስቷል!",

--- a/public/translations/cat-CAT.json
+++ b/public/translations/cat-CAT.json
@@ -513,6 +513,7 @@
       "action_count": "{{actions}} accions",
       "complete": "Completat",
       "edit": "Edita l'objectiu",
+      "error_loading": "S'ha produït un error en carregar els objectius",
       "editor": {
         "not_found": "No trobat",
         "error": "Ui! Quelcom ha fallat",

--- a/public/translations/en-US.json
+++ b/public/translations/en-US.json
@@ -509,6 +509,7 @@
       "action_count": "{{actions}} actions",
       "complete": "Complete",
       "edit": "Edit objective",
+      "error_loading": "Something went wrong when loading objectives",
       "editor": {
         "not_found": "Not Found",
         "error": "Ops something went wrong!",

--- a/public/translations/es-ES.json
+++ b/public/translations/es-ES.json
@@ -513,6 +513,7 @@
       "action_count": "{{actions}} acciones",
       "complete": "Terminado",
       "edit": "Editar objetivo",
+      "error_loading": "Ocurrió algo mal al cargar los objetivos",
       "editor": {
         "not_found": "No encontrado",
         "error": "¡Huy! Algo salió mal",

--- a/public/translations/pt-BR.json
+++ b/public/translations/pt-BR.json
@@ -517,6 +517,7 @@
       "action_count": "{{actions}} ações",
       "complete": "Completo",
       "edit": "Editar objetivo",
+      "error_loading": "Algo de errado aconteceu ao carregar os objetivos",
       "editor": {
         "not_found": "Não encontrado",
         "error": "Ops algo deu errado!",

--- a/src/elm/Community.elm
+++ b/src/elm/Community.elm
@@ -106,18 +106,13 @@ type alias Model =
     , productCount : Int
     , orderCount : Int
     , members : List Profile.Minimal
-
-    -- TODO - Figure out a type for this
-    , objectives : RemoteData () (List Objective)
+    , objectives : RemoteData (Graphql.Http.Error (List Objective)) (List Objective)
     , hasObjectives : Bool
     , hasShop : Bool
     , hasKyc : Bool
     , hasAutoInvite : Bool
     , validators : List Eos.Name
-
-    -- , validators : RemoteData () (List Eos.Name)
-    -- , uploads : List String
-    , uploads : RemoteData () (List String)
+    , uploads : RemoteData (Graphql.Http.Error (List String)) (List String)
     , website : Maybe String
     }
 

--- a/src/elm/Community.elm
+++ b/src/elm/Community.elm
@@ -32,6 +32,7 @@ module Community exposing
     , newCommunitySubscription
     , queryForField
     , queryForFields
+    , setFieldAsLoading
     , setFieldValue
     , subdomainQuery
     , symbolQuery
@@ -157,6 +158,16 @@ setFieldValue fieldValue model =
 
         UploadsValue uploads ->
             { model | uploads = RemoteData.Success uploads }
+
+
+setFieldAsLoading : Field -> Model -> Model
+setFieldAsLoading field model =
+    case field of
+        ObjectivesField ->
+            { model | objectives = RemoteData.Loading }
+
+        UploadsField ->
+            { model | uploads = RemoteData.Loading }
 
 
 isFieldLoading : Field -> Model -> Bool

--- a/src/elm/Community.elm
+++ b/src/elm/Community.elm
@@ -248,7 +248,6 @@ communitySelectionSet =
         |> with Community.hasKyc
         |> with Community.autoInvite
         |> with (Community.validators (Eos.nameSelectionSet Profile.account))
-        -- |> with (Community.uploads Upload.url)
         |> SelectionSet.hardcoded RemoteData.NotAsked
         |> with Community.website
 

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -1224,7 +1224,7 @@ changeRouteTo maybeRoute model =
 
         Just Route.Community ->
             (\l -> CommunityPage.init l)
-                >> updateStatusWith Community GotCommunityMsg model
+                >> updateLoggedInUResult Community GotCommunityMsg model
                 |> withLoggedIn Route.Community
 
         Just Route.CommunitySettings ->

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -1274,12 +1274,12 @@ changeRouteTo maybeRoute model =
 
         Just (Route.NewAction objectiveId) ->
             (\l -> ActionEditor.init l objectiveId Nothing)
-                >> updateStatusWith ActionEditor GotActionEditorMsg model
+                >> updateLoggedInUResult ActionEditor GotActionEditorMsg model
                 |> withLoggedIn (Route.NewAction objectiveId)
 
         Just (Route.EditAction objectiveId actionId) ->
             (\l -> ActionEditor.init l objectiveId (Just actionId))
-                >> updateStatusWith ActionEditor GotActionEditorMsg model
+                >> updateLoggedInUResult ActionEditor GotActionEditorMsg model
                 |> withLoggedIn (Route.EditAction objectiveId actionId)
 
         Just (Route.Claim objectiveId actionId claimId) ->

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -823,8 +823,7 @@ updateLoggedInUResult toStatus toMsg model uResult =
                                 )
                                 updateResult.afterAuthMsg
                       }
-                    , Cmd.map toMsg updateResult.externalCmd
-                        :: Cmd.map (Page.GotLoggedInMsg >> GotPageMsg) updateResult.cmd
+                    , Cmd.map (Page.GotLoggedInMsg >> GotPageMsg) updateResult.cmd
                         :: broadcastCmd
                         :: cmds_
                     )

--- a/src/elm/Page/Community.elm
+++ b/src/elm/Page/Community.elm
@@ -403,7 +403,7 @@ msgToString msg =
             [ "NoOp" ]
 
         RequestedCommunityObjectives ->
-            [ "RequestedReloadCommunity" ]
+            [ "RequestedCommunityObjectives" ]
 
         CompletedLoadCommunity _ ->
             [ "CompletedLoadCommunity" ]

--- a/src/elm/Page/Community.elm
+++ b/src/elm/Page/Community.elm
@@ -23,7 +23,6 @@ import Page
 import RemoteData exposing (RemoteData)
 import Session.LoggedIn as LoggedIn exposing (External(..))
 import Session.Shared exposing (Shared, Translators)
-import Task
 import Time exposing (Posix, posixToMillis)
 import Token
 import UpdateResult as UR
@@ -36,11 +35,11 @@ import View.MarkdownEditor
 -- INIT
 
 
-init : LoggedIn.Model -> ( Model, Cmd Msg )
+init : LoggedIn.Model -> UpdateResult
 init loggedIn =
-    ( initModel loggedIn
-    , Task.succeed RequestedReloadCommunityObjectives |> Task.perform identity
-    )
+    initModel loggedIn
+        |> UR.init
+        |> UR.addExt (LoggedIn.RequestedReloadCommunityField Community.ObjectivesField)
 
 
 initModel : LoggedIn.Model -> Model
@@ -353,7 +352,6 @@ type alias UpdateResult =
 
 type Msg
     = NoOp
-    | RequestedReloadCommunityObjectives
     | CompletedLoadCommunity Community.Model
     | GotTokenInfo (Result Http.Error Token.Model)
       -- Objective
@@ -367,10 +365,6 @@ update msg model loggedIn =
     case msg of
         NoOp ->
             UR.init model
-
-        RequestedReloadCommunityObjectives ->
-            UR.init model
-                |> UR.addExt (LoggedIn.RequestedReloadCommunityField Community.ObjectivesField)
 
         CompletedLoadCommunity community ->
             UR.init model
@@ -422,9 +416,6 @@ msgToString msg =
     case msg of
         NoOp ->
             [ "NoOp" ]
-
-        RequestedReloadCommunityObjectives ->
-            [ "RequestedReloadCommunityObjectives" ]
 
         CompletedLoadCommunity _ ->
             [ "CompletedLoadCommunity" ]

--- a/src/elm/Page/Community/ActionEditor.elm
+++ b/src/elm/Page/Community/ActionEditor.elm
@@ -79,16 +79,16 @@ type alias ActionId =
     Int
 
 
-init : LoggedIn.Model -> ObjectiveId -> Maybe ActionId -> ( Model, Cmd Msg )
+init : LoggedIn.Model -> ObjectiveId -> Maybe ActionId -> UpdateResult
 init loggedIn objectiveId actionId =
-    ( { status = NotFound
-      , objectiveId = objectiveId
-      , actionId = actionId
-      , form = initForm loggedIn.shared
-      , multiSelectState = Select.newState ""
-      }
-    , LoggedIn.maybeInitWith CompletedLoadCommunity .selectedCommunity loggedIn
-    )
+    { status = Loading
+    , objectiveId = objectiveId
+    , actionId = actionId
+    , form = initForm loggedIn.shared
+    , multiSelectState = Select.newState ""
+    }
+        |> UR.init
+        |> UR.addExt (LoggedIn.RequestedCommunityField Community.ObjectivesField)
 
 
 
@@ -106,6 +106,7 @@ type alias Model =
 
 type Status
     = Authorized
+    | Loading
     | NotFound
     | Unauthorized
 
@@ -473,7 +474,7 @@ type alias UpdateResult =
 
 type Msg
     = NoOp
-    | CompletedLoadCommunity Community.Model
+    | CompletedLoadObjectives Community.Model (List Community.Objective)
     | ClosedAuthModal
     | OnSelectVerifier (Maybe Profile.Minimal)
     | OnRemoveVerifier Profile.Minimal
@@ -559,38 +560,17 @@ update msg model ({ shared } as loggedIn) =
         NoOp ->
             UR.init model
 
-        CompletedLoadCommunity community ->
+        CompletedLoadObjectives community objectives ->
             if community.creator == loggedIn.accountName then
-                -- Check the action belongs to the objective
                 let
                     maybeObjective =
-                        -- List.filterMap
-                        --     (\o ->
-                        --         if o.id == model.objectiveId then
-                        --             Just o
-                        --         else
-                        --             Nothing
-                        --     )
-                        --     community.objectives
-                        --     |> List.head
-                        -- TODO
-                        Nothing
+                        List.find (.id >> (==) model.objectiveId) objectives
                 in
                 case ( maybeObjective, model.actionId ) of
                     ( Just objective, Just actionId ) ->
-                        -- Edit form
                         let
                             maybeAction =
-                                List.filterMap
-                                    (\a ->
-                                        if a.id == actionId then
-                                            Just a
-
-                                        else
-                                            Nothing
-                                    )
-                                    objective.actions
-                                    |> List.head
+                                List.find (.id >> (==) actionId) objective.actions
                         in
                         case maybeAction of
                             Just action ->
@@ -1033,7 +1013,7 @@ update msg model ({ shared } as loggedIn) =
                 |> UR.addCmd (Route.replaceUrl loggedIn.shared.navKey Route.Objectives)
                 |> UR.addExt (ShowFeedback Feedback.Success (t "community.actions.save_success"))
                 -- TODO - This only works sometimes
-                |> UR.addExt (LoggedIn.ReloadResource LoggedIn.CommunityResource)
+                |> UR.addExt (LoggedIn.RequestedReloadCommunityField Community.ObjectivesField)
                 |> UR.addBreadcrumb
                     { type_ = Log.DebugBreadcrumb
                     , category = msg
@@ -1272,6 +1252,9 @@ view ({ shared } as loggedIn) model =
                     Page.fullPageLoading shared
 
                 ( RemoteData.NotAsked, _ ) ->
+                    Page.fullPageLoading shared
+
+                ( _, Loading ) ->
                     Page.fullPageLoading shared
 
                 ( RemoteData.Success community, Authorized ) ->
@@ -1865,8 +1848,8 @@ subscriptions model =
 receiveBroadcast : LoggedIn.BroadcastMsg -> Maybe Msg
 receiveBroadcast broadcastMsg =
     case broadcastMsg of
-        LoggedIn.CommunityLoaded community ->
-            Just (CompletedLoadCommunity community)
+        LoggedIn.CommunityFieldLoaded community (Community.ObjectivesValue objectives) ->
+            Just (CompletedLoadObjectives community objectives)
 
         _ ->
             Nothing
@@ -1897,8 +1880,8 @@ msgToString msg =
         NoOp ->
             [ "NoOp" ]
 
-        CompletedLoadCommunity _ ->
-            [ "CompletedLoadCommunity" ]
+        CompletedLoadObjectives _ _ ->
+            [ "CompletedLoadObjectives" ]
 
         ClosedAuthModal ->
             [ "ClosedAuthModal" ]

--- a/src/elm/Page/Community/ActionEditor.elm
+++ b/src/elm/Page/Community/ActionEditor.elm
@@ -564,16 +564,17 @@ update msg model ({ shared } as loggedIn) =
                 -- Check the action belongs to the objective
                 let
                     maybeObjective =
-                        List.filterMap
-                            (\o ->
-                                if o.id == model.objectiveId then
-                                    Just o
-
-                                else
-                                    Nothing
-                            )
-                            community.objectives
-                            |> List.head
+                        -- List.filterMap
+                        --     (\o ->
+                        --         if o.id == model.objectiveId then
+                        --             Just o
+                        --         else
+                        --             Nothing
+                        --     )
+                        --     community.objectives
+                        --     |> List.head
+                        -- TODO
+                        Nothing
                 in
                 case ( maybeObjective, model.actionId ) of
                     ( Just objective, Just actionId ) ->

--- a/src/elm/Page/Community/ObjectiveEditor.elm
+++ b/src/elm/Page/Community/ObjectiveEditor.elm
@@ -112,6 +112,7 @@ type alias UpdateResult =
 
 type Msg
     = CompletedLoadCommunity Community.Model
+    | CompletedLoadObjectives (List Community.Objective)
     | ClosedAuthModal
     | GotDescriptionEditorMsg MarkdownEditor.Msg
     | ClickedSaveObjective
@@ -394,24 +395,26 @@ update msg model loggedIn =
                 if model.status == Loading then
                     case model.objectiveId of
                         Just objectiveId ->
-                            case List.find (\o -> o.id == objectiveId) community.objectives of
-                                Just objective ->
-                                    { model
-                                        | status =
-                                            Editing
-                                                |> EditingObjective objective
-                                                    { description =
-                                                        MarkdownEditor.init "objective-description"
-                                                            |> MarkdownEditor.setContents objective.description
-                                                    , isCompleted = objective.isCompleted
-                                                    }
-                                                |> Authorized
-                                    }
-                                        |> UR.init
-
-                                Nothing ->
-                                    { model | status = NotFound }
-                                        |> UR.init
+                            -- case List.find (\o -> o.id == objectiveId) community.objectives of
+                            --     Just objective ->
+                            --         { model
+                            --             | status =
+                            --                 Editing
+                            --                     |> EditingObjective objective
+                            --                         { description =
+                            --                             MarkdownEditor.init "objective-description"
+                            --                                 |> MarkdownEditor.setContents objective.description
+                            --                         , isCompleted = objective.isCompleted
+                            --                         }
+                            --                     |> Authorized
+                            --         }
+                            --             |> UR.init
+                            --     Nothing ->
+                            --         { model | status = NotFound }
+                            --             |> UR.init
+                            -- TODO
+                            model
+                                |> UR.init
 
                         Nothing ->
                             { model
@@ -428,6 +431,11 @@ update msg model loggedIn =
             else
                 { model | status = Unauthorized }
                     |> UR.init
+
+        CompletedLoadObjectives objectives ->
+            -- TODO
+            model
+                |> UR.init
 
         ClosedAuthModal ->
             case model.status of
@@ -688,8 +696,6 @@ update msg model loggedIn =
                                         , level = Log.Warning
                                         }
 
-                -- =======
-                -- >>>>>>> master
                 _ ->
                     model
                         |> UR.init
@@ -938,6 +944,9 @@ msgToString msg =
     case msg of
         CompletedLoadCommunity _ ->
             [ "CompletedLoadCommunity" ]
+
+        CompletedLoadObjectives _ ->
+            [ "CompletedLoadObjectives" ]
 
         ClosedAuthModal ->
             [ "ClosedAuthModal" ]

--- a/src/elm/Page/Community/ObjectiveEditor.elm
+++ b/src/elm/Page/Community/ObjectiveEditor.elm
@@ -801,7 +801,7 @@ update msg model loggedIn =
             UR.init model
                 |> UR.addExt (ShowFeedback Feedback.Success (t "community.objectives.create_success"))
                 -- TODO - This only works sometimes
-                |> UR.addExt (LoggedIn.ReloadResource LoggedIn.CommunityResource)
+                |> UR.addExt (LoggedIn.RequestedReloadCommunityField Community.ObjectivesField)
                 |> UR.addCmd (Route.replaceUrl loggedIn.shared.navKey Route.Community)
 
         GotSaveObjectiveResponse (Err v) ->

--- a/src/elm/Page/Community/Objectives.elm
+++ b/src/elm/Page/Community/Objectives.elm
@@ -81,10 +81,12 @@ view ({ shared } as loggedIn) model =
                         , div [ class "container mx-auto px-4 my-10" ]
                             [ div [ class "flex justify-end mb-10" ] [ viewNewObjectiveButton loggedIn community ]
                             , div []
-                                (community.objectives
+                                -- (community.objectives
+                                -- TODO
+                                ([]
                                     |> List.sortBy .id
                                     |> List.reverse
-                                    |> List.indexedMap (viewObjective loggedIn model community)
+                                    |> List.indexedMap (viewObjective loggedIn model)
                                 )
                             ]
                         ]
@@ -126,8 +128,8 @@ viewNewObjectiveButton ({ shared } as loggedIn) community =
         text ""
 
 
-viewObjective : LoggedIn.Model -> Model -> Community.Model -> Int -> Community.Objective -> Html Msg
-viewObjective ({ shared } as loggedIn) model _ index objective =
+viewObjective : LoggedIn.Model -> Model -> Int -> Community.Objective -> Html Msg
+viewObjective ({ shared } as loggedIn) model index objective =
     let
         isOpen : Bool
         isOpen =
@@ -409,32 +411,34 @@ update msg model loggedIn =
                         }
 
             else
-                { model
-                    | openObjective = Just index
-                    , profileSummaries =
-                        loggedIn.selectedCommunity
-                            |> RemoteData.toMaybe
-                            |> Maybe.map .objectives
-                            |> Maybe.andThen (List.getAt index)
-                            |> Maybe.map .actions
-                            |> Maybe.withDefault []
-                            |> List.map
-                                (\action ->
-                                    ( action.id
-                                    , List.length action.validators
-                                        |> Profile.Summary.initMany False
-                                    )
-                                )
-                            |> Dict.fromList
-                }
-                    |> UR.init
-                    |> UR.addBreadcrumb
-                        { type_ = Log.DebugBreadcrumb
-                        , category = msg
-                        , message = "Closed objective"
-                        , data = Dict.fromList [ ( "objectiveId", Encode.int index ) ]
-                        , level = Log.DebugLevel
-                        }
+                -- { model
+                --     | openObjective = Just index
+                --     , profileSummaries =
+                --         loggedIn.selectedCommunity
+                --             |> RemoteData.toMaybe
+                --             |> Maybe.map .objectives
+                --             |> Maybe.andThen (List.getAt index)
+                --             |> Maybe.map .actions
+                --             |> Maybe.withDefault []
+                --             |> List.map
+                --                 (\action ->
+                --                     ( action.id
+                --                     , List.length action.validators
+                --                         |> Profile.Summary.initMany False
+                --                     )
+                --                 )
+                --             |> Dict.fromList
+                -- }
+                --     |> UR.init
+                --     |> UR.addBreadcrumb
+                --         { type_ = Log.DebugBreadcrumb
+                --         , category = msg
+                --         , message = "Closed objective"
+                --         , data = Dict.fromList [ ( "objectiveId", Encode.int index ) ]
+                --         , level = Log.DebugLevel
+                --         }
+                -- TODO
+                UR.init model
 
         GotProfileSummaryMsg actionIndex validatorIndex subMsg ->
             { model

--- a/src/elm/Page/Community/Objectives.elm
+++ b/src/elm/Page/Community/Objectives.elm
@@ -17,7 +17,6 @@ import Profile.Summary
 import RemoteData
 import Route
 import Session.LoggedIn as LoggedIn exposing (External(..))
-import Task
 import Time exposing (Posix)
 import UpdateResult as UR
 import Utils
@@ -28,10 +27,7 @@ import View.MarkdownEditor
 init : LoggedIn.Model -> ( Model, Cmd Msg )
 init loggedIn =
     ( initModel
-    , Cmd.batch
-        [ Task.succeed RequestedReloadCommunity |> Task.perform identity
-        , LoggedIn.maybeInitWith CompletedLoadCommunity .selectedCommunity loggedIn
-        ]
+    , LoggedIn.maybeInitWith CompletedLoadCommunity .selectedCommunity loggedIn
     )
 
 
@@ -74,16 +70,18 @@ view ({ shared } as loggedIn) model =
             t "community.objectives.title_plural"
 
         content =
-            case ( loggedIn.selectedCommunity, model.status ) of
-                ( RemoteData.Success community, Loaded ) ->
+            case
+                ( Community.getField loggedIn.selectedCommunity .objectives
+                , model.status
+                )
+            of
+                ( RemoteData.Success ( community, objectives ), Loaded ) ->
                     div []
                         [ Page.viewHeader loggedIn (t "community.objectives.title_plural")
                         , div [ class "container mx-auto px-4 my-10" ]
                             [ div [ class "flex justify-end mb-10" ] [ viewNewObjectiveButton loggedIn community ]
                             , div []
-                                -- (community.objectives
-                                -- TODO
-                                ([]
+                                (objectives
                                     |> List.sortBy .id
                                     |> List.reverse
                                     |> List.indexedMap (viewObjective loggedIn model)
@@ -98,7 +96,10 @@ view ({ shared } as loggedIn) model =
                             [ text (shared.translators.t "community.edit.unauthorized") ]
                         ]
 
-                ( RemoteData.Failure e, _ ) ->
+                ( RemoteData.Failure (Community.CommunityError e), _ ) ->
+                    Page.fullPageGraphQLError (t "community.objectives.title_plural") e
+
+                ( RemoteData.Failure (Community.FieldError e), _ ) ->
                     Page.fullPageGraphQLError (t "community.objectives.title_plural") e
 
                 ( RemoteData.Loading, _ ) ->
@@ -372,7 +373,6 @@ type alias UpdateResult =
 
 type Msg
     = CompletedLoadCommunity Community.Model
-    | RequestedReloadCommunity
     | OpenObjective Int
     | GotProfileSummaryMsg Int Int Profile.Summary.Msg
 
@@ -381,22 +381,17 @@ update : Msg -> Model -> LoggedIn.Model -> UpdateResult
 update msg model loggedIn =
     case msg of
         CompletedLoadCommunity community ->
-            UR.init
-                { model
-                    | status =
-                        if not community.hasObjectives then
-                            Unauthorized
+            let
+                ( status, maybeRequestObjectives ) =
+                    if community.hasObjectives && community.creator == loggedIn.accountName then
+                        ( Loaded, UR.addExt (LoggedIn.RequestedReloadCommunityField Community.ObjectivesField) )
 
-                        else if community.creator == loggedIn.accountName then
-                            Loaded
-
-                        else
-                            Unauthorized
-                }
-
-        RequestedReloadCommunity ->
-            UR.init model
-                |> UR.addExt (LoggedIn.ReloadResource LoggedIn.CommunityResource)
+                    else
+                        ( Unauthorized, identity )
+            in
+            { model | status = status }
+                |> UR.init
+                |> maybeRequestObjectives
 
         OpenObjective index ->
             if model.openObjective == Just index then
@@ -411,34 +406,32 @@ update msg model loggedIn =
                         }
 
             else
-                -- { model
-                --     | openObjective = Just index
-                --     , profileSummaries =
-                --         loggedIn.selectedCommunity
-                --             |> RemoteData.toMaybe
-                --             |> Maybe.map .objectives
-                --             |> Maybe.andThen (List.getAt index)
-                --             |> Maybe.map .actions
-                --             |> Maybe.withDefault []
-                --             |> List.map
-                --                 (\action ->
-                --                     ( action.id
-                --                     , List.length action.validators
-                --                         |> Profile.Summary.initMany False
-                --                     )
-                --                 )
-                --             |> Dict.fromList
-                -- }
-                --     |> UR.init
-                --     |> UR.addBreadcrumb
-                --         { type_ = Log.DebugBreadcrumb
-                --         , category = msg
-                --         , message = "Closed objective"
-                --         , data = Dict.fromList [ ( "objectiveId", Encode.int index ) ]
-                --         , level = Log.DebugLevel
-                --         }
-                -- TODO
-                UR.init model
+                { model
+                    | openObjective = Just index
+                    , profileSummaries =
+                        loggedIn.selectedCommunity
+                            |> RemoteData.toMaybe
+                            |> Maybe.andThen (.objectives >> RemoteData.toMaybe)
+                            |> Maybe.andThen (List.getAt index)
+                            |> Maybe.map .actions
+                            |> Maybe.withDefault []
+                            |> List.map
+                                (\action ->
+                                    ( action.id
+                                    , List.length action.validators
+                                        |> Profile.Summary.initMany False
+                                    )
+                                )
+                            |> Dict.fromList
+                }
+                    |> UR.init
+                    |> UR.addBreadcrumb
+                        { type_ = Log.DebugBreadcrumb
+                        , category = msg
+                        , message = "Closed objective"
+                        , data = Dict.fromList [ ( "objectiveId", Encode.int index ) ]
+                        , level = Log.DebugLevel
+                        }
 
         GotProfileSummaryMsg actionIndex validatorIndex subMsg ->
             { model
@@ -468,9 +461,6 @@ msgToString msg =
     case msg of
         CompletedLoadCommunity _ ->
             [ "CompletedLoadCommunity" ]
-
-        RequestedReloadCommunity ->
-            [ "RequestedReloadCommunity" ]
 
         OpenObjective _ ->
             [ "OpenObjective" ]

--- a/src/elm/Page/Community/Settings/Info.elm
+++ b/src/elm/Page/Community/Settings/Info.elm
@@ -565,7 +565,6 @@ update msg model ({ shared } as loggedIn) =
 
                             newUploads =
                                 case ( community.uploads, model.coverPhoto ) of
-                                    -- TODO - Check this
                                     ( RemoteData.Success uploads, RemoteData.Success coverPhoto ) ->
                                         RemoteData.Success (coverPhoto :: uploads)
 

--- a/src/elm/Page/Community/Settings/Info.elm
+++ b/src/elm/Page/Community/Settings/Info.elm
@@ -352,13 +352,10 @@ update msg model ({ shared } as loggedIn) =
         GotDomainAvailableResponse (RemoteData.Success True) ->
             case
                 ( isModelValid shared.translators (RemoteData.toMaybe loggedIn.selectedCommunity) model
-                , loggedIn.selectedCommunity
-                , loggedIn.selectedCommunity
-                    |> RemoteData.mapError (\_ -> ())
-                    |> RemoteData.andThen .uploads
+                , Community.getField loggedIn.selectedCommunity .uploads
                 )
             of
-                ( True, RemoteData.Success community, RemoteData.Success communityUploads ) ->
+                ( True, RemoteData.Success ( community, communityUploads ) ) ->
                     let
                         authorization =
                             { actor = loggedIn.accountName
@@ -371,7 +368,6 @@ update msg model ({ shared } as loggedIn) =
                             }
 
                         newUpload =
-                            -- TODO - Check this `case of`
                             case ( model.coverPhoto, List.head communityUploads ) of
                                 ( RemoteData.Success url, Just firstUpload ) ->
                                     if url == firstUpload then

--- a/src/elm/Page/Join.elm
+++ b/src/elm/Page/Join.elm
@@ -296,10 +296,11 @@ viewAsLoggedIn : String -> LoggedIn.Model -> Model -> Html Msg
 viewAsLoggedIn title loggedIn model =
     case loggedIn.selectedCommunity of
         RemoteData.Success community ->
-            div [ class "flex-grow flex" ]
-                [ Community.communityPreviewImage True loggedIn.shared community
-                , view_ False loggedIn.shared community model
-                ]
+            -- div [ class "flex-grow flex" ]
+            --     [ Community.communityPreviewImage True loggedIn.shared community
+            --     , view_ False loggedIn.shared community model
+            --     ]
+            text "TODO"
 
         RemoteData.Failure err ->
             Page.fullPageGraphQLError title err


### PR DESCRIPTION
## What issue does this PR close
Closes #640

## Changes Proposed ( a list of new changes introduced by this PR)
- Adicionada nova variedade de `BroadcastMsg`: `CommunityFieldLoaded`
- Alguns campos da comunidade, como `uploads` e `objectives` não são mais carregados junto com a comunidade. Podemos usar a `BroadcastMsg` acima para pedir ao `LoggedIn` fazer uma query e pegar esses campos

Lista de todos os campos afetados:
- Objectives
- Uploads

Esse PR estabelece uma boa estrutura para termos mais campos que podem ser carregados separados da comunidade. Para adicionar um novo campo nesse estilo:
1. Adicionar o campo em `Community.Model` com um tipo de `RemoteData (Graphql.Http.Error field) field`
2. Adicionar um novo construtor ao tipo `Field`. O nome deve ser composto do nome do campo seguido por `Field` (e.g. `ObjectivesField`)
3. Adicionar um novo construtor ao tipo `FieldValue`. O nome deve ser composto do nome do campo seguido por `Value`, e possuir o valor do campo (e.g. `ObjectivesValue (List Objective)`)
4. Preencher as funções que lidam com esses tipos (`setFieldValue`, `setFieldAsLoading`, `isFieldLoading` e `maybeFieldValue`) 

Páginas podem solicitar o campo usando as mensagens `LoggedIn.External`:
- `RequestedCommunityField Community.Field` recebe um `Community.Field`, e verifica se a `selectedCommunity` de `loggedIn` já possui o campo. Se sim, manda o valor por uma `BroadcastMsg`. Se não, executa uma query para buscar o campo e envia uma `BroadcastMsg` quando receber o resultado.
- `RequestedReloadCommunityField` é similar à mensagem acima, mas **sempre** executa a query para buscar o campo. Útil para forçar o reload de algum campo.

Para receber o campo, devem usar um `receiveBroadcast`, fazendo pattern match em `LoggedIn.CommunityFieldLoaded` e o campo desejado (e.g. `LoggedIn.CommunityFieldLoaded community (Community.Objectives objectives)`). O objeto `community` é repassado para evitar estados impossíveis, onde o campo está carregado, mas a comunidade não.

## How to test ( a list of instructions on how to test this PR)
- Navegue pelo app nas páginas onde os dados acima precisam ser mostrados
- Verifique se o funcionamento do app nessas páginas permanece normal