### PR TITLE
Move line-clamp to markdown-viewer

### DIFF
--- a/src/elm/Page/Community/Objectives.elm
+++ b/src/elm/Page/Community/Objectives.elm
@@ -1258,11 +1258,8 @@ viewAction ({ t } as translators) model objective index action =
                     ]
                     [ text (String.fromInt (index + 1)), text "." ]
                 , div [ class "ml-5 mt-1 min-w-0 w-full" ]
-                    [ h4
-                        [ class "line-clamp-3"
-                        , title (Markdown.toRawString action.description)
-                        ]
-                        [ Markdown.view [] action.description ]
+                    [ h4 [ title (Markdown.toRawString action.description) ]
+                        [ Markdown.view [ class "line-clamp-3" ] action.description ]
                     , span [ class "sr-only" ]
                         [ text <|
                             t "community.objectives.reward"


### PR DESCRIPTION
## What issue does this PR close
Closes N/A. Issue reported by @lucca65 after the release: https://cambiatus.slack.com/archives/CA83HJAAD/p1651026956611939

## Changes Proposed ( a list of new changes introduced by this PR)
- Move `line-clamp-3` from `h4` to the `markdown-viewer`. This fixes an issue in Safari where text just wouldn't show up

## How to test ( a list of instructions on how to test this PR)
- Create an action with a long description
- Check if the description shows up correctly, and is 3 lines long


Before:
<img width="416" alt="image" src="https://user-images.githubusercontent.com/39280468/165531249-214f1036-902e-493a-8f41-0e246c9a2028.png">

Now:
<img width="413" alt="image" src="https://user-images.githubusercontent.com/39280468/165531313-9ea7405b-ed73-491b-b3c1-55cff49a3865.png">
