### PR TITLE
Use backend api manifest

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,8 +7,13 @@
     <!--
          manifest.json provides metadata used when your web app is added to the
          homescreen on Android. See https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/
+
+         We first try to get the manifest from our backend, which will populate
+         it with data related to the current community (based on the subdomain
+         the user is at). If it can't find a valid community, it redirects to the
+         manifest file we keep in the `public` folder
     -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json">
+    <link rel="manifest" href="%PUBLIC_URL%/api/manifest">
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
     <link rel="apple-touch-icon" sizes="57x57" href="%PUBLIC_URL%/icons/apple-icon-57x57.png">
     <link rel="apple-touch-icon" sizes="60x60" href="%PUBLIC_URL%/icons/apple-icon-60x60.png">


### PR DESCRIPTION
## What issue does this PR close
Closes N/A.

**We should wait for the backend PR to be merged before merging this**

## Changes Proposed ( a list of new changes introduced by this PR)
- Change the manifest link to point to the manifest served by our backend after https://github.com/cambiatus/backend/issues/218

## How to test ( a list of instructions on how to test this PR)
To make things easier, deploy the correct version of the backend and frontend on staging.

Then, go to a community (e.g. https://cambiatus.staging.cambiatus.io). The browser should load the correct information on the manifest 

Next, go to a url that doesn't represent a community (e.g. https://asdfasdfa.staging.cambiatus.io). The browser should follow the 301 redirect and serve the generic manifest.json, which is stored in the frontend.

Browsers have different ways to show what the manifest file looks like:
- Safari shows the request in the network tab, you can just see the response
(it differs from browser to browser on how to check this - it might show up in the network tab, or in the application tab of the devtools)
- Chrome and Firefox show the manifest in the application tab (and the request doesn't show up on the network tab 🤷)
- Other browsers may show it somewhere else, but it should be there!
