### PR TITLE
Display date alongside day on transfer page

### DIFF
--- a/src/elm/Page/ViewTransfer.elm
+++ b/src/elm/Page/ViewTransfer.elm
@@ -173,10 +173,22 @@ viewDetails ({ shared } as loggedIn) transfer profileSummaries direction =
                 [ class "pb-6 border-b border-gray-500" ]
             , viewDetail [ class "mt-6" ]
                 (t "transfer_result.date")
-                (View.Components.dateViewer []
-                    identity
-                    shared
-                    (Utils.fromDateTime transfer.blockTime)
+                (p []
+                    [ View.Components.dateViewer []
+                        identity
+                        shared
+                        (Utils.fromDateTime transfer.blockTime)
+                    , View.Components.dateViewer []
+                        (\translations ->
+                            { translations
+                                | today = Just ", {{date}}"
+                                , yesterday = Just ", {{date}}"
+                                , other = ""
+                            }
+                        )
+                        shared
+                        (Utils.fromDateTime transfer.blockTime)
+                    ]
                 )
             , case transfer.memo of
                 Nothing ->


### PR DESCRIPTION
## What issue does this PR close
Closes N/A
Asked by Luiz on Slack

## Changes Proposed ( a list of new changes introduced by this PR)
- Display the date (e.g. 20 Apr 2022) alongside the day (e.g. Today) on the transfer page

## How to test ( a list of instructions on how to test this PR)
- Transfer some amount to another account
- Go to the "View transfer" page
- See some text like "Today, 20 Apr 2022"