### PR TITLE
Fix/action modal text

### DIFF
--- a/src/elm/Page/Community/Objectives.elm
+++ b/src/elm/Page/Community/Objectives.elm
@@ -1373,7 +1373,7 @@ viewClaimModal ({ translators } as shared) model =
                         ]
                         [ span [ class "text-lg text-gray-500 font-bold" ] [ text (String.fromInt position ++ ".") ]
                         , div [ class "ml-5 mt-1 min-w-0 w-full" ]
-                            [ Markdown.view [ class "truncate" ] action.description
+                            [ Markdown.view [] action.description
                             , div [ class "md:flex md:justify-between md:w-full" ]
                                 [ div []
                                     [ span [ class "font-bold text-sm text-gray-900 uppercase block mt-6" ]

--- a/src/elm/Page/Community/Objectives.elm
+++ b/src/elm/Page/Community/Objectives.elm
@@ -1478,7 +1478,7 @@ viewClaimModal ({ translators } as shared) model =
                             text ""
                     ]
                 |> View.Modal.withFooter
-                    [ div [ class "w-full grid md:grid-cols-2 gap-4 pt-4 md:pt-0" ]
+                    [ div [ class "w-full grid md:grid-cols-2 gap-4" ]
                         [ if Action.isClaimable action then
                             button
                                 [ class "button button-secondary w-full"
@@ -1495,7 +1495,7 @@ viewClaimModal ({ translators } as shared) model =
                             [ text <| t "dashboard.claim" ]
                         ]
                     ]
-                |> View.Modal.withSize View.Modal.Large
+                |> View.Modal.withSize View.Modal.FullScreen
                 |> View.Modal.toHtml
 
 

--- a/src/elm/Page/Community/Objectives.elm
+++ b/src/elm/Page/Community/Objectives.elm
@@ -1259,7 +1259,7 @@ viewAction ({ t } as translators) model objective index action =
                     [ text (String.fromInt (index + 1)), text "." ]
                 , div [ class "ml-5 mt-1 min-w-0 w-full" ]
                     [ h4 [ title (Markdown.toRawString action.description) ]
-                        [ Markdown.view [ class "line-clamp-3" ] action.description ]
+                        [ Markdown.view [ class "line-clamp-3 hide-children-from-2" ] action.description ]
                     , span [ class "sr-only" ]
                         [ text <|
                             t "community.objectives.reward"

--- a/src/elm/View/Modal.elm
+++ b/src/elm/View/Modal.elm
@@ -169,21 +169,7 @@ viewModalDetails options =
         body =
             case options.body of
                 Just b ->
-                    case options.size of
-                        Default ->
-                            div
-                                [ class "modal-body", tabindex -1 ]
-                                b
-
-                        Large ->
-                            div
-                                [ class "modal-body-lg", tabindex -1 ]
-                                b
-
-                        FullScreen ->
-                            div
-                                [ class "modal-body modal-body-full", tabindex -1 ]
-                                b
+                    div [ class "modal-body", tabindex -1 ] b
 
                 Nothing ->
                     text ""

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -366,6 +366,10 @@ https://tailwindcss.com/docs/adding-new-utilities */
     @apply hidden;
   }
 
+  .hide-children-from-2 > :nth-child(n + 2) {
+    @apply hidden;
+  }
+
   .focus-ring {
     @apply focus:outline-none focus-visible:ring ring-green ring-opacity-50 active:ring-0;
   }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -249,10 +249,19 @@ body > * {
 
 .modal-content {
   @apply bg-white rounded-t-lg absolute left-0 bottom-0 w-full flex flex-col;
+
+  min-height: 4rem;
+  max-height: 60vh;
+}
+
+.modal-content-lg {
+  max-height: 80vh;
 }
 
 .modal-content-full {
-  @apply rounded-t-none top-0 overflow-auto h-screen;
+  @apply overflow-auto;
+
+  max-height: 95vh;
 }
 
 .modal-header {
@@ -261,24 +270,10 @@ body > * {
 
 .modal-body {
   @apply p-4 pt-0 overflow-y-auto flex-grow;
-
-  min-height: 4rem;
-  max-height: 60vh;
-}
-
-.modal-body-lg {
-  @apply p-4 pt-0 overflow-y-auto;
-
-  min-height: 4rem;
-  max-height: 80vh;
-}
-
-.modal-body-full {
-  max-height: 100%;
 }
 
 .modal-footer {
-  @apply flex flex-wrap justify-center items-center p-4 pt-0;
+  @apply flex flex-wrap justify-center items-center bg-gray-100 p-4;
 }
 
 .modal-cancel {
@@ -298,10 +293,6 @@ body > * {
     --tw-translate-x: -50%;
   }
 
-  .modal-content-full {
-    height: unset;
-  }
-
   .modal-content-lg,
   .modal-content-full {
     @apply top-1/2;
@@ -309,19 +300,8 @@ body > * {
     --tw-translate-y: -50%;
   }
 
-  .modal-body-lg {
-    @apply px-4 py-0 overflow-y-auto;
-
-    min-height: 4rem;
-    max-height: 60vh;
-  }
-
-  .modal-body-full {
-    max-height: 80vh;
-  }
-
   .modal-footer {
-    @apply bg-gray-100 rounded-b-lg p-4;
+    @apply rounded-b-lg;
   }
 
   .modal-cancel {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -251,17 +251,17 @@ body > * {
   @apply bg-white rounded-t-lg absolute left-0 bottom-0 w-full flex flex-col;
 
   min-height: 4rem;
-  max-height: 60vh;
+  max-height: 60%;
 }
 
 .modal-content-lg {
-  max-height: 80vh;
+  max-height: 80%;
 }
 
 .modal-content-full {
   @apply overflow-auto;
 
-  max-height: 95vh;
+  max-height: 95%;
 }
 
 .modal-header {


### PR DESCRIPTION
## What issue does this PR close
Closes #741 

## Changes Proposed ( a list of new changes introduced by this PR)
- Remove rogue `truncate` class on action description
- Revisit logic behind modal sizing (`max-height` is now set on `modal-content` instead of `modal-body`)
- Make claim modal taller
- Put modal buttons on footer

## How to test ( a list of instructions on how to test this PR)
- Go to the "How to earn page" (`/community/objectives`)
- Open the modal for an action with a long description
- Check that you can read the entire description
- Check that the buttons to claim or cancel are always visible on the bottom of the modal
- If the action contents are big enough, the modal should now be able to grow taller (up to 95% of your screen height)
