### PR TITLE
Enhancement/create default role

### DIFF
--- a/src/elm/Page/Community/New.elm
+++ b/src/elm/Page/Community/New.elm
@@ -555,7 +555,7 @@ update msg model loggedIn =
                     model
 
 
-defaultRoleTransaction : Eos.Symbol -> Encode.Value
+defaultRoleTransaction : Eos.Symbol -> Value
 defaultRoleTransaction symbol =
     Encode.object
         [ ( "community_id", Eos.encodeSymbol symbol )

--- a/src/elm/Session/LoggedIn.elm
+++ b/src/elm/Session/LoggedIn.elm
@@ -1026,7 +1026,6 @@ type External msg
     = UpdatedLoggedIn Model
     | ShowInsufficientPermissionsModal
     | AddedCommunity Profile.CommunityInfo
-    | CreatedCommunity Eos.Symbol String
     | ExternalBroadcast BroadcastMsg
     | ReloadResource Resource
     | RequestedReloadCommunityField Community.Field
@@ -1382,9 +1381,6 @@ mapExternal mapFn msg =
         AddedCommunity communityInfo ->
             AddedCommunity communityInfo
 
-        CreatedCommunity symbol name ->
-            CreatedCommunity symbol name
-
         ExternalBroadcast broadcastMsg ->
             ExternalBroadcast broadcastMsg
 
@@ -1480,12 +1476,6 @@ updateExternal externalMsg ({ shared } as model) =
             { defaultResult
                 | model = { newModel | profile = profileWithCommunity }
                 , cmd = cmd
-            }
-
-        CreatedCommunity _ _ ->
-            { defaultResult
-                | model = { model | feedback = Feedback.Visible Feedback.Success (shared.translators.t "community.create.created") }
-                , cmd = Route.pushUrl shared.navKey Route.Dashboard
             }
 
         ExternalBroadcast broadcastMsg ->
@@ -2985,9 +2975,6 @@ externalMsgToString externalMsg =
 
         AddedCommunity _ ->
             [ "AddedCommunity" ]
-
-        CreatedCommunity symbol _ ->
-            [ "CreatedCommunity", Eos.symbolToString symbol ]
 
         ExternalBroadcast _ ->
             [ "ExternalBroadcast" ]


### PR DESCRIPTION
## What issue does this PR close
Closes #701 

## Changes Proposed ( a list of new changes introduced by this PR)
- Call the given transaction right after creating a new community

## How to test ( a list of instructions on how to test this PR)
- Create a new community
- Check the block explorer's `role` table, giving the community symbol as the scope
- Verify that the correct permissions are given to the correct role (role should be named `member`, and should have the `invite`, `claim`, `order`, `verify`, `sell` and `transfer` permissions). No other role should be present

<img width="1094" alt="image" src="https://user-images.githubusercontent.com/39280468/157104829-01981a6d-e49b-4a95-9e23-b625df0fd947.png">

