### PR TITLE
Fix/shop images

### DIFF
--- a/src/elm/Page/Shop.elm
+++ b/src/elm/Page/Shop.elm
@@ -290,18 +290,12 @@ viewCard model ({ shared } as loggedIn) index card =
         tr rId replaces =
             shared.translators.tr rId replaces
 
-        title =
-            if String.length card.product.title > 17 then
-                String.slice 0 17 card.product.title ++ " ..."
-
-            else
-                card.product.title
-
         profileSummaryId =
             "shop-item-card-" ++ String.fromInt card.product.id
     in
     a
         [ class "w-full md:w-1/2 lg:w-1/3 xl:w-1/4 px-2 mb-6"
+        , Html.Attributes.title card.product.title
         , Route.href (Route.ViewSale card.product.id)
         ]
         [ div [ class "md:hidden rounded-lg bg-white h-32 flex" ]
@@ -354,7 +348,7 @@ viewCard model ({ shared } as loggedIn) index card =
                     ]
                 ]
             , div [ class "w-full px-6 pt-4" ]
-                [ p [ class "text-xl" ] [ text title ]
+                [ p [ class "text-xl truncate" ] [ text card.product.title ]
                 ]
             , if card.product.units == 0 && card.product.trackStock then
                 div [ class "flex flex-none w-full px-6 pb-2" ]

--- a/src/elm/Page/Shop/Editor.elm
+++ b/src/elm/Page/Shop/Editor.elm
@@ -546,7 +546,16 @@ update msg model loggedIn =
                                 trackNo
                     in
                     initForm loggedIn.shared.translators initDescriptionEditor
-                        |> EditingUpdate balances sale RemoteData.NotAsked Closed
+                        |> EditingUpdate balances
+                            sale
+                            (case sale.image of
+                                Nothing ->
+                                    RemoteData.NotAsked
+
+                                Just img ->
+                                    RemoteData.Success img
+                            )
+                            Closed
                         |> updateForm
                             (\form ->
                                 { form

--- a/src/elm/Page/Shop/Editor.elm
+++ b/src/elm/Page/Shop/Editor.elm
@@ -297,24 +297,7 @@ viewForm ({ shared } as loggedIn) imageStatus isEdit isDisabled deleteModal form
         [ Page.viewHeader loggedIn pageTitle
         , div
             [ class "container mx-auto" ]
-            [ div [ class "px-4 py-6" ]
-                [ if isEdit then
-                    button
-                        [ class "btn delete-button"
-                        , disabled isDisabled
-                        , onClick ClickedDelete
-                        ]
-                        [ text (t "shop.delete") ]
-
-                  else
-                    text ""
-                , if isEdit && deleteModal == Open then
-                    viewConfirmDeleteModal t
-
-                  else
-                    text ""
-                ]
-            , FileUploader.init
+            [ FileUploader.init
                 { label = ""
                 , id = fieldId "image"
                 , onFileInput = EnteredImage
@@ -404,16 +387,29 @@ viewForm ({ shared } as loggedIn) imageStatus isEdit isDisabled deleteModal form
 
                     Just err ->
                         viewFieldErrors [ err ]
-                , div
-                    [ class "flex align-center justify-center mb-10"
-                    , disabled (isDisabled || RemoteData.isLoading imageStatus)
-                    ]
-                    [ button
+                , div [ class "flex flex-col-reverse sm:flex-row align-center justify-center mb-10" ]
+                    [ if isEdit then
+                        button
+                            [ class "button button-danger w-full mt-4 sm:w-40 sm:mt-0 sm:mr-4"
+                            , disabled isDisabled
+                            , onClick ClickedDelete
+                            ]
+                            [ text (t "shop.delete") ]
+
+                      else
+                        text ""
+                    , button
                         [ class "button button-primary w-full sm:w-40"
+                        , disabled (isDisabled || RemoteData.isLoading imageStatus)
                         , onClick ClickedSave
                         ]
                         [ text actionText ]
                     ]
+                , if isEdit && deleteModal == Open then
+                    viewConfirmDeleteModal t
+
+                  else
+                    text ""
                 ]
             ]
         ]

--- a/src/elm/Shop.elm
+++ b/src/elm/Shop.elm
@@ -110,7 +110,7 @@ productSelection =
         |> with (Eos.nameSelectionSet Cambiatus.Object.Product.creatorId)
         |> with Cambiatus.Object.Product.price
         |> with (Eos.symbolSelectionSet Cambiatus.Object.Product.communityId)
-        |> with Cambiatus.Object.Product.image
+        |> with (detectEmptyString Cambiatus.Object.Product.image)
         |> with Cambiatus.Object.Product.units
         |> with Cambiatus.Object.Product.trackStock
         |> with (Cambiatus.Object.Product.creator shopProfileSelectionSet)
@@ -126,9 +126,22 @@ productPreviewSelectionSet =
             )
         |> with Cambiatus.Object.ProductPreview.description
         |> with Cambiatus.Object.ProductPreview.id
-        |> with Cambiatus.Object.ProductPreview.image
+        |> with (detectEmptyString Cambiatus.Object.ProductPreview.image)
         |> with Cambiatus.Object.ProductPreview.price
         |> with Cambiatus.Object.ProductPreview.title
+
+
+detectEmptyString : SelectionSet (Maybe String) typeLock -> SelectionSet (Maybe String) typeLock
+detectEmptyString =
+    SelectionSet.map
+        (\selection ->
+            case selection of
+                Just "" ->
+                    Nothing
+
+                _ ->
+                    selection
+        )
 
 
 productPreviewProfile : Eos.Name -> ShopProfile


### PR DESCRIPTION
## What issue does this PR close
Closes #655 

## Changes Proposed ( a list of new changes introduced by this PR)
- Add `title` attribute to shop cards. This way, if the title is too long, the user can still see the entire title by hovering on the card (thanks @flpfar for the nice catch)
- Instead of relying on an image error event when a shop offer doesn't have an image, we check if there is an image or not, and display the placeholder images based on that
- Instead of limiting the title length in characters, use CSS to display as much as possible, and add `...` if needed
- If the offer has an image, show it when the user is editing the offer
- Detect if the image's source is an empty string as soon as we get it from GraphQL

## How to test ( a list of instructions on how to test this PR)
- Create an offer with a long title. Make sure it's card only shows one line of the title, and adds `...` at the end. Hovering the card should show the entire title.
- Create an offer without an image. It's card should display one of the placeholder images.
- Create an offer with an image. Go to it's editor page and see if the image shows up on the editor.