### PR TITLE
Fix/profile icon

### DIFF
--- a/src/elm/Session/LoggedIn.elm
+++ b/src/elm/Session/LoggedIn.elm
@@ -752,9 +752,9 @@ viewHeader page ({ shared } as model) profile_ =
 
               else
                 text ""
-            , div [ class "relative z-50" ]
+            , div [ class "relative z-50 lg:min-w-50" ]
                 [ button
-                    [ class "h-12 z-10 py-2 px-3 relative hidden lg:visible lg:flex lg:items-center lg:bg-white lg:focus-ring lg:focus-visible:ring-orange-300 lg:focus-visible:ring-opacity-50"
+                    [ class "h-12 z-10 py-2 px-3 relative hidden lg:w-full lg:visible lg:flex lg:items-center lg:bg-white lg:focus-ring lg:focus-visible:ring-orange-300 lg:focus-visible:ring-opacity-50"
                     , classList
                         [ ( "rounded-tr-lg rounded-tl-lg", model.showUserNav )
                         , ( "rounded-lg", not model.showUserNav )

--- a/src/elm/Session/LoggedIn.elm
+++ b/src/elm/Session/LoggedIn.elm
@@ -727,7 +727,7 @@ viewHeader page ({ shared } as model) profile_ =
                 model.searchModel
                 |> Html.map GotSearchMsg
         , div
-            [ class "flex items-center justify-end space-x-8 my-auto shrink-0"
+            [ class "flex items-center justify-end space-x-8 my-auto flex-shrink-0"
             , classList [ ( "md:flex-shrink md:w-full", not isSearchOpen ) ]
             ]
             [ a

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -165,7 +165,8 @@ module.exports = {
         '120': '30rem'
       },
       minWidth: {
-        '30': '7.5rem'
+        '30': '7.5rem',
+        '50': '12.5rem'
       },
       opacity: {
         '10': '0.1',


### PR DESCRIPTION
## What issue does this PR close
Closes #659 

## Changes Proposed ( a list of new changes introduced by this PR)
- Add a minimum width to the profile icon on large screens
- Prevent the search bar from pushing items further to the right (which was causing text to wrap)

## How to test ( a list of instructions on how to test this PR)
- Log in with an account that has < 12 characters on the name (either `lucca` or `karla`)
- Hover over your profile. Icons should remain the same size as usual
- Click on the search bar. The notification icon and everything to the right of it should remain in the same place, instead of being pushed to the right and wrapping lines
