### PR TITLE
Fix/layout issues from footer

### DIFF
--- a/src/elm/Action.elm
+++ b/src/elm/Action.elm
@@ -646,7 +646,7 @@ claimWithProofsForm translators =
 
 viewClaimWithProofs : Proof -> Translators -> Bool -> Action -> Html Msg
 viewClaimWithProofs ((Proof photoStatus proofCode) as proof) ({ t } as translators) isLoading action =
-    div [ class "bg-white border-t border-gray-300" ]
+    div [ class "bg-white border-t border-gray-300 flex-grow" ]
         [ div [ class "container p-4 mx-auto" ]
             [ div [ class "text-lg font-bold my-3" ] [ text <| t "community.actions.proof.title" ]
             , action.photoProofInstructions

--- a/src/elm/Page/ViewTransfer.elm
+++ b/src/elm/Page/ViewTransfer.elm
@@ -96,7 +96,7 @@ view loggedIn model =
                         Just transfer ->
                             div [ class "flex-grow flex flex-col" ]
                                 [ Page.viewHeader loggedIn (t "transfer_result.title")
-                                , div [ class "relative flex-grow grid items-center" ]
+                                , div [ class "relative flex-grow flex items-center" ]
                                     [ div [ class "bg-purple-500 absolute top-0 bottom-0 left-0 right-1/2 hidden lg:block" ] []
                                     , div [ class "bg-white absolute top-0 bottom-0 left-1/2 right-0 hidden lg:block" ] []
                                     , div


### PR DESCRIPTION
## What issue does this PR close
Closes #715 

## Changes Proposed ( a list of new changes introduced by this PR)
- Fix layout on ViewTransfer page on Safari
- Fix layout on claim with photo proof page

## How to test ( a list of instructions on how to test this PR)
- ViewTransfer:
  - On Safari, go to a transfer
  - Check that the page is not cutoff by the footer (usually on large screens)
- Claim with photo:
  - Use the search feature to look for an action that requires photo proof
  - Click to claim that action
  - Check that the footer is all the way down the screen

