### PR TITLE
Add cambiatus.version tag to Sentry

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -119,6 +119,7 @@ const logEvent = (event) => {
       }
       // If the error comes from Elm, this key will be overwritten
       scope.setTag('cambiatus.language', 'javascript')
+      scope.setTag('cambiatus.version', process.env.COMMIT)
       scope.setTags(tags)
       scope.setTransaction(transaction)
       contexts.forEach((context) => {

--- a/src/index.js
+++ b/src/index.js
@@ -47,6 +47,8 @@ if (env !== 'development') {
       return unusedCategories.includes(breadcrumb.category) ? null : breadcrumb
     }
   })
+
+  Sentry.setTag('cambiatus.version', process.env.COMMIT)
 }
 
 /** On production, adds a breadcrumb to sentry. Needs an object like this:
@@ -119,7 +121,6 @@ const logEvent = (event) => {
       }
       // If the error comes from Elm, this key will be overwritten
       scope.setTag('cambiatus.language', 'javascript')
-      scope.setTag('cambiatus.version', process.env.COMMIT)
       scope.setTags(tags)
       scope.setTransaction(transaction)
       contexts.forEach((context) => {


### PR DESCRIPTION
## What issue does this PR close
Closes #733 

## Changes Proposed ( a list of new changes introduced by this PR)
- Add a `cambiatus.version` tag to Sentry errors. The tag's value will be the current commit hash (the same one we show on the footer)

## How to test ( a list of instructions on how to test this PR)
Checkout this error: https://sentry.io/organizations/cambiatus/issues/3229438253/?project=1480468&referrer=slack

![image](https://user-images.githubusercontent.com/39280468/165520526-b44b81cc-f93c-43ba-93f1-de4524d58acd.png)
