### PR TITLE
Fix profile PDF download and clipboard access on Safari

### DIFF
--- a/src/elm/Auth.elm
+++ b/src/elm/Auth.elm
@@ -51,8 +51,8 @@ import View.Pin as Pin
 -- INIT
 
 
-init : Bool -> Maybe Eos.PrivateKey -> ( Model, Cmd Msg )
-init pinVisibility maybePrivateKey_ =
+init : Maybe String -> Bool -> Maybe Eos.PrivateKey -> ( Model, Cmd Msg )
+init lastKnownPin pinVisibility maybePrivateKey_ =
     let
         status =
             case maybePrivateKey_ of
@@ -63,7 +63,7 @@ init pinVisibility maybePrivateKey_ =
                     WithPrivateKey privateKey
 
         ( pinModel, pinCmd ) =
-            initPinModel pinVisibility status
+            initPinModel lastKnownPin pinVisibility status
     in
     ( { status = status
       , error = Nothing
@@ -84,8 +84,8 @@ type alias Model =
     }
 
 
-initPinModel : Bool -> Status -> ( Pin.Model, Cmd Msg )
-initPinModel pinVisibility status =
+initPinModel : Maybe String -> Bool -> Status -> ( Pin.Model, Cmd Msg )
+initPinModel lastKnownPin pinVisibility status =
     let
         ( pinModel, pinCmd ) =
             Pin.init
@@ -95,6 +95,7 @@ initPinModel pinVisibility status =
                 , submitLabel = "auth.login.continue"
                 , submittingLabel = "auth.login.continue"
                 , pinVisibility = pinVisibility
+                , lastKnownPin = lastKnownPin
                 }
     in
     ( pinModel

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -782,8 +782,11 @@ updateGuestUResult toStatus toMsg model uResult =
 
                 Page.Guest guest ->
                     case commExtMsg of
-                        Guest.LoggedIn privateKey { profile, token } ->
+                        Guest.LoggedIn { pin, privateKey, signInResponse } ->
                             let
+                                { profile, token } =
+                                    signInResponse
+
                                 shared =
                                     guest.shared
 
@@ -811,7 +814,7 @@ updateGuestUResult toStatus toMsg model uResult =
                                     }
 
                                 ( session, cmd ) =
-                                    LoggedIn.initLogin shared (Just privateKey) userWithCommunity token
+                                    LoggedIn.initLogin shared pin (Just privateKey) userWithCommunity token
 
                                 redirectRoute =
                                     case guest.afterLoginRedirect of

--- a/src/elm/Page/Login.elm
+++ b/src/elm/Page/Login.elm
@@ -78,6 +78,7 @@ initPinModel pinVisibility passphrase =
                 , submitLabel = "auth.login.submit"
                 , submittingLabel = "auth.login.submitting"
                 , pinVisibility = pinVisibility
+                , lastKnownPin = Nothing
                 }
     in
     ( { status = InputtingPin
@@ -633,7 +634,14 @@ updateWithPin msg model ({ shared } as guest) =
                             , ( "pin", Encode.string pin )
                             ]
                     }
-                |> UR.addExt (Guest.LoggedIn privateKey signInResponse |> PinGuestExternal)
+                |> UR.addExt
+                    (Guest.LoggedIn
+                        { pin = pin
+                        , privateKey = privateKey
+                        , signInResponse = signInResponse
+                        }
+                        |> PinGuestExternal
+                    )
 
         GotSignInResult _ _ (RemoteData.Failure err) ->
             UR.init model

--- a/src/elm/Page/Profile.elm
+++ b/src/elm/Page/Profile.elm
@@ -542,7 +542,7 @@ update msg model loggedIn =
             let
                 currentPin =
                     model.currentPin
-                        |> Maybe.Extra.orElse model.pinInputModel.lastKnownPin
+                        |> Maybe.Extra.orElse loggedIn.auth.pinModel.lastKnownPin
                         |> Maybe.withDefault ""
             in
             { model | downloadingPdfStatus = Downloading }

--- a/src/elm/Page/Profile.elm
+++ b/src/elm/Page/Profile.elm
@@ -112,6 +112,7 @@ init loggedIn profileName =
                 , submitLabel = "profile.pin.button"
                 , submittingLabel = "profile.pin.button"
                 , pinVisibility = loggedIn.shared.pinVisibility
+                , lastKnownPin = loggedIn.auth.pinModel.lastKnownPin
                 }
 
         model =

--- a/src/elm/Session/Guest.elm
+++ b/src/elm/Session/Guest.elm
@@ -285,7 +285,11 @@ viewPageHeader model shared =
 
 
 type External
-    = LoggedIn Eos.PrivateKey Api.Graphql.SignInResponse
+    = LoggedIn
+        { pin : String
+        , privateKey : Eos.PrivateKey
+        , signInResponse : Api.Graphql.SignInResponse
+        }
     | SetFeedback Feedback.Model
     | UpdatedShared Shared
 

--- a/src/elm/Session/LoggedIn.elm
+++ b/src/elm/Session/LoggedIn.elm
@@ -93,7 +93,7 @@ init : Shared -> Eos.Name -> Maybe Api.Graphql.Token -> ( Model, Cmd (Msg extern
 init shared accountName authToken =
     let
         ( model, cmd ) =
-            initModel shared Nothing accountName authToken
+            initModel shared Nothing Nothing accountName authToken
     in
     ( model
     , Cmd.batch
@@ -170,8 +170,8 @@ sendPreferredLanguage model language =
 
 {-| Initialize logged in user after signing-in.
 -}
-initLogin : Shared -> Maybe Eos.PrivateKey -> Profile.Model -> Api.Graphql.Token -> ( Model, Cmd (Msg externalMsg) )
-initLogin shared maybePrivateKey_ profile_ authToken =
+initLogin : Shared -> String -> Maybe Eos.PrivateKey -> Profile.Model -> Api.Graphql.Token -> ( Model, Cmd (Msg externalMsg) )
+initLogin shared pin maybePrivateKey_ profile_ authToken =
     let
         loadedProfile =
             Just profile_
@@ -180,7 +180,7 @@ initLogin shared maybePrivateKey_ profile_ authToken =
                 |> Task.perform CompletedLoadProfile
 
         ( model, cmd ) =
-            initModel shared maybePrivateKey_ profile_.account (Just authToken)
+            initModel shared (Just pin) maybePrivateKey_ profile_.account (Just authToken)
     in
     ( model
     , Cmd.batch
@@ -259,11 +259,11 @@ type CodeOfConductModalStatus
     | CodeOfConductShownWithWarning { hasCompletedAnimation : Bool }
 
 
-initModel : Shared -> Maybe Eos.PrivateKey -> Eos.Name -> Maybe Api.Graphql.Token -> ( Model, Cmd (Msg externalMsg) )
-initModel shared maybePrivateKey_ accountName authToken =
+initModel : Shared -> Maybe String -> Maybe Eos.PrivateKey -> Eos.Name -> Maybe Api.Graphql.Token -> ( Model, Cmd (Msg externalMsg) )
+initModel shared lastKnownPin maybePrivateKey_ accountName authToken =
     let
         ( authModel, authCmd ) =
-            Auth.init shared.pinVisibility maybePrivateKey_
+            Auth.init lastKnownPin shared.pinVisibility maybePrivateKey_
     in
     ( { shared = shared
       , updateTimeEvery = 60 * 1000

--- a/src/elm/View/Pin.elm
+++ b/src/elm/View/Pin.elm
@@ -79,18 +79,19 @@ type alias RequiredOptions =
     , submitLabel : String
     , submittingLabel : String
     , pinVisibility : Bool
+    , lastKnownPin : Maybe String
     }
 
 
 {-| Initializes a `Model` with some initial `RequiredOptions`
 -}
 init : RequiredOptions -> ( Model, Cmd Msg )
-init { label, id, withConfirmation, submitLabel, submittingLabel, pinVisibility } =
+init { label, id, withConfirmation, submitLabel, submittingLabel, pinVisibility, lastKnownPin } =
     ( { label = label
       , disabled = False
       , id = id
       , form = Form.init { pin = "", confirmation = "" }
-      , lastKnownPin = Nothing
+      , lastKnownPin = lastKnownPin
       , problems = []
       , needsConfirmation = withConfirmation
       , isPinVisible = pinVisibility

--- a/src/index.js
+++ b/src/index.js
@@ -271,14 +271,25 @@ async function readClipboardWithPermission () {
     const clipboardContent = await navigator.clipboard.readText()
     return { clipboardContent }
   } catch (err) {
-    logEvent({
-      user: null,
-      message: 'Error when reading clipboard',
-      tags: { 'cambiatus.kind': 'clipboard' },
-      contexts: [{ name: 'Error details', extras: { error: err } }],
-      transaction: 'readClipboardWithPermission',
-      level: 'error'
-    })
+    if (err.name && err.name === 'NotAllowedError') {
+      addBreadcrumb({
+        type: 'info',
+        category: 'readClipboardWithPermission',
+        message: 'User denied permission to read clipboard',
+        data: { error: err },
+        localData: {},
+        level: 'info'
+      })
+    } else {
+      logEvent({
+        user: null,
+        message: 'Error when reading clipboard',
+        tags: { 'cambiatus.kind': 'clipboard' },
+        contexts: [{ name: 'Error details', extras: { error: err } }],
+        transaction: 'readClipboardWithPermission',
+        level: 'error'
+      })
+    }
 
     return { error: err.message }
   }

--- a/src/index.js
+++ b/src/index.js
@@ -262,9 +262,7 @@ function getUserLanguage () {
 
 function canReadClipboard () {
   return Boolean(navigator.clipboard) &&
-    Boolean(navigator.clipboard.readText) &&
-    Boolean(navigator.permissions) &&
-    Boolean(navigator.permissions.query)
+    Boolean(navigator.clipboard.readText)
 }
 
 /** Assumes we already have clipboard permissions */
@@ -1356,7 +1354,7 @@ async function handleJavascriptPort (arg) {
             level: 'info'
           })
 
-          return { notSupported: true }
+          return readClipboardWithPermission()
         }
       } else {
         addBreadcrumb({

--- a/src/index.js
+++ b/src/index.js
@@ -261,7 +261,10 @@ function getUserLanguage () {
 }
 
 function canReadClipboard () {
-  return !!navigator.clipboard && !!navigator.clipboard.readText
+  return Boolean(navigator.clipboard) &&
+    Boolean(navigator.clipboard.readText) &&
+    Boolean(navigator.permissions) &&
+    Boolean(navigator.permissions.query)
 }
 
 /** Assumes we already have clipboard permissions */
@@ -1353,7 +1356,7 @@ async function handleJavascriptPort (arg) {
             level: 'info'
           })
 
-          return readClipboardWithPermission()
+          return { notSupported: true }
         }
       } else {
         addBreadcrumb({


### PR DESCRIPTION
## What issue does this PR close
Closes N/A. Raised by Verdes on Slack: https://cambiatus.slack.com/archives/G01GNQB5G5B/p1650728963382709

## Changes Proposed ( a list of new changes introduced by this PR)
- Fix the PDF download from the profile
- Require permissions API to read from the clipboard. Specifically, Safari doesn't support the permissions API. [In Safari, to access the Clipboard API, it must come from a user event](https://stackoverflow.com/a/62566097) (like clicking a button). Apparently, if we call a port from elm, that doesn't count as a user event anymore (?), so we get an error that says we don't have permissions to do that. For now, we can just require that the permissions API is implemented in the user's browser. Other than that, all we can do is:
  - Wait for Safari to implement permissions API (it's listed as an Experimental Feature on Safari 15.4)
  - Use some deprecated way to access the clipboard.


## How to test ( a list of instructions on how to test this PR)
Testing profile PDF:
- Go to your profile
- Try to download your 12 words PDF

Testing paste on Safari:
- Go to the login page on Safari
- See that the "Paste" button is no longer there