### PR TITLE
Add back image parameter to upsertaction transaction

### DIFF
--- a/src/elm/Page/Community/ActionEditor.elm
+++ b/src/elm/Page/Community/ActionEditor.elm
@@ -448,6 +448,7 @@ upsertAction { markAsCompleted } msg maybeAction loggedIn model formOutput =
                                 |> (\isCompleted -> isCompleted || markAsCompleted)
                                 |> encodeBool
                           )
+                        , ( "image", Encode.string "" )
                         ]
               }
             ]


### PR DESCRIPTION
## What issue does this PR close
Closes #697 

## Changes Proposed ( a list of new changes introduced by this PR)
- Add `image` parameter to the `upsertaction` transaction (it should've been added on #676, but must have gotten lost during merging)

## How to test ( a list of instructions on how to test this PR)
- Try to create a new action, as described on the issue