### PR TITLE
Reload community members when entering transfer page

### DIFF
--- a/src/elm/Community.elm
+++ b/src/elm/Community.elm
@@ -153,6 +153,7 @@ variants they can use to do so:
 type Field
     = ObjectivesField
     | UploadsField
+    | MembersField
 
 
 {-| `FieldValue` is useful to wrap results of queries for fields that aren't
@@ -163,6 +164,7 @@ should hold the actual value of that field (e.g. `ObjectivesValue (List Objetive
 type FieldValue
     = ObjectivesValue (List Objective)
     | UploadsValue (List String)
+    | MembersValue (List Profile.Minimal)
 
 
 {-| When we want to extract a field that is not loaded by default with the
@@ -198,6 +200,9 @@ setFieldValue fieldValue model =
         UploadsValue uploads ->
             { model | uploads = RemoteData.Success uploads }
 
+        MembersValue members ->
+            { model | members = members }
+
 
 setFieldAsLoading : Field -> Model -> Model
 setFieldAsLoading field model =
@@ -208,6 +213,9 @@ setFieldAsLoading field model =
         UploadsField ->
             { model | uploads = RemoteData.Loading }
 
+        MembersField ->
+            model
+
 
 isFieldLoading : Field -> Model -> Bool
 isFieldLoading field model =
@@ -217,6 +225,9 @@ isFieldLoading field model =
 
         UploadsField ->
             RemoteData.isLoading model.uploads
+
+        MembersField ->
+            False
 
 
 maybeFieldValue : Field -> Model -> Maybe FieldValue
@@ -231,6 +242,9 @@ maybeFieldValue field model =
             model.uploads
                 |> RemoteData.toMaybe
                 |> Maybe.map UploadsValue
+
+        MembersField ->
+            Just (MembersValue model.members)
 
 
 mergeFields : RemoteData x Model -> Model -> Model
@@ -325,6 +339,10 @@ selectionSetForField field =
         UploadsField ->
             Community.uploads Upload.url
                 |> SelectionSet.map UploadsValue
+
+        MembersField ->
+            Community.members Profile.minimalSelectionSet
+                |> SelectionSet.map MembersValue
 
 
 queryForField :

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -1323,7 +1323,7 @@ changeRouteTo maybeRoute model =
 
         Just (Route.Transfer maybeTo) ->
             (\l -> Transfer.init l maybeTo)
-                >> updateStatusWith Transfer GotTransferMsg model
+                >> updateLoggedInUResult Transfer GotTransferMsg model
                 |> withLoggedIn (Route.Transfer maybeTo)
 
         Just Route.Analysis ->

--- a/src/elm/Page/Community/Transfer.elm
+++ b/src/elm/Page/Community/Transfer.elm
@@ -42,11 +42,12 @@ import View.Form.Input as Input
 import View.MarkdownEditor as MarkdownEditor
 
 
-init : LoggedIn.Model -> Maybe String -> ( Model, Cmd Msg )
+init : LoggedIn.Model -> Maybe String -> UpdateResult
 init loggedIn maybeTo =
-    ( initModel maybeTo
-    , LoggedIn.maybeInitWith CompletedLoadCommunity .selectedCommunity loggedIn
-    )
+    initModel maybeTo
+        |> UR.init
+        |> UR.addCmd (LoggedIn.maybeInitWith CompletedLoadCommunity .selectedCommunity loggedIn)
+        |> UR.addExt (LoggedIn.RequestedReloadCommunityField Community.MembersField)
 
 
 


### PR DESCRIPTION
## What issue does this PR close
Closes #648 

## Changes Proposed ( a list of new changes introduced by this PR)
- Adicionar construtores nos tipos `Community.Field` e `Community.Value` relacionados ao campo de membros da comunidade
- Recarregar membros da comunidade ao entrar na página de "Transferir para um amigo"

## How to test ( a list of instructions on how to test this PR)
- Faça login numa comunidade (usando uma conta c1)
- Em uma janela anônima, crie uma nova conta nessa comunidade (conta c2)
- Com a conta c1, entre em "Transferir para um amigo"
- Comece a preencher o nome da conta c2
- Veja a conta c2 aparecer para o autocomplete