### PR TITLE
Update GraphQL types and use images

### DIFF
--- a/src/elm/Cambiatus/Object/Product.elm
+++ b/src/elm/Cambiatus/Object/Product.elm
@@ -31,26 +31,6 @@ communityId =
     Object.selectionForField "String" "communityId" [] Decode.string
 
 
-createdAt : SelectionSet Cambiatus.ScalarCodecs.DateTime Cambiatus.Object.Product
-createdAt =
-    Object.selectionForField "ScalarCodecs.DateTime" "createdAt" [] (Cambiatus.ScalarCodecs.codecs |> Cambiatus.Scalar.unwrapCodecs |> .codecDateTime |> .decoder)
-
-
-createdBlock : SelectionSet Int Cambiatus.Object.Product
-createdBlock =
-    Object.selectionForField "Int" "createdBlock" [] Decode.int
-
-
-createdEosAccount : SelectionSet String Cambiatus.Object.Product
-createdEosAccount =
-    Object.selectionForField "String" "createdEosAccount" [] Decode.string
-
-
-createdTx : SelectionSet String Cambiatus.Object.Product
-createdTx =
-    Object.selectionForField "String" "createdTx" [] Decode.string
-
-
 creator :
     SelectionSet decodesTo Cambiatus.Object.User
     -> SelectionSet decodesTo Cambiatus.Object.Product
@@ -71,11 +51,6 @@ description =
 id : SelectionSet Int Cambiatus.Object.Product
 id =
     Object.selectionForField "Int" "id" [] Decode.int
-
-
-image : SelectionSet (Maybe String) Cambiatus.Object.Product
-image =
-    Object.selectionForField "(Maybe String)" "image" [] (Decode.string |> Decode.nullable)
 
 
 images :

--- a/src/elm/Cambiatus/Object/ProductPreview.elm
+++ b/src/elm/Cambiatus/Object/ProductPreview.elm
@@ -46,11 +46,6 @@ id =
     Object.selectionForField "Int" "id" [] Decode.int
 
 
-image : SelectionSet (Maybe String) Cambiatus.Object.ProductPreview
-image =
-    Object.selectionForField "(Maybe String)" "image" [] (Decode.string |> Decode.nullable)
-
-
 images :
     SelectionSet decodesTo Cambiatus.Object.ProductImage
     -> SelectionSet (List decodesTo) Cambiatus.Object.ProductPreview

--- a/src/elm/Notification.elm
+++ b/src/elm/Notification.elm
@@ -18,6 +18,7 @@ import Cambiatus.Object.Mint as Mint
 import Cambiatus.Object.NotificationHistory as NotificationHistory
 import Cambiatus.Object.Order as Order
 import Cambiatus.Object.Product as Product
+import Cambiatus.Object.ProductImage
 import Cambiatus.Object.Subdomain as Subdomain
 import Cambiatus.Object.Transfer as Transfer
 import Cambiatus.Query as Query
@@ -184,7 +185,10 @@ saleHistorySelectionSet =
                 (SelectionSet.succeed Product
                     |> with Shop.idSelectionSet
                     |> with Product.title
-                    |> with Product.image
+                    |> with
+                        (Product.images Cambiatus.Object.ProductImage.uri
+                            |> SelectionSet.map List.head
+                        )
                     |> with (Product.community logoSelectionSet)
                 )
             )


### PR DESCRIPTION
## What issue does this PR close
Closes #746 

## Changes Proposed ( a list of new changes introduced by this PR)
- Update GraphQL types (remove `image` and other fields on products)
- Use first image out of `images` field on notifications about purchases

## How to test ( a list of instructions on how to test this PR)
- Go to your notifications
- It should load, and show the first image of the product