### PR TITLE
Feature/shop multiple images

### DIFF
--- a/public/translations/amh-ETH.json
+++ b/public/translations/amh-ETH.json
@@ -832,7 +832,8 @@
         "inventory_management": "የንብረት አያያዝ",
         "inventory_management_description": "ተጨማሪ ክፍሎች በሌሉዎት ጊዜ ቅናሽዎን ማሰናከል ከፈለጉ ይህንን አማራጭ ያንቁት"
       },
-      "continue": "ቀጥል"
+      "continue": "ቀጥል",
+      "index": "ደረጃ {{current}} ከ {{total}}"
     },
     "empty": {
       "all_title": "ቅናሾቹ የት አሉ?",

--- a/public/translations/amh-ETH.json
+++ b/public/translations/amh-ETH.json
@@ -784,18 +784,14 @@
     "create_offer_success": "የሚሰጠዉ በትክክል ተፈጥሯል",
     "edit_offer": "የሚሰጠዉን አርትዕ",
     "delete_offer_success": "የሚሰጠዉ በትክክል ወጥቷል",
+    "delete_offer_failure": "ቅናሽዎን በሚያስወግዱበት ጊዜ የሆነ ችግር ተፈጥሯል",
     "unauthorized": "እርሶ ይህንን ሽያጭ አርትዕ ለማድረግ አልተፈቃደም",
-    "photo_label": "የምርት ምስል",
-    "what_label": "የምርት ስም",
-    "description_label": "ምርቱን ይግለጹ",
-    "description_placeholder": "ምርትዎን ሙሉ በሙሉ ይግለጹ። ይህ በሽያጭ ላይ ይረዳል",
     "which_community_label": "በየትኛዉ ማህበረሰብ ዉስጥ መነገድ ይፈልጋሉ?",
     "choose_community_label": "ማህበረሰብ ምርጥ",
     "track_stock_label": "በመተግበሪያው ላይ ክፍሎችን መከታተል ይፈልጋሉ?",
     "choose_track_stock_label": "መከታትል ወይም አለመከታተልን ምረጥ",
     "track_stock_no": "አይደለም",
     "track_stock_yes": "አዎ",
-    "price_label": "የምርት ዋጋ",
     "units_available": "አሁን ያለዉ ብዛት",
     "out_of_stock": "የለም",
     "offer_action": "{{accountName}} እየገዛ ነዉ",
@@ -812,6 +808,27 @@
     "no_image": "ምስል የለም",
     "subtract_unit": "አሃድ ቀንስ",
     "add_unit": "ክፍል ጨምር",
+    "steps": {
+      "main_information": {
+        "title": "ዋና መረጃ",
+        "name_label": "ስም",
+        "name_placeholder": "የምርት ስም",
+        "description_label": "መግለጫ",
+        "description_placeholder": "ምርትዎን ሙሉ በሙሉ ይግለጹ። ለሽያጭ ይረዳል"
+      },
+      "images": {
+        "title": "ምስሎች",
+        "guidance": "የምርት ምስሎችን ያክሉ። በኋላ ላይ ተጨማሪ ምስሎችን ማከል ትችላለህ"
+      },
+      "price_and_inventory": {
+        "title": "ዋጋ እና ክምችት",
+        "price_label": "ዋጋ",
+        "quantity_label": "በክምችት ውስጥ ያለው መጠን",
+        "inventory_management": "የንብረት አያያዝ",
+        "inventory_management_description": "ተጨማሪ ክፍሎች በሌሉዎት ጊዜ ቅናሽዎን ማሰናከል ከፈለጉ ይህንን አማራጭ ያንቁት"
+      },
+      "continue": "ቀጥል"
+    },
     "empty": {
       "all_title": "ቅናሾቹ የት አሉ?",
       "user_title": "በዚህ ማህበረሰብ ውስጥ ምንም ቅናሾች የሉዎትም",

--- a/public/translations/amh-ETH.json
+++ b/public/translations/amh-ETH.json
@@ -808,6 +808,11 @@
     "no_image": "ምስል የለም",
     "subtract_unit": "አሃድ ቀንስ",
     "add_unit": "ክፍል ጨምር",
+    "carrousel": {
+      "previous": "ወደ ቀዳሚው ምስል ይሂዱ",
+      "next": "ወደ ቀጣዩ ምስል ይሂዱ",
+      "index": "ወደ ምስል {{index}} ይሂዱ"
+    },
     "steps": {
       "main_information": {
         "title": "ዋና መረጃ",

--- a/public/translations/cat-CAT.json
+++ b/public/translations/cat-CAT.json
@@ -850,6 +850,11 @@
     "no_image": "Cap imatge",
     "subtract_unit": "Resta una unitat",
     "add_unit": "Afegir una unitat",
+    "carrousel": {
+      "previous": "Vés a la imatge anterior",
+      "next": "Vés a la imatge següent",
+      "index": "Vés a la imatge {{index}}"
+    },
     "steps": {
       "main_information": {
         "title": "Informació principal",

--- a/public/translations/cat-CAT.json
+++ b/public/translations/cat-CAT.json
@@ -874,7 +874,8 @@
         "inventory_management": "Gestió d'inventari",
         "inventory_management_description": "Si vols desactivar la teva oferta quan no tinguis més unitats en estoc, activa aquesta opció"
       },
-      "continue": "Continua"
+      "continue": "Continua",
+      "index": "Pas {{current}} de {{total}}"
     },
     "empty": {
       "all_title": "On són les ofertes?",

--- a/public/translations/cat-CAT.json
+++ b/public/translations/cat-CAT.json
@@ -826,18 +826,14 @@
     "create_offer_success": "Oferta creada amb èxit",
     "edit_offer": "Editar oferta",
     "delete_offer_success": "L’oferta s’ha suprimit correctament",
+    "delete_offer_failure": "S'ha produït un error en eliminar la teva oferta",
     "unauthorized": "No tens autorització per a editar aquesta venda",
-    "photo_label": "Imatge del producte",
-    "what_label": "Nom del producte",
-    "description_label": "Descriure el producte",
-    "description_placeholder": "Descriu el teu producte completament. Això ajudarà en les vendes",
     "which_community_label": "En quina comunitat vols fer la venda?",
     "choose_community_label": "Escull una comunitat",
     "track_stock_label": "Voleu fer un seguiment de les unitats a l'aplicació?",
     "choose_track_stock_label": "Trieu entre fer un seguiment o no",
     "track_stock_no": "No",
     "track_stock_yes": "Sí",
-    "price_label": "Preu del producte",
     "units_available": "Quantitat disponible",
     "out_of_stock": "fora d'estoc",
     "offer_action": "{{accountName}} està VENENT",
@@ -854,6 +850,27 @@
     "no_image": "Cap imatge",
     "subtract_unit": "Resta una unitat",
     "add_unit": "Afegir una unitat",
+    "steps": {
+      "main_information": {
+        "title": "Informació principal",
+        "name_label": "Nom",
+        "name_placeholder": "Nom del producte",
+        "description_label": "Descripció",
+        "description_placeholder": "Descriu completament el teu producte. Ajudarà amb les vendes"
+      },
+      "images": {
+        "title": "Imatges",
+        "guidance": "Afegeix imatges del producte. Podeu afegir més imatges més endavant"
+      },
+      "price_and_inventory": {
+        "title": "Preu i Inventari",
+        "price_label": "Preu",
+        "quantity_label": "Quantitat en estoc",
+        "inventory_management": "Gestió d'inventari",
+        "inventory_management_description": "Si vols desactivar la teva oferta quan no tinguis més unitats en estoc, activa aquesta opció"
+      },
+      "continue": "Continua"
+    },
     "empty": {
       "all_title": "On són les ofertes?",
       "user_title": "No tienes ninguna oferta en esta comunidad",

--- a/public/translations/en-US.json
+++ b/public/translations/en-US.json
@@ -847,6 +847,11 @@
     "no_image": "No image",
     "subtract_unit": "Subtract a unit",
     "add_unit": "Add a unit",
+    "carrousel": {
+      "previous": "Go to previous image",
+      "next": "Go to next image",
+      "index": "Go to image {{index}}"
+    },
     "steps": {
       "main_information": {
         "title": "Main information",

--- a/public/translations/en-US.json
+++ b/public/translations/en-US.json
@@ -871,7 +871,8 @@
         "inventory_management": "Inventory management",
         "inventory_management_description": "If you want to disable your offer when there are no more units in stock, enable this option"
       },
-      "continue": "Continue"
+      "continue": "Continue",
+      "index": "Step {{current}} of {{total}}"
     },
     "empty": {
       "all_title": "Where are all the offers?",

--- a/public/translations/en-US.json
+++ b/public/translations/en-US.json
@@ -823,18 +823,14 @@
     "create_offer_success": "Offer created with success",
     "edit_offer": "Edit offer",
     "delete_offer_success": "Offer removed with success",
+    "delete_offer_failure": "Something went wrong when removing your offer",
     "unauthorized": "You are not authorized to edit this sale",
-    "photo_label": "Product's image",
-    "what_label": "Product's name",
-    "description_label": "Describe the product",
-    "description_placeholder": "Describe your product fully. This will help in sales",
     "which_community_label": "In which community do you want to sell it?",
     "choose_community_label": "Choose a community",
     "track_stock_label": "Do you want to track units on the app?",
     "choose_track_stock_label": "Choose between tracking or not",
     "track_stock_no": "No",
     "track_stock_yes": "Yes",
-    "price_label": "Product's price",
     "units_available": "Available Quantity",
     "out_of_stock": "out of stock",
     "offer_action": "{{accountName}} is BUYING",
@@ -851,6 +847,27 @@
     "no_image": "No image",
     "subtract_unit": "Subtract a unit",
     "add_unit": "Add a unit",
+    "steps": {
+      "main_information": {
+        "title": "Main information",
+        "name_label": "Name",
+        "name_placeholder": "Product's name",
+        "description_label": "Description",
+        "description_placeholder": "Describe your product fully. This will help in sales"
+      },
+      "images": {
+        "title": "Images",
+        "guidance": "Set the product images. You can add more later"
+      },
+      "price_and_inventory": {
+        "title": "Price and Inventory",
+        "price_label": "Price",
+        "quantity_label": "Quantity in stock",
+        "inventory_management": "Inventory management",
+        "inventory_management_description": "If you want to disable your offer when there are no more units in stock, enable this option"
+      },
+      "continue": "Continue"
+    },
     "empty": {
       "all_title": "Where are all the offers?",
       "user_title": "You don't have any offers in this community",

--- a/public/translations/es-ES.json
+++ b/public/translations/es-ES.json
@@ -826,18 +826,14 @@
     "create_offer_success": "Oferta creada con éxito",
     "edit_offer": "Editar oferta",
     "delete_offer_success": "Oferta eliminado con éxito",
+    "delete_offer_failure": "Algo salió mal al eliminar tu oferta",
     "unauthorized": "No tienes autorización para editar esta venta",
-    "photo_label": "Imagen del producto",
-    "what_label": "Nombre del producto",
-    "description_label": "Describa el producto",
-    "description_placeholder": "Describa su producto completamente. Esto ayudará en las ventas",
     "which_community_label": "En cual comunidad quieres realizar tu venta?",
     "choose_community_label": "Escoge una comunidad",
     "track_stock_label": "¿Quieres controlar el stock a través de la app?",
     "choose_track_stock_label": "Elija entre seguimiento o no",
     "track_stock_no": "No",
     "track_stock_yes": "Sí",
-    "price_label": "Precio del producto",
     "units_available": "Cantidad disponible",
     "out_of_stock": "agotado",
     "offer_action": "{{accountName}} esta VENDIENDO",
@@ -854,6 +850,27 @@
     "no_image": "Sin imágen",
     "subtract_unit": "Restar una unidad",
     "add_unit": "Añadir una unidad",
+    "steps": {
+      "main_information": {
+        "title": "Información principal",
+        "name_label": "Nombre",
+        "name_placeholder": "Nombre del producto",
+        "description_label": "Descripción",
+        "description_placeholder": "Describa completamente su producto. Ayudará con las ventas"
+      },
+      "images": {
+        "title": "Imágenes",
+        "guidance": "Añade imágenes del producto. Puedes agregar más imágenes más tarde"
+      },
+      "price_and_inventory": {
+        "title": "Precio y Inventario",
+        "price_label": "Precio",
+        "quantity_label": "Cantidad en inventario",
+        "inventory_management": "Gestión del inventario",
+        "inventory_management_description": "Si quieres desactivar tu oferta cuando no tengas más unidades en stock, activa esta opción"
+      },
+      "continue": "Continuar"
+    },
     "empty": {
       "all_title": "¿Dónde están las ofertas?",
       "user_title": "No tienes ninguna oferta en esta comunidad",

--- a/public/translations/es-ES.json
+++ b/public/translations/es-ES.json
@@ -850,6 +850,11 @@
     "no_image": "Sin imágen",
     "subtract_unit": "Restar una unidad",
     "add_unit": "Añadir una unidad",
+    "carrousel": {
+      "previous": "Ir a la imagen anterior",
+      "next": "Ir a la siguiente imagen",
+      "index": "Ir a la imagen {{index}}"
+    },
     "steps": {
       "main_information": {
         "title": "Información principal",

--- a/public/translations/es-ES.json
+++ b/public/translations/es-ES.json
@@ -874,7 +874,8 @@
         "inventory_management": "Gestión del inventario",
         "inventory_management_description": "Si quieres desactivar tu oferta cuando no tengas más unidades en stock, activa esta opción"
       },
-      "continue": "Continuar"
+      "continue": "Continuar",
+      "index": "Paso {{current}} de {{total}}"
     },
     "empty": {
       "all_title": "¿Dónde están las ofertas?",

--- a/public/translations/pt-BR.json
+++ b/public/translations/pt-BR.json
@@ -878,7 +878,8 @@
         "inventory_management": "Gerenciamento de inventário",
         "inventory_management_description": "Se você quer desabilitar sua oferta quando não tiver mais unidades em estoque, habilite esta opção"
       },
-      "continue": "Continuar"
+      "continue": "Continuar",
+      "index": "Passo {{current}} de {{total}}"
     },
     "empty": {
       "all_title": "Onde estão as ofertas?",

--- a/public/translations/pt-BR.json
+++ b/public/translations/pt-BR.json
@@ -830,18 +830,14 @@
     "edit_offer": "Editar oferta",
     "create_offer_success": "Oferta criada com sucesso!",
     "delete_offer_success": "Oferta removida com sucesso",
+    "delete_offer_failure": "Algo de errado aconteceu ao remover sua oferta",
     "unauthorized": "Você não tem autorização para editar essa venda",
-    "photo_label": "Imagem do produto",
-    "what_label": "Nome do produto",
-    "description_label": "Descreva o produto",
-    "description_placeholder": "Descreva completamente seu produto. Isso ajudará nas vendas",
     "which_community_label": "Em qual comunidade voce deseja vender?",
     "choose_community_label": "Escolha uma comunidade",
     "track_stock_label": "Deseja controlar estoque pelo app?",
     "choose_track_stock_label": "Escolha entre o rastreamento ou não",
     "track_stock_no": "No",
     "track_stock_yes": "Sim",
-    "price_label": "Preço do produto",
     "units_available": "Quantidade disponível",
     "out_of_stock": "fora de estoque",
     "offer_action": "{{accountName}} está VENDENDO",
@@ -858,6 +854,27 @@
     "no_image": "Sem imagem",
     "subtract_unit": "Subtrair uma unidade",
     "add_unit": "Adicionar uma unidade",
+    "steps": {
+      "main_information": {
+        "title": "Informações principais",
+        "name_label": "Nome",
+        "name_placeholder": "Nome do produto",
+        "description_label": "Descrição",
+        "description_placeholder": "Descreva completamente seu produto. Isso ajudará nas vendas"
+      },
+      "images": {
+        "title": "Imagens",
+        "guidance": "Adicione imagens do produto. Você pode adicionar mais imagens mais tarde"
+      },
+      "price_and_inventory": {
+        "title": "Preço e Inventário",
+        "price_label": "Preço",
+        "quantity_label": "Quantidade em estoque",
+        "inventory_management": "Gerenciamento de inventário",
+        "inventory_management_description": "Se você quer desabilitar sua oferta quando não tiver mais unidades em estoque, habilite esta opção"
+      },
+      "continue": "Continuar"
+    },
     "empty": {
       "all_title": "Onde estão as ofertas?",
       "user_title": "Você não tem nenhuma oferta nessa comunidade",

--- a/public/translations/pt-BR.json
+++ b/public/translations/pt-BR.json
@@ -854,6 +854,11 @@
     "no_image": "Sem imagem",
     "subtract_unit": "Subtrair uma unidade",
     "add_unit": "Adicionar uma unidade",
+    "carrousel": {
+      "previous": "Ir para imagem anterior",
+      "next": "Ir para próxima imagem",
+      "index": "Ir para imagem {{index}}"
+    },
     "steps": {
       "main_information": {
         "title": "Informações principais",

--- a/src/customElements/intersectionObserverElement.js
+++ b/src/customElements/intersectionObserverElement.js
@@ -22,9 +22,18 @@ export default () => (
         .filter((target) => target !== null)
     }
 
+    isAboveMaxWidth () {
+      const maxWidthAttribute = this.getAttribute('elm-max-width')
+      if (maxWidthAttribute === 'none') {
+        return false
+      }
+
+      const maxWidth = parseInt(maxWidthAttribute) || 0
+      return window.innerWidth >= maxWidth
+    }
+
     connectedCallback () {
-      this.maxWidth = parseInt(this.getAttribute('elm-max-width')) || 0
-      if (window.innerWidth >= this.maxWidth) {
+      if (this.isAboveMaxWidth()) {
         return
       }
 
@@ -37,7 +46,7 @@ export default () => (
     }
 
     disconnectedCallback () {
-      if (window.innerWidth >= this.maxWidth) {
+      if (this.isAboveMaxWidth()) {
         return
       }
 
@@ -45,7 +54,7 @@ export default () => (
     }
 
     observe () {
-      if (window.innerWidth >= this.maxWidth) {
+      if (this.isAboveMaxWidth()) {
         return
       }
 

--- a/src/elm/Form/File.elm
+++ b/src/elm/Form/File.elm
@@ -532,11 +532,9 @@ viewSimplePlus (Options options) viewConfig value toMsg =
                     Icons.plus "fill-current text-orange-300"
 
                 RemoteData.Loading ->
-                    div
-                        [ class "animate-skeleton-loading"
-                        , ariaLive "polite"
-                        ]
-                        [ span [ class "sr-only" ]
+                    div [ class "w-full px-4" ]
+                        [ View.Components.loadingLogoAnimatedFluid
+                        , span [ class "sr-only" ]
                             [ Html.text <| viewConfig.translators.t "menu.loading"
                             ]
                         ]

--- a/src/elm/Form/File.elm
+++ b/src/elm/Form/File.elm
@@ -178,6 +178,7 @@ type FileType
 type Variant
     = SmallCircle
     | LargeRectangle RectangleBackground
+    | SimplePlus
 
 
 type RectangleBackground
@@ -362,6 +363,9 @@ view (Options options) viewConfig toMsg =
                 SmallCircle ->
                     viewSmallCircle (Options options) viewConfig file toMsg
 
+                SimplePlus ->
+                    viewSimplePlus (Options options) viewConfig file toMsg
+
         WithChoices choices ->
             viewHardcodedChoices (Options options) viewConfig choices toMsg
 
@@ -503,6 +507,59 @@ viewSmallCircle (Options options) viewConfig value toMsg =
                 ]
             ]
         , viewConfig.error
+        ]
+
+
+viewSimplePlus : Options msg -> ViewConfig msg -> RemoteData Http.Error String -> (Msg -> msg) -> Html msg
+viewSimplePlus (Options options) viewConfig value toMsg =
+    let
+        imgClasses =
+            "object-cover rounded max-w-full max-h-full"
+    in
+    div options.containerAttrs
+        [ viewInput (Options options) viewConfig toMsg
+        , Html.label
+            (for options.id
+                :: class "hover:opacity-70"
+                :: classList
+                    [ ( "cursor-pointer", not options.disabled )
+                    , ( "cursor-not-allowed", options.disabled )
+                    ]
+                :: options.extraAttrs
+            )
+            [ case value of
+                RemoteData.NotAsked ->
+                    Icons.plus "fill-current text-orange-300"
+
+                RemoteData.Loading ->
+                    div
+                        [ class "animate-skeleton-loading"
+                        , ariaLive "polite"
+                        ]
+                        [ span [ class "sr-only" ]
+                            [ Html.text <| viewConfig.translators.t "menu.loading"
+                            ]
+                        ]
+
+                RemoteData.Failure _ ->
+                    Icons.plus "fill-current text-orange-300"
+
+                RemoteData.Success url ->
+                    if List.member PDF options.fileTypes then
+                        View.Components.pdfViewer [ class imgClasses ]
+                            { url = url
+                            , childClass = imgClasses
+                            , maybeTranslators = Nothing
+                            }
+
+                    else
+                        img
+                            [ class imgClasses
+                            , src url
+                            , alt ""
+                            ]
+                            []
+            ]
         ]
 
 

--- a/src/elm/Form/File.elm
+++ b/src/elm/Form/File.elm
@@ -2,7 +2,7 @@ module Form.File exposing
     ( init, Options
     , withDisabled, withAttrs, withContainerAttrs, withFileTypes, FileType(..), withVariant, Variant(..), RectangleBackground(..)
     , getId
-    , isEmpty, parser
+    , isEmpty, isLoading, parser
     , view
     , Model, initModel, initModelWithChoices, update, Msg, msgToString
     )
@@ -35,7 +35,7 @@ module Form.File exposing
 
 # Helpers
 
-@docs isEmpty, parser
+@docs isEmpty, isLoading, parser
 
 
 # View
@@ -137,6 +137,21 @@ isEmpty model =
 
                 Nothing ->
                     True
+
+
+isLoading : Model -> Bool
+isLoading model =
+    case model of
+        SingleFile file ->
+            RemoteData.isLoading file
+
+        WithChoices { files, selected } ->
+            case List.Extra.getAt selected files of
+                Just file ->
+                    RemoteData.isLoading file
+
+                Nothing ->
+                    False
 
 
 

--- a/src/elm/Icons.elm
+++ b/src/elm/Icons.elm
@@ -7,6 +7,7 @@ module Icons exposing
     , calendar
     , cambiatusCoin
     , camera
+    , circularClose
     , clearInput
     , clock
     , close
@@ -67,6 +68,18 @@ close : String -> Svg msg
 close class_ =
     svg [ class class_, width "24", height "24", viewBox "0 0 24 24" ]
         [ Svg.path [ fillRule "evenodd", clipRule "evenodd", d "M13.6299 12.0242L22.2329 3.25164C22.603 2.84787 22.5865 2.22339 22.1956 1.83974C21.8046 1.4561 21.18 1.45137 20.7833 1.82906L12.1938 10.5881L3.25206 1.81551C2.99607 1.54661 2.6138 1.43874 2.25501 1.53415C1.89622 1.62956 1.61802 1.91306 1.5294 2.2736C1.44078 2.63414 1.55584 3.01431 1.82951 3.26519L10.7577 12.0242L1.82951 20.7832C1.45184 21.1799 1.45656 21.8046 1.8402 22.1956C2.22383 22.5865 2.8483 22.603 3.25206 22.2329L12.1938 13.4603L20.7833 22.2194C21.18 22.597 21.8046 22.5923 22.1956 22.2087C22.5865 21.825 22.603 21.2005 22.2329 20.7968L13.6299 12.0242Z" ] [] ]
+
+
+circularClose : String -> Svg msg
+circularClose class_ =
+    svg
+        [ width "18"
+        , height "16"
+        , viewBox "0 0 18 16"
+        , fill "none"
+        , class class_
+        ]
+        [ Svg.path [ d "M5.45632 11.5353C7.57956 13.4879 11.022 13.4879 13.1452 11.5353C15.2685 9.58269 15.2685 6.41687 13.1452 4.46424C11.022 2.51162 7.57956 2.51162 5.45632 4.46424C3.33308 6.41687 3.33308 9.58269 5.45632 11.5353Z", stroke "#DB1B1B", strokeWidth "1.5", strokeLinecap "round", strokeLinejoin "round" ] [], Svg.path [ d "M11.6075 8.00023L6.9941 8.00023", stroke "#DB1B1B", strokeWidth "1.5", strokeLinecap "round", strokeLinejoin "round" ] [] ]
 
 
 plus : String -> Svg msg

--- a/src/elm/Icons.elm
+++ b/src/elm/Icons.elm
@@ -7,6 +7,7 @@ module Icons exposing
     , calendar
     , cambiatusCoin
     , camera
+    , checkmark
     , circledPlus
     , circularClose
     , clearInput
@@ -149,6 +150,11 @@ camera class_ =
             , Svg.path [ d "m7.99998 11.3333c1.47276 0 2.66662-1.1939 2.66662-2.66663 0-1.47276-1.19386-2.66667-2.66662-2.66667s-2.66667 1.19391-2.66667 2.66667c0 1.47273 1.19391 2.66663 2.66667 2.66663z" ] []
             ]
         ]
+
+
+checkmark : String -> Svg msg
+checkmark class_ =
+    svg [ width "14", height "10", fill "none", class class_ ] [ Svg.path [ fillRule "evenodd", clipRule "evenodd", d "M5.662 9.5c-.266 0-.521-.102-.71-.284L.27 4.704a.942.942 0 0 1 .025-1.342 1.031 1.031 0 0 1 1.394-.024l3.974 3.829 6.65-6.408a1.031 1.031 0 0 1 1.394.024.942.942 0 0 1 .025 1.343l-7.36 7.09a1.023 1.023 0 0 1-.71.284Z", fill "#fff" ] [] ]
 
 
 notification : String -> Svg msg

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -1139,13 +1139,13 @@ statusToRoute status session =
         Shop filter _ ->
             Just (Route.Shop filter)
 
-        ShopEditor maybeSaleId _ ->
+        ShopEditor maybeSaleId subModel ->
             case maybeSaleId of
                 Nothing ->
                     Just Route.NewSale
 
                 Just saleId ->
-                    Just (Route.EditSale saleId)
+                    Just (Route.EditSale saleId (ShopEditor.getCurrentStep subModel))
 
         ShopViewer saleId _ ->
             Just (Route.ViewSale saleId)
@@ -1534,10 +1534,10 @@ changeRouteTo maybeRoute model =
                 >> updateStatusWith (ShopEditor Nothing) GotShopEditorMsg model
                 |> withLoggedIn Route.NewSale
 
-        Just (Route.EditSale saleId) ->
-            (\l -> ShopEditor.initUpdate saleId l)
+        Just (Route.EditSale saleId saleStep) ->
+            (\l -> ShopEditor.initUpdate saleId saleStep l)
                 >> updateStatusWith (ShopEditor (Just saleId)) GotShopEditorMsg model
-                |> withLoggedIn (Route.EditSale saleId)
+                |> withLoggedIn (Route.EditSale saleId saleStep)
 
         Just (Route.ViewSale saleId) ->
             (\s -> ShopViewer.init s saleId)

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -1554,9 +1554,9 @@ changeRouteTo maybeRoute model =
                 newModelCmd l =
                     case model.status of
                         ShopEditor _ shopEditorModel ->
-                            ( ShopEditor.maybeGoBackOneStep step shopEditorModel
-                            , Cmd.none
-                            )
+                            ShopEditor.maybeSetStep l.shared.translators
+                                step
+                                shopEditorModel
 
                         _ ->
                             ShopEditor.initCreate l
@@ -1570,9 +1570,15 @@ changeRouteTo maybeRoute model =
                 newUpdateResult l =
                     case model.status of
                         ShopEditor _ shopEditorModel ->
-                            shopEditorModel
-                                |> ShopEditor.maybeGoBackOneStep saleStep
+                            let
+                                ( newModel, newCmd ) =
+                                    ShopEditor.maybeSetStep l.shared.translators
+                                        saleStep
+                                        shopEditorModel
+                            in
+                            newModel
                                 |> UR.init
+                                |> UR.addCmd newCmd
 
                         _ ->
                             ShopEditor.initUpdate saleId saleStep l

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -1535,8 +1535,18 @@ changeRouteTo maybeRoute model =
                 |> withLoggedIn Route.NewSale
 
         Just (Route.EditSale saleId saleStep) ->
-            (\l -> ShopEditor.initUpdate saleId saleStep l)
-                >> updateStatusWith (ShopEditor (Just saleId)) GotShopEditorMsg model
+            let
+                newModelCmd l =
+                    case model.status of
+                        ShopEditor _ shopEditorModel ->
+                            -- TODO - Change step
+                            UR.init shopEditorModel
+
+                        _ ->
+                            ShopEditor.initUpdate saleId saleStep l
+            in
+            newModelCmd
+                >> updateLoggedInUResult (ShopEditor (Just saleId)) GotShopEditorMsg model
                 |> withLoggedIn (Route.EditSale saleId saleStep)
 
         Just (Route.ViewSale saleId) ->

--- a/src/elm/Notification.elm
+++ b/src/elm/Notification.elm
@@ -110,7 +110,7 @@ type alias Community =
 type alias Product =
     { id : Shop.Id
     , title : String
-    , image : Maybe String
+    , images : List String
     , community : Community
     }
 
@@ -185,10 +185,7 @@ saleHistorySelectionSet =
                 (SelectionSet.succeed Product
                     |> with Shop.idSelectionSet
                     |> with Product.title
-                    |> with
-                        (Product.images Cambiatus.Object.ProductImage.uri
-                            |> SelectionSet.map List.head
-                        )
+                    |> with (Product.images Cambiatus.Object.ProductImage.uri)
                     |> with (Product.community logoSelectionSet)
                 )
             )

--- a/src/elm/Page/Community/Objectives.elm
+++ b/src/elm/Page/Community/Objectives.elm
@@ -896,7 +896,7 @@ view loggedIn model =
                                                         Just ("#" ++ actionCardId action)
                                                 )
                                     , threshold = 0.01
-                                    , breakpointToExclude = View.Components.Lg
+                                    , breakpointToExclude = Just View.Components.Lg
                                     , onStartedIntersecting = Just StartedIntersecting
                                     , onStoppedIntersecting = Just StoppedIntersecting
                                     }

--- a/src/elm/Page/Notification.elm
+++ b/src/elm/Page/Notification.elm
@@ -296,13 +296,16 @@ viewNotificationSaleHistoryDetail ({ shared } as loggedIn) sale date =
             shared
             (Utils.fromDateTime date)
         ]
-    , div [ class "flex flex-none pl-4" ]
-        [ img
-            [ src (Maybe.withDefault "" sale.product.image)
-            , class "object-scale-down rounded-full h-10"
-            ]
-            []
-        ]
+    , case sale.product.images of
+        [] ->
+            text ""
+
+        firstImage :: _ ->
+            img
+                [ src firstImage
+                , class "object-scale-down rounded-full h-10 ml-4"
+                ]
+                []
     ]
 
 

--- a/src/elm/Page/Shop.elm
+++ b/src/elm/Page/Shop.elm
@@ -334,6 +334,7 @@ viewCard loggedIn index card =
                         { containerAttrs = [ class "h-32" ]
                         , listAttrs = [ class "gap-x-4 rounded-t bg-gray-100" ]
                         , imageContainerAttrs = [ class "bg-white rounded-t" ]
+                        , imageOverlayAttrs = []
                         , imageAttrs = [ class "w-full h-full" ]
                         }
                         { showArrows = False

--- a/src/elm/Page/Shop.elm
+++ b/src/elm/Page/Shop.elm
@@ -330,6 +330,7 @@ viewCard loggedIn index card =
 
                 firstImage :: otherImages ->
                     Shop.viewImageCarrousel
+                        translators
                         { containerAttrs = [ class "h-32" ]
                         , listAttrs = [ class "gap-x-4 rounded-t bg-gray-100" ]
                         , imageContainerAttrs = [ class "bg-white rounded-t" ]

--- a/src/elm/Page/Shop.elm
+++ b/src/elm/Page/Shop.elm
@@ -216,7 +216,7 @@ viewShopFilter loggedIn model =
             , classList [ ( "button-disabled", not loggedIn.hasAcceptedCodeOfConduct ) ]
 
             -- TODO - Maybe we should check that the user has permission to sell
-            , Route.href Route.NewSale
+            , Route.href (Route.NewSale Route.SaleMainInformation)
             ]
             [ text <| t "shop.create_new_offer" ]
         , a
@@ -271,7 +271,7 @@ viewEmptyState { t, tr } communitySymbol model =
         , p [ class "text-black text-center mt-4" ] description
         , a
             [ class "button button-primary mt-6 md:px-6 w-full md:w-max"
-            , Route.href Route.NewSale
+            , Route.href (Route.NewSale Route.SaleMainInformation)
             ]
             [ text <| t "shop.empty.create_new" ]
         ]

--- a/src/elm/Page/Shop.elm
+++ b/src/elm/Page/Shop.elm
@@ -231,6 +231,8 @@ viewShopFilter loggedIn model =
             { isDisabled = not loggedIn.hasAcceptedCodeOfConduct }
             [ class "w-full md:w-40 button button-primary"
             , classList [ ( "button-disabled", not loggedIn.hasAcceptedCodeOfConduct ) ]
+
+            -- TODO - Maybe we should check that the user has permission to sell
             , Route.href Route.NewSale
             ]
             [ text <| t "shop.create_new_offer" ]

--- a/src/elm/Page/Shop.elm
+++ b/src/elm/Page/Shop.elm
@@ -319,15 +319,16 @@ viewCard loggedIn index card =
             loggedIn.shared.translators
 
         image =
-            Maybe.withDefault
-                ("/icons/shop-placeholder"
-                    ++ (index
-                            |> modBy 3
-                            |> String.fromInt
-                       )
-                    ++ ".svg"
-                )
-                card.product.image
+            -- TODO - We only show one image
+            List.head card.product.images
+                |> Maybe.withDefault
+                    ("/icons/shop-placeholder"
+                        ++ (index
+                                |> modBy 3
+                                |> String.fromInt
+                           )
+                        ++ ".svg"
+                    )
 
         isFree =
             card.product.price == 0

--- a/src/elm/Page/Shop.elm
+++ b/src/elm/Page/Shop.elm
@@ -306,7 +306,6 @@ viewCard loggedIn index card =
         images =
             case card.product.images of
                 [] ->
-                    -- TODO
                     img
                         [ class "h-32 rounded-t object-cover"
                         , alt ""
@@ -322,9 +321,12 @@ viewCard loggedIn index card =
                         []
 
                 firstImage :: otherImages ->
-                    -- TODO - Change background of images
-                    -- TODO - Should we do object-cover how we used to?
-                    Shop.viewImageCarrousel [ class "h-32" ]
+                    Shop.viewImageCarrousel
+                        { containerAttrs = [ class "h-32" ]
+                        , listAttrs = [ class "gap-x-4 rounded-t bg-gray-100" ]
+                        , imageContainerAttrs = [ class "bg-white rounded-t" ]
+                        , imageAttrs = [ class "w-full h-full" ]
+                        }
                         { showArrows = False
                         , productId = Just card.product.id
                         , onScrollToImage = ClickedScrollToImage
@@ -485,7 +487,7 @@ update msg model loggedIn =
                                 (\card ->
                                     { card
                                         | currentVisibleImage = Just imageId
-                                        , previousVisibleImage = card.previousVisibleImage
+                                        , previousVisibleImage = card.currentVisibleImage
                                     }
                                 )
                                 cards

--- a/src/elm/Page/Shop.elm
+++ b/src/elm/Page/Shop.elm
@@ -9,6 +9,7 @@ module Page.Shop exposing
     )
 
 import Api
+import Cambiatus.Enum.Permission as Permission
 import Community exposing (Balance)
 import Eos
 import Eos.Account
@@ -208,14 +209,21 @@ viewShopFilter loggedIn model =
 
                 Shop.UserSales ->
                     Shop.All
+
+        canSell =
+            case loggedIn.profile of
+                RemoteData.Success profile ->
+                    LoggedIn.hasPermissions profile [ Permission.Sell ]
+
+                _ ->
+                    False
     in
     div [ class "grid xs-max:grid-cols-1 grid-cols-2 md:flex mt-4 gap-4" ]
         [ View.Components.disablableLink
-            { isDisabled = not loggedIn.hasAcceptedCodeOfConduct }
+            { isDisabled = not loggedIn.hasAcceptedCodeOfConduct || not canSell
+            }
             [ class "w-full md:w-40 button button-primary"
             , classList [ ( "button-disabled", not loggedIn.hasAcceptedCodeOfConduct ) ]
-
-            -- TODO - Maybe we should check that the user has permission to sell
             , Route.href (Route.NewSale Route.SaleMainInformation)
             ]
             [ text <| t "shop.create_new_offer" ]

--- a/src/elm/Page/Shop/Editor.elm
+++ b/src/elm/Page/Shop/Editor.elm
@@ -20,7 +20,7 @@ import Form.Toggle
 import Form.Validate
 import Graphql.Http
 import Graphql.SelectionSet
-import Html exposing (Html, button, div, h2, hr, p, span, text)
+import Html exposing (Html, a, button, div, h2, hr, p, span, text)
 import Html.Attributes exposing (class, classList, disabled, maxlength, type_)
 import Html.Attributes.Aria exposing (ariaLabel)
 import Html.Events exposing (onClick)
@@ -489,20 +489,27 @@ viewForm ({ shared } as loggedIn) { isEdit, isDisabled } deleteModal formData =
                 shared.translators
                 (\submitButton ->
                     [ div [ class "mt-auto" ]
-                        [ div [ class "mt-10" ]
-                            [ if isEdit then
-                                button
-                                    [ class "button button-danger w-full"
-                                    , disabled isDisabled
-                                    , onClick ClickedDelete
-                                    , type_ "button"
-                                    ]
-                                    [ text (t "shop.delete") ]
-
-                              else
-                                text ""
+                        [ div [ class "mt-10 flex gap-x-4" ]
+                            -- TODO - Remove delete button from here
+                            -- [ if isEdit then
+                            --     button
+                            --         [ class "button button-danger w-full"
+                            --         , disabled isDisabled
+                            --         , onClick ClickedDelete
+                            --         , type_ "button"
+                            --         ]
+                            --         [ text (t "shop.delete") ]
+                            --   else
+                            --     text ""
+                            [ a
+                                [ class "button button-secondary w-full"
+                                , Route.href (Route.Shop Shop.All)
+                                ]
+                                [ -- TODO - I18N
+                                  text "Cancel"
+                                ]
                             , submitButton
-                                [ class "button button-primary w-full mt-4"
+                                [ class "button button-primary w-full"
                                 , disabled isDisabled
                                 ]
                                 [ text submitText ]
@@ -542,7 +549,7 @@ viewForm ({ shared } as loggedIn) { isEdit, isDisabled } deleteModal formData =
                     viewForm_ (mainInformationForm shared.translators)
                         formData.mainInformation
                         -- TODO - I18N
-                        "Next"
+                        "Continue"
                         MainInformationMsg
                         SubmittedMainInformation
 
@@ -550,7 +557,7 @@ viewForm ({ shared } as loggedIn) { isEdit, isDisabled } deleteModal formData =
                     viewForm_ (imagesForm shared.translators)
                         formData.images
                         -- TODO - I18N
-                        "Next"
+                        "Continue"
                         ImagesMsg
                         SubmittedImages
 

--- a/src/elm/Page/Shop/Editor.elm
+++ b/src/elm/Page/Shop/Editor.elm
@@ -509,18 +509,10 @@ viewForm ({ shared } as loggedIn) { isEdit, isDisabled } deleteModal formData =
                 (\submitButton ->
                     [ div [ class "mt-auto" ]
                         [ div [ class "mt-10 flex gap-x-4" ]
-                            -- TODO - Remove delete button from here
-                            -- [ if isEdit then
-                            --     button
-                            --         [ class "button button-danger w-full"
-                            --         , disabled isDisabled
-                            --         , onClick ClickedDelete
-                            --         , type_ "button"
-                            --         ]
-                            --         [ text (t "shop.delete") ]
-                            --   else
-                            --     text ""
-                            [ div [ class "grid grid-cols-2 w-full gap-6 lg:w-1/2 lg:mx-auto" ]
+                            [ div
+                                [ class "grid grid-cols-2 w-full gap-6 lg:w-1/2 lg:mx-auto"
+                                , classList [ ( "grid-cols-3", isEdit ) ]
+                                ]
                                 [ a
                                     [ class "button button-secondary w-full"
                                     , Route.href (Route.Shop Shop.All)
@@ -528,6 +520,19 @@ viewForm ({ shared } as loggedIn) { isEdit, isDisabled } deleteModal formData =
                                     [ -- TODO - I18N
                                       text "Cancel"
                                     ]
+
+                                -- TODO - Remove delete button from here
+                                , if isEdit then
+                                    button
+                                        [ class "button button-danger w-full"
+                                        , disabled isDisabled
+                                        , onClick ClickedDelete
+                                        , type_ "button"
+                                        ]
+                                        [ text (t "shop.delete") ]
+
+                                  else
+                                    text ""
                                 , submitButton
                                     [ class "button button-primary w-full"
                                     , disabled isDisabled

--- a/src/elm/Page/Shop/Editor.elm
+++ b/src/elm/Page/Shop/Editor.elm
@@ -490,7 +490,7 @@ initFormData =
             { name = ""
             , description = Form.RichText.initModel "product-description-editor" Nothing
             }
-    , images = Form.init []
+    , images = Form.init [ Form.File.initModel Nothing ]
     , priceAndInventory =
         Form.init
             { price = "0"
@@ -508,12 +508,9 @@ initEditingFormData product =
             { name = product.title
             , description = Form.RichText.initModel "product-description-editor" (Just product.description)
             }
-
-    -- TODO - Use images instead of image
     , images =
-        product.image
-            |> Form.File.initModel
-            |> List.singleton
+        product.images
+            |> List.map (Just >> Form.File.initModel)
             |> Form.init
     , priceAndInventory =
         Form.init

--- a/src/elm/Page/Shop/Editor.elm
+++ b/src/elm/Page/Shop/Editor.elm
@@ -329,7 +329,6 @@ stockTrackingForm translators { isDisabled } =
             )
             (Form.Toggle.init
                 { label =
-                    -- TODO - Should these be in `label`? We could use `withGroupOf3` from the community contacts PR
                     div [ class "text-gray-333 text-base mb-4" ]
                         [ -- TODO - I18N
                           span [ class "font-bold" ] [ text "Inventory management" ]

--- a/src/elm/Page/Shop/Editor.elm
+++ b/src/elm/Page/Shop/Editor.elm
@@ -247,7 +247,7 @@ priceAndInventoryForm translators isDisabled symbol =
 stockTrackingForm : Translation.Translators -> { isDisabled : Bool } -> Form.Form Msg { input | unitsInStock : String, trackUnits : Bool } Shop.StockTracking
 stockTrackingForm translators { isDisabled } =
     Form.succeed
-        (\availableUnits trackStock ->
+        (\trackStock availableUnits ->
             if trackStock then
                 Shop.UnitTracking { availableUnits = availableUnits }
 
@@ -255,6 +255,24 @@ stockTrackingForm translators { isDisabled } =
                 Shop.NoTracking
         )
         |> Form.withGroup [ class "bg-gray-100 rounded-sm p-4" ]
+            (Form.Toggle.init
+                { label =
+                    div [ class "text-gray-333 text-base mb-4" ]
+                        [ span [ class "font-bold" ] [ text <| translators.t "shop.steps.price_and_inventory.inventory_management" ]
+                        , p [ class "mt-2" ] [ text <| translators.t "shop.steps.price_and_inventory.inventory_management_description" ]
+                        ]
+                , id = "product-track-units-toggle"
+                }
+                |> Form.Toggle.withContainerAttrs [ class "flex flex-col" ]
+                |> Form.Toggle.withToggleContainerAttrs [ class "ml-0 pl-0" ]
+                |> Form.Toggle.withToggleSide (Form.Toggle.Right { invert = True })
+                |> Form.toggle
+                    { parser = Ok
+                    , value = .trackUnits
+                    , update = \newTrackUnits values -> { values | trackUnits = newTrackUnits }
+                    , externalError = always Nothing
+                    }
+            )
             (Form.introspect
                 (\{ trackUnits } ->
                     if trackUnits then
@@ -265,6 +283,7 @@ stockTrackingForm translators { isDisabled } =
                             |> Form.Text.withPlaceholder "0"
                             |> Form.Text.asNumeric
                             |> Form.Text.withType Form.Text.Number
+                            |> Form.Text.withContainerAttrs [ class "mb-0 mt-10" ]
                             |> Form.Text.withExtraAttrs
                                 [ Html.Attributes.min "0"
                                 , class "text-center"
@@ -308,24 +327,6 @@ stockTrackingForm translators { isDisabled } =
                     else
                         Form.succeed 0
                 )
-            )
-            (Form.Toggle.init
-                { label =
-                    div [ class "text-gray-333 text-base mb-4" ]
-                        [ span [ class "font-bold" ] [ text <| translators.t "shop.steps.price_and_inventory.inventory_management" ]
-                        , p [ class "mt-2" ] [ text <| translators.t "shop.steps.price_and_inventory.inventory_management_description" ]
-                        ]
-                , id = "product-track-units-toggle"
-                }
-                |> Form.Toggle.withContainerAttrs [ class "flex flex-col" ]
-                |> Form.Toggle.withToggleContainerAttrs [ class "ml-0 pl-0" ]
-                |> Form.Toggle.withToggleSide (Form.Toggle.Right { invert = True })
-                |> Form.toggle
-                    { parser = Ok
-                    , value = .trackUnits
-                    , update = \newTrackUnits values -> { values | trackUnits = newTrackUnits }
-                    , externalError = always Nothing
-                    }
             )
 
 

--- a/src/elm/Page/Shop/Editor.elm
+++ b/src/elm/Page/Shop/Editor.elm
@@ -349,8 +349,8 @@ initFormData =
     }
 
 
-initEditingFormData : Product -> Route.EditSaleStep -> FormData
-initEditingFormData product step =
+initEditingFormData : Translation.Translators -> Product -> Route.EditSaleStep -> FormData
+initEditingFormData translators product step =
     { mainInformation =
         Form.init
             { title = product.title
@@ -363,7 +363,7 @@ initEditingFormData product step =
             |> Form.init
     , priceAndInventory =
         Form.init
-            { price = String.fromFloat product.price
+            { price = Eos.formatSymbolAmount translators product.symbol product.price
             , unitsInStock =
                 case product.stockTracking of
                     Shop.NoTracking ->
@@ -702,7 +702,7 @@ update msg model loggedIn =
         CompletedSaleLoad (RemoteData.Success maybeSale) ->
             case ( model, maybeSale ) of
                 ( LoadingSaleUpdate step, Just sale ) ->
-                    initEditingFormData sale step
+                    initEditingFormData loggedIn.shared.translators sale step
                         |> EditingUpdate sale
                         |> UR.init
 

--- a/src/elm/Page/Shop/Editor.elm
+++ b/src/elm/Page/Shop/Editor.elm
@@ -209,7 +209,7 @@ imagesForm translators =
                                     )
                         )
                         images
-                        |> Form.list [ class "flex flex-wrap gap-x-6 gap-y-4" ]
+                        |> Form.list [ class "flex flex-wrap gap-6" ]
                 )
             )
 
@@ -547,7 +547,7 @@ viewForm ({ shared } as loggedIn) { isEdit, isDisabled } formData =
     div [ class "flex flex-col flex-grow" ]
         [ Page.viewHeader loggedIn pageTitle
         , div [ class "lg:container lg:mx-auto lg:px-4 lg:mt-6 lg:mb-20" ]
-            [ div [ class "bg-white pt-4 pb-8 flex-grow flex flex-col min-h-150 lg:rounded" ]
+            [ div [ class "bg-white pt-4 pb-8 flex-grow flex flex-col min-h-150 lg:w-2/3 lg:mx-auto lg:rounded lg:shadow-lg lg:animate-fade-in-from-above-lg lg:motion-reduce:animate-none" ]
                 [ div [ class "container mx-auto px-4 lg:max-w-none lg:mx-0 lg:px-6" ]
                     [ h2 [ class "font-bold text-black mb-2" ]
                         [ text ("Step " ++ String.fromInt stepNumber ++ " of 3") ]

--- a/src/elm/Page/Shop/Editor.elm
+++ b/src/elm/Page/Shop/Editor.elm
@@ -221,7 +221,7 @@ type alias PriceAndInventoryFormOutput =
 priceAndInventoryForm : Translation.Translators -> { isDisabled : Bool } -> Eos.Symbol -> Form.Form Msg PriceAndInventoryFormInput PriceAndInventoryFormOutput
 priceAndInventoryForm translators isDisabled symbol =
     Form.succeed PriceAndInventoryFormOutput
-        |> Form.withGroup [ class "grid grid-cols-2 gap-8" ]
+        |> Form.withGroup [ class "grid lg:grid-cols-2 gap-8" ]
             (Form.Text.init
                 { label = translators.t "shop.steps.price_and_inventory.price_label"
                 , id = "product-price-input"

--- a/src/elm/Page/Shop/Editor.elm
+++ b/src/elm/Page/Shop/Editor.elm
@@ -103,17 +103,15 @@ type alias MainInformationFormOutput =
 
 
 mainInformationForm : Translation.Translators -> Form.Form msg MainInformationFormInput MainInformationFormOutput
-mainInformationForm translators =
+mainInformationForm ({ t } as translators) =
     Form.succeed MainInformationFormOutput
         |> Form.with
             (Form.Text.init
-                { -- TODO - I18N
-                  label = "Name"
+                { label = t "shop.steps.main_information.name_label"
                 , id = "product-title-input"
                 }
                 |> Form.Text.withExtraAttrs [ maxlength 255 ]
-                -- TODO - I18N
-                |> Form.Text.withPlaceholder (translators.t "shop.what_label")
+                |> Form.Text.withPlaceholder (t "shop.steps.main_information.name_placeholder")
                 |> Form.textField
                     { parser =
                         Form.Validate.succeed
@@ -127,10 +125,9 @@ mainInformationForm translators =
             )
         |> Form.with
             (Form.RichText.init
-                { -- TODO - I18N
-                  label = "Description"
+                { label = t "shop.steps.main_information.description_label"
                 }
-                |> Form.RichText.withPlaceholder (translators.t "shop.description_placeholder")
+                |> Form.RichText.withPlaceholder (t "shop.steps.main_information.description_placeholder")
                 |> Form.richText
                     { parser =
                         Form.Validate.succeed
@@ -156,8 +153,7 @@ imagesForm translators =
     Form.succeed (List.filterMap identity)
         |> Form.withNoOutput
             (Form.arbitrary
-                -- TODO - I18N
-                (p [ class "mb-4" ] [ text "Set the product images (Only PNG or JPEG up to 10MB)" ])
+                (p [ class "mb-4" ] [ text <| translators.t "shop.steps.images.guidance" ])
             )
         |> Form.with
             (Form.introspect
@@ -227,8 +223,7 @@ priceAndInventoryForm translators isDisabled symbol =
     Form.succeed PriceAndInventoryFormOutput
         |> Form.withGroup [ class "grid grid-cols-2 gap-8" ]
             (Form.Text.init
-                { -- TODO - I18N
-                  label = "Price"
+                { label = translators.t "shop.steps.price_and_inventory.price_label"
                 , id = "product-price-input"
                 }
                 |> Form.Text.withCurrency symbol
@@ -264,8 +259,7 @@ stockTrackingForm translators { isDisabled } =
                 (\{ trackUnits } ->
                     if trackUnits then
                         Form.Text.init
-                            { -- TODO - I18N
-                              label = "Quantity in stock"
+                            { label = translators.t "shop.steps.price_and_inventory.quantity_label"
                             , id = "product-quantity-input"
                             }
                             |> Form.Text.withPlaceholder "0"
@@ -318,11 +312,8 @@ stockTrackingForm translators { isDisabled } =
             (Form.Toggle.init
                 { label =
                     div [ class "text-gray-333 text-base mb-4" ]
-                        [ -- TODO - I18N
-                          span [ class "font-bold" ] [ text "Inventory management" ]
-
-                        -- TODO - I18N
-                        , p [ class "mt-2" ] [ text "If you want to disable your offer when there are no more units in stock, enable this option" ]
+                        [ span [ class "font-bold" ] [ text <| translators.t "shop.steps.price_and_inventory.inventory_management" ]
+                        , p [ class "mt-2" ] [ text <| translators.t "shop.steps.price_and_inventory.inventory_management_description" ]
                         ]
                 , id = "product-track-units-toggle"
                 }
@@ -499,9 +490,7 @@ viewForm ({ shared } as loggedIn) { isEdit, isDisabled } formData =
                                     [ class "button button-secondary w-full"
                                     , Route.href (Route.Shop Shop.All)
                                     ]
-                                    [ -- TODO - I18N
-                                      text "Cancel"
-                                    ]
+                                    [ text <| t "menu.cancel" ]
                                 , submitButton
                                     [ class "button button-primary w-full"
                                     , disabled isDisabled
@@ -519,16 +508,15 @@ viewForm ({ shared } as loggedIn) { isEdit, isDisabled } formData =
                 }
 
         ( stepNumber, stepName ) =
-            -- TODO - I18N
             case formData.currentStep of
                 MainInformation ->
-                    ( 1, "Main information" )
+                    ( 1, t "shop.steps.main_information.title" )
 
                 Images _ ->
-                    ( 2, "Images" )
+                    ( 2, t "shop.steps.images.title" )
 
                 PriceAndInventory _ _ ->
-                    ( 3, "Price and Inventory" )
+                    ( 3, t "shop.steps.price_and_inventory.title" )
     in
     div [ class "flex flex-col flex-grow" ]
         [ Page.viewHeader loggedIn pageTitle
@@ -544,16 +532,14 @@ viewForm ({ shared } as loggedIn) { isEdit, isDisabled } formData =
                     MainInformation ->
                         viewForm_ (mainInformationForm shared.translators)
                             formData.mainInformation
-                            -- TODO - I18N
-                            "Continue"
+                            (t "shop.steps.continue")
                             MainInformationMsg
                             SubmittedMainInformation
 
                     Images _ ->
                         viewForm_ (imagesForm shared.translators)
                             formData.images
-                            -- TODO - I18N
-                            "Continue"
+                            (t "shop.steps.continue")
                             ImagesMsg
                             SubmittedImages
 

--- a/src/elm/Page/Shop/Editor.elm
+++ b/src/elm/Page/Shop/Editor.elm
@@ -176,27 +176,44 @@ imagesForm translators =
                 (\images ->
                     List.indexedMap
                         (\index image ->
-                            -- TODO - Add option to remove image
-                            Form.File.init
-                                { label = ""
-                                , id = "product-image-input-" ++ String.fromInt index
-                                }
-                                |> Form.File.withAttrs
-                                    [ class "w-24 h-24 rounded bg-gray-100 flex items-center justify-center"
-                                    ]
-                                |> Form.File.withVariant Form.File.SimplePlus
-                                |> Form.File.withContainerAttrs [ classList [ ( "animate-bounce-in", Form.File.isEmpty image ) ] ]
-                                |> Form.file
-                                    { translators = translators
-                                    , value = \_ -> image
-                                    , update = \newImage _ -> newImage
-                                    , externalError = always Nothing
-                                    }
-                                |> Form.mapValues
-                                    { value = \_ -> image
-                                    , update = \newImage -> List.Extra.setAt index newImage
-                                    }
-                                |> Form.optional
+                            Form.succeed (\imageOutput _ -> imageOutput)
+                                |> Form.withGroup [ class "relative" ]
+                                    (Form.File.init
+                                        { label = ""
+                                        , id = "product-image-input-" ++ String.fromInt index
+                                        }
+                                        |> Form.File.withAttrs
+                                            [ class "w-24 h-24 rounded bg-gray-100 flex items-center justify-center"
+                                            ]
+                                        |> Form.File.withVariant Form.File.SimplePlus
+                                        |> Form.File.withContainerAttrs [ classList [ ( "animate-bounce-in", Form.File.isEmpty image ) ] ]
+                                        |> Form.file
+                                            { translators = translators
+                                            , value = \_ -> image
+                                            , update = \newImage _ -> newImage
+                                            , externalError = always Nothing
+                                            }
+                                        |> Form.mapValues
+                                            { value = \_ -> image
+                                            , update = \newImage -> List.Extra.setAt index newImage
+                                            }
+                                        |> Form.optional
+                                    )
+                                    (Form.arbitraryWith ()
+                                        (div
+                                            [ class "absolute top-0 right-0"
+                                            , classList [ ( "hidden", Form.File.isEmpty image ) ]
+                                            ]
+                                            [ button
+                                                [ class "bg-white rounded-full -translate-y-1/2 ml-1/2"
+                                                , onClick (\values -> values |> List.Extra.removeAt index)
+                                                , type_ "button"
+                                                ]
+                                                [ Icons.circularClose "w-6 h-6"
+                                                ]
+                                            ]
+                                        )
+                                    )
                         )
                         images
                         |> Form.list [ class "flex flex-wrap gap-x-6 gap-y-4" ]

--- a/src/elm/Page/Shop/Editor.elm
+++ b/src/elm/Page/Shop/Editor.elm
@@ -466,7 +466,7 @@ viewForm :
     -> Html Msg
 viewForm ({ shared } as loggedIn) { isEdit, isDisabled } formData =
     let
-        { t } =
+        { t, tr } =
             shared.translators
 
         ( actionText, pageTitle ) =
@@ -524,7 +524,12 @@ viewForm ({ shared } as loggedIn) { isEdit, isDisabled } formData =
             [ div [ class "bg-white pt-4 pb-8 flex-grow flex flex-col min-h-150 lg:w-2/3 lg:mx-auto lg:rounded lg:shadow-lg lg:animate-fade-in-from-above-lg lg:motion-reduce:animate-none" ]
                 [ div [ class "container mx-auto px-4 lg:max-w-none lg:mx-0 lg:px-6" ]
                     [ h2 [ class "font-bold text-black mb-2" ]
-                        [ text ("Step " ++ String.fromInt stepNumber ++ " of 3") ]
+                        [ text <|
+                            tr "shop.steps.index"
+                                [ ( "current", String.fromInt stepNumber )
+                                , ( "total", String.fromInt 3 )
+                                ]
+                        ]
                     , text stepName
                     ]
                 , hr [ class "mt-4 mb-6 border-gray-500 lg:mx-4 lg:mb-10" ] []

--- a/src/elm/Page/Shop/Editor.elm
+++ b/src/elm/Page/Shop/Editor.elm
@@ -527,13 +527,75 @@ viewForm ({ shared } as loggedIn) { isEdit, isDisabled } formData =
 
                 PriceAndInventory _ _ ->
                     ( 3, t "shop.steps.price_and_inventory.title" )
+
+        isStepCompleted : Route.EditSaleStep -> Bool
+        isStepCompleted step =
+            case ( step, formData.currentStep ) of
+                ( Route.SaleMainInformation, Images _ ) ->
+                    True
+
+                ( Route.SaleMainInformation, PriceAndInventory _ _ ) ->
+                    True
+
+                ( Route.SaleImages, PriceAndInventory _ _ ) ->
+                    True
+
+                _ ->
+                    False
+
+        stepBall : Route.EditSaleStep -> Html msg
+        stepBall step =
+            let
+                isCurrent =
+                    case formData.currentStep of
+                        MainInformation ->
+                            step == Route.SaleMainInformation
+
+                        Images _ ->
+                            step == Route.SaleImages
+
+                        PriceAndInventory _ _ ->
+                            step == Route.SalePriceAndInventory
+            in
+            div
+                [ class "w-6 h-6 rounded-full bg-gray-900 flex-shrink-0 flex items-center justify-center transition-colors"
+                , classList
+                    [ ( "bg-orange-300 delay-150", isStepCompleted step || isCurrent )
+                    ]
+                ]
+                [ div
+                    [ class "transition-opacity"
+                    , classList [ ( "opacity-0", not (isStepCompleted step) ) ]
+                    ]
+                    [ Icons.checkmark ""
+                    ]
+                ]
+
+        stepLine step =
+            div [ class "w-full h-px bg-gray-900 relative" ]
+                [ div
+                    [ class "bg-orange-300 w-full absolute left-0 top-0 bottom-0 transition-transform ease-out origin-left"
+                    , classList
+                        [ ( "scale-x-0 delay-150", not (isStepCompleted step) )
+                        , ( "scale-x-100", isStepCompleted step )
+                        ]
+                    ]
+                    []
+                ]
     in
     div [ class "flex flex-col flex-grow" ]
         [ Page.viewHeader loggedIn pageTitle
         , div [ class "lg:container lg:mx-auto lg:px-4 lg:mt-6 lg:mb-20" ]
             [ div [ class "bg-white pt-4 pb-8 flex-grow flex flex-col min-h-150 lg:w-2/3 lg:mx-auto lg:rounded lg:shadow-lg lg:animate-fade-in-from-above-lg lg:motion-reduce:animate-none" ]
                 [ div [ class "container mx-auto px-4 lg:max-w-none lg:mx-0 lg:px-6" ]
-                    [ h2 [ class "font-bold text-black mb-2" ]
+                    [ div [ class "mb-4 flex items-center" ]
+                        [ stepBall Route.SaleMainInformation
+                        , stepLine Route.SaleMainInformation
+                        , stepBall Route.SaleImages
+                        , stepLine Route.SaleImages
+                        , stepBall Route.SalePriceAndInventory
+                        ]
+                    , h2 [ class "font-bold text-black mb-2" ]
                         [ text <|
                             tr "shop.steps.index"
                                 [ ( "current", String.fromInt stepNumber )

--- a/src/elm/Page/Shop/Editor.elm
+++ b/src/elm/Page/Shop/Editor.elm
@@ -740,6 +740,23 @@ update msg model loggedIn =
             in
             UR.init model
                 |> UR.addCmd (Route.replaceUrl loggedIn.shared.navKey redirectUrl)
+                |> UR.addExt
+                    (LoggedIn.DropFromRouteHistoryWhile
+                        (\route ->
+                            case route of
+                                Route.NewSale _ ->
+                                    True
+
+                                Route.EditSale _ _ ->
+                                    True
+
+                                Route.ViewSale _ ->
+                                    True
+
+                                _ ->
+                                    False
+                        )
+                    )
                 |> UR.addExt (ShowFeedback Feedback.Success (t "shop.create_offer_success"))
 
         GotSaveResponse (RemoteData.Failure error) ->

--- a/src/elm/Page/Shop/Viewer.elm
+++ b/src/elm/Page/Shop/Viewer.elm
@@ -612,6 +612,7 @@ view session model =
 
                             firstImage :: otherImages ->
                                 Shop.viewImageCarrousel
+                                    translators
                                     { containerAttrs = [ class "h-68" ]
                                     , listAttrs = [ class "gap-x-4 rounded" ]
                                     , imageContainerAttrs = [ class "bg-gray-100 rounded" ]

--- a/src/elm/Page/Shop/Viewer.elm
+++ b/src/elm/Page/Shop/Viewer.elm
@@ -23,8 +23,8 @@ import Form.RichText
 import Form.Text
 import Form.Validate
 import Graphql.Http
-import Html exposing (Html, a, button, div, h2, h3, img, span, text)
-import Html.Attributes exposing (alt, autocomplete, class, classList, disabled, href, src, type_)
+import Html exposing (Html, a, button, div, h2, h3, span, text)
+import Html.Attributes exposing (autocomplete, class, classList, disabled, href, type_)
 import Html.Attributes.Aria exposing (ariaHidden, ariaLabel)
 import Html.Events exposing (onClick)
 import Http

--- a/src/elm/Page/Shop/Viewer.elm
+++ b/src/elm/Page/Shop/Viewer.elm
@@ -987,7 +987,7 @@ viewEditSaleModal { t } model product =
             [ div [ class "flex flex-col divide-y divide-gray-500 mt-1" ]
                 [ a
                     [ class "py-4 flex items-center hover:opacity-70 focus-ring rounded-sm"
-                    , Route.href (Route.EditSale product.id)
+                    , Route.href (Route.EditSale product.id Route.SaleMainInformation)
                     ]
                     -- TODO - I18N
                     [ text "Main information"
@@ -995,7 +995,7 @@ viewEditSaleModal { t } model product =
                     ]
                 , a
                     [ class "py-4 flex items-center hover:opacity-70 focus-ring rounded-sm"
-                    , Route.href (Route.EditSale product.id)
+                    , Route.href (Route.EditSale product.id Route.SaleImages)
                     ]
                     -- TODO - I18N
                     [ text "Images"
@@ -1003,7 +1003,7 @@ viewEditSaleModal { t } model product =
                     ]
                 , a
                     [ class "py-4 flex items-center hover:opacity-70 focus-ring rounded-sm"
-                    , Route.href (Route.EditSale product.id)
+                    , Route.href (Route.EditSale product.id Route.SalePriceAndInventory)
                     ]
                     -- TODO - I18N
                     [ text "Price and Inventory"

--- a/src/elm/Page/Shop/Viewer.elm
+++ b/src/elm/Page/Shop/Viewer.elm
@@ -503,8 +503,7 @@ updateAsLoggedIn msg model loggedIn =
                     { moduleName = "Page.Shop.Viewer", function = "updateAsLoggedIn" }
                     []
                     err
-                -- TODO - I18N
-                |> UR.addExt (LoggedIn.ShowFeedback Feedback.Failure "Something went wrong when deleting your offer")
+                |> UR.addExt (LoggedIn.ShowFeedback Feedback.Failure (t "shop.delete_offer_failure"))
 
         CompletedDeleteProduct _ ->
             UR.init model
@@ -1002,32 +1001,28 @@ viewEditSaleModal { t } model product =
         { closeMsg = ClosedEditSaleModal
         , isVisible = model.isEditModalVisible
         }
-        -- TODO - I18N
-        |> View.Modal.withHeader "Edit offer"
+        |> View.Modal.withHeader (t "shop.edit_offer")
         |> View.Modal.withBody
             [ div [ class "flex flex-col divide-y divide-gray-500 mt-1" ]
                 [ a
                     [ class "py-4 flex items-center hover:opacity-70 focus-ring rounded-sm"
                     , Route.href (Route.EditSale product.id Route.SaleMainInformation)
                     ]
-                    -- TODO - I18N
-                    [ text "Main information"
+                    [ text <| t "shop.steps.main_information.title"
                     , Icons.arrowDown "-rotate-90 ml-auto"
                     ]
                 , a
                     [ class "py-4 flex items-center hover:opacity-70 focus-ring rounded-sm"
                     , Route.href (Route.EditSale product.id Route.SaleImages)
                     ]
-                    -- TODO - I18N
-                    [ text "Images"
+                    [ text <| t "shop.steps.images.title"
                     , Icons.arrowDown "-rotate-90 ml-auto"
                     ]
                 , a
                     [ class "py-4 flex items-center hover:opacity-70 focus-ring rounded-sm"
                     , Route.href (Route.EditSale product.id Route.SalePriceAndInventory)
                     ]
-                    -- TODO - I18N
-                    [ text "Price and Inventory"
+                    [ text <| t "shop.steps.price_and_inventory.title"
                     , Icons.arrowDown "-rotate-90 ml-auto"
                     ]
                 , button

--- a/src/elm/Page/Shop/Viewer.elm
+++ b/src/elm/Page/Shop/Viewer.elm
@@ -44,6 +44,7 @@ import Session.LoggedIn as LoggedIn
 import Session.Shared as Shared
 import Shop exposing (Product, ProductPreview)
 import Transfer
+import Translation
 import UpdateResult as UR
 import View.Feedback as Feedback
 import View.Modal
@@ -454,6 +455,7 @@ updateAsLoggedIn msg model loggedIn =
         ClickedDelete ->
             case model.status of
                 -- TODO - Mark as deleting so other buttons are disabled?
+                -- TODO - Show a confirmation modal?
                 RemoteData.Success sale ->
                     model
                         |> UR.init
@@ -470,8 +472,7 @@ updateAsLoggedIn msg model loggedIn =
         CompletedDeleteProduct (RemoteData.Success _) ->
             model
                 |> UR.init
-                -- TODO - I18N
-                |> UR.addExt (LoggedIn.ShowFeedback Feedback.Success "Offer deleted with success")
+                |> UR.addExt (LoggedIn.ShowFeedback Feedback.Success (t "shop.delete_offer_success"))
                 |> UR.addCmd (Route.pushUrl loggedIn.shared.navKey (Route.Shop Shop.All))
 
         CompletedDeleteProduct (RemoteData.Failure err) ->
@@ -750,7 +751,7 @@ view session model =
                                                 }
                                                 |> Html.map AsLoggedInMsg
                                             )
-                                        , viewEditSaleModal model_ sale
+                                        , viewEditSaleModal translators model_ sale
                                             |> Html.map AsLoggedInMsg
                                         ]
 
@@ -974,8 +975,8 @@ createForm ({ t, tr } as translators) product maybeBalance { isDisabled } toForm
             )
 
 
-viewEditSaleModal : LoggedInModel -> Product -> Html LoggedInMsg
-viewEditSaleModal model product =
+viewEditSaleModal : Translation.Translators -> LoggedInModel -> Product -> Html LoggedInMsg
+viewEditSaleModal { t } model product =
     View.Modal.initWith
         { closeMsg = ClosedEditSaleModal
         , isVisible = model.isEditModalVisible
@@ -1009,12 +1010,10 @@ viewEditSaleModal model product =
                     , Icons.arrowDown "-rotate-90 ml-auto"
                     ]
                 , button
-                    -- TODO - Add onClick
                     [ class "text-red py-4 flex items-center hover:opacity-60 focus-ring rounded-sm"
                     , onClick ClickedDelete
                     ]
-                    -- TODO - I18N
-                    [ text "Delete"
+                    [ text <| t "shop.delete"
                     , Icons.arrowDown "-rotate-90 ml-auto"
                     ]
                 ]

--- a/src/elm/Page/Shop/Viewer.elm
+++ b/src/elm/Page/Shop/Viewer.elm
@@ -539,7 +539,12 @@ view session model =
                                     ]
 
                             firstImage :: otherImages ->
-                                Shop.viewImageCarrousel [ class "h-68" ]
+                                Shop.viewImageCarrousel
+                                    { containerAttrs = [ class "h-68" ]
+                                    , listAttrs = [ class "gap-x-4 rounded" ]
+                                    , imageContainerAttrs = [ class "bg-gray-100 rounded" ]
+                                    , imageAttrs = []
+                                    }
                                     { showArrows = True
                                     , productId = Nothing
                                     , onScrollToImage = ClickedScrollToImage

--- a/src/elm/Page/Shop/Viewer.elm
+++ b/src/elm/Page/Shop/Viewer.elm
@@ -541,6 +541,7 @@ view session model =
                             firstImage :: otherImages ->
                                 Shop.viewImageCarrousel [ class "h-68" ]
                                     { showArrows = True
+                                    , productId = Nothing
                                     , onScrollToImage = ClickedScrollToImage
                                     , currentIntersecting = model.currentVisibleImage
                                     , onStartedIntersecting = ImageStartedIntersecting

--- a/src/elm/Page/Shop/Viewer.elm
+++ b/src/elm/Page/Shop/Viewer.elm
@@ -616,6 +616,7 @@ view session model =
                                     { containerAttrs = [ class "h-68" ]
                                     , listAttrs = [ class "gap-x-4 rounded" ]
                                     , imageContainerAttrs = [ class "bg-gray-100 rounded" ]
+                                    , imageOverlayAttrs = [ class "rounded-b" ]
                                     , imageAttrs = []
                                     }
                                     { showArrows = True

--- a/src/elm/Page/Shop/Viewer.elm
+++ b/src/elm/Page/Shop/Viewer.elm
@@ -441,7 +441,7 @@ view session model =
 
         viewContent :
             { product
-                | image : Maybe String
+                | images : List String
                 , title : String
                 , description : Markdown
                 , creator : Profile.Minimal
@@ -470,7 +470,8 @@ view session model =
                 [ div [ class "absolute bg-white top-0 bottom-0 left-0 right-1/2 hidden md:block" ] []
                 , div [ class "container mx-auto px-4 my-4 md:my-10 md:isolate grid md:grid-cols-2" ]
                     [ div [ class "mb-6 md:mb-0 md:w-2/3 md:mx-auto" ]
-                        [ viewProductImg translators sale.image
+                        -- TODO - We only show one image
+                        [ viewProductImg translators (List.head sale.images)
                         , h2 [ class "font-bold text-lg text-black mt-4", ariaHidden True ] [ text sale.title ]
                         , Markdown.view [ class "mt-2 mb-6 text-gray-333" ] sale.description
                         , if isCreator then

--- a/src/elm/Search.elm
+++ b/src/elm/Search.elm
@@ -605,11 +605,9 @@ viewOffers translators symbol offers =
         viewOffer offer =
             let
                 imageUrl =
-                    case offer.image of
+                    -- TODO - We only show one image
+                    case List.head offer.images of
                         Nothing ->
-                            "/icons/shop-placeholder1.svg"
-
-                        Just "" ->
                             "/icons/shop-placeholder1.svg"
 
                         Just url ->

--- a/src/elm/Search.elm
+++ b/src/elm/Search.elm
@@ -715,6 +715,7 @@ viewOffers translators symbol offers =
 
                         firstImage :: otherImages ->
                             Shop.viewImageCarrousel
+                                translators
                                 { containerAttrs = [ class "h-32" ]
                                 , listAttrs = [ class "gap-x-4 rounded-t bg-gray-100" ]
                                 , imageContainerAttrs = [ class "bg-white rounded-t" ]

--- a/src/elm/Search.elm
+++ b/src/elm/Search.elm
@@ -719,6 +719,7 @@ viewOffers translators symbol offers =
                                 { containerAttrs = [ class "h-32" ]
                                 , listAttrs = [ class "gap-x-4 rounded-t bg-gray-100" ]
                                 , imageContainerAttrs = [ class "bg-white rounded-t" ]
+                                , imageOverlayAttrs = []
                                 , imageAttrs = [ class "w-full h-full" ]
                                 }
                                 { showArrows = False

--- a/src/elm/Session/LoggedIn.elm
+++ b/src/elm/Session/LoggedIn.elm
@@ -1308,6 +1308,7 @@ codeOfConductUrl language =
 -}
 type External msg
     = UpdatedLoggedIn Model
+    | DropFromRouteHistoryWhile (Route -> Bool)
     | SetUpdateTimeEvery Float
     | ShowInsufficientPermissionsModal
     | AddedCommunity Profile.CommunityInfo
@@ -1679,6 +1680,9 @@ mapExternal mapFn msg =
         UpdatedLoggedIn model ->
             UpdatedLoggedIn model
 
+        DropFromRouteHistoryWhile dropFn ->
+            DropFromRouteHistoryWhile dropFn
+
         SetUpdateTimeEvery n ->
             SetUpdateTimeEvery n
 
@@ -1765,6 +1769,9 @@ updateExternal externalMsg ({ shared } as model) =
     case externalMsg of
         UpdatedLoggedIn newModel ->
             { defaultResult | model = newModel }
+
+        DropFromRouteHistoryWhile dropFn ->
+            { defaultResult | model = { model | routeHistory = List.dropWhile dropFn model.routeHistory } }
 
         SetUpdateTimeEvery n ->
             { defaultResult | model = { model | updateTimeEvery = n } }
@@ -3408,6 +3415,9 @@ externalMsgToString externalMsg =
     case externalMsg of
         UpdatedLoggedIn _ ->
             [ "UpdatedLoggedIn" ]
+
+        DropFromRouteHistoryWhile _ ->
+            [ "PopFromRouteHistory" ]
 
         SetUpdateTimeEvery _ ->
             [ "SetUpdateTimeEvery" ]

--- a/src/elm/Shop.elm
+++ b/src/elm/Shop.elm
@@ -549,7 +549,7 @@ viewImageCarrousel { containerAttrs, listAttrs, imageContainerAttrs, imageAttrs 
             text ""
 
           else
-            div [ class "bg-gradient-to-t from-black/40 to-transparent absolute bottom-0 left-0 right-0 h-10" ] []
+            div [ class "bg-gradient-to-t rounded-b from-black/40 to-transparent absolute bottom-0 left-0 right-0 h-10" ] []
         , View.Components.intersectionObserver
             { targetSelectors =
                 List.indexedMap (\index _ -> "#" ++ imageId index) imageUrls

--- a/src/elm/Shop.elm
+++ b/src/elm/Shop.elm
@@ -403,6 +403,7 @@ viewImageCarrousel :
         { containerAttrs : List (Html.Attribute msg)
         , listAttrs : List (Html.Attribute msg)
         , imageContainerAttrs : List (Html.Attribute msg)
+        , imageOverlayAttrs : List (Html.Attribute msg)
         , imageAttrs : List (Html.Attribute msg)
         }
     ->
@@ -415,7 +416,7 @@ viewImageCarrousel :
         }
     -> ( String, List String )
     -> Html msg
-viewImageCarrousel { t, tr } { containerAttrs, listAttrs, imageContainerAttrs, imageAttrs } options ( firstImage, otherImages ) =
+viewImageCarrousel { t, tr } { containerAttrs, listAttrs, imageContainerAttrs, imageOverlayAttrs, imageAttrs } options ( firstImage, otherImages ) =
     let
         maybeProductId =
             Maybe.map (\(Id opaqueId) -> opaqueId) options.productId
@@ -553,7 +554,11 @@ viewImageCarrousel { t, tr } { containerAttrs, listAttrs, imageContainerAttrs, i
             text ""
 
           else
-            div [ class "bg-gradient-to-t rounded-b from-black/40 to-transparent absolute bottom-0 left-0 right-0 h-10" ] []
+            div
+                (class "bg-gradient-to-t from-black/40 to-transparent absolute bottom-0 left-0 right-0 h-10"
+                    :: imageOverlayAttrs
+                )
+                []
         , View.Components.intersectionObserver
             { targetSelectors =
                 List.indexedMap (\index _ -> "#" ++ imageId index) imageUrls

--- a/src/elm/Shop.elm
+++ b/src/elm/Shop.elm
@@ -438,7 +438,6 @@ viewImageCarrousel extraAttrs options ( firstImage, otherImages ) =
             options.currentIntersecting
                 |> Maybe.andThen indexFromImageId
     in
-    -- TODO - Treat case where there is only one image
     div (class "relative" :: extraAttrs)
         [ case maybeCurrentIntersectingIndex of
             Nothing ->
@@ -497,22 +496,26 @@ viewImageCarrousel extraAttrs options ( firstImage, otherImages ) =
                         ]
                         [ Icons.arrowDown "-rotate-90" ]
                     ]
-        , div [ class "absolute bottom-4 left-1/2 -translate-x-1/2 flex items-center gap-2" ]
-            (List.indexedMap
-                (\index _ ->
-                    -- TODO - Probably need aria
-                    button
-                        [ class "border-2 w-2 h-2 rounded-full transition-colors"
-                        , classList
-                            [ ( "bg-white border-orange-500", isCurrentIntersecting index )
-                            , ( "bg-white/80 border-white/80", not (isCurrentIntersecting index) )
+        , if List.length imageUrls == 1 then
+            text ""
+
+          else
+            div [ class "absolute bottom-4 left-1/2 -translate-x-1/2 flex items-center gap-2" ]
+                (List.indexedMap
+                    (\index _ ->
+                        -- TODO - Probably need aria
+                        button
+                            [ class "border-2 w-2 h-2 rounded-full transition-colors"
+                            , classList
+                                [ ( "bg-white border-orange-500", isCurrentIntersecting index )
+                                , ( "bg-white/80 border-white/80", not (isCurrentIntersecting index) )
+                                ]
+                            , onClick (clickedScrollToImage index)
                             ]
-                        , onClick (clickedScrollToImage index)
-                        ]
-                        []
+                            []
+                    )
+                    imageUrls
                 )
-                imageUrls
-            )
         , View.Components.intersectionObserver
             { targetSelectors =
                 List.indexedMap (\index _ -> "#" ++ imageId index) imageUrls

--- a/src/elm/Shop.elm
+++ b/src/elm/Shop.elm
@@ -36,11 +36,13 @@ import Graphql.OptionalArgument exposing (OptionalArgument(..))
 import Graphql.SelectionSet as SelectionSet exposing (SelectionSet, with)
 import Html exposing (Html, button, div, img, text, ul)
 import Html.Attributes exposing (alt, class, classList, id, src)
+import Html.Attributes.Aria exposing (ariaHidden, ariaLabel)
 import Html.Events exposing (onClick)
 import Icons
 import Json.Encode as Encode exposing (Value)
 import Markdown exposing (Markdown)
 import Profile
+import Translation
 import Url.Parser
 import Utils exposing (onClickPreventAll)
 import View.Components
@@ -396,11 +398,13 @@ type ImageId
 {-| This does not treat the case where there are no images. Treat it accordingly!
 -}
 viewImageCarrousel :
-    { containerAttrs : List (Html.Attribute msg)
-    , listAttrs : List (Html.Attribute msg)
-    , imageContainerAttrs : List (Html.Attribute msg)
-    , imageAttrs : List (Html.Attribute msg)
-    }
+    Translation.Translators
+    ->
+        { containerAttrs : List (Html.Attribute msg)
+        , listAttrs : List (Html.Attribute msg)
+        , imageContainerAttrs : List (Html.Attribute msg)
+        , imageAttrs : List (Html.Attribute msg)
+        }
     ->
         { showArrows : Bool
         , productId : Maybe Id
@@ -411,7 +415,7 @@ viewImageCarrousel :
         }
     -> ( String, List String )
     -> Html msg
-viewImageCarrousel { containerAttrs, listAttrs, imageContainerAttrs, imageAttrs } options ( firstImage, otherImages ) =
+viewImageCarrousel { t, tr } { containerAttrs, listAttrs, imageContainerAttrs, imageAttrs } options ( firstImage, otherImages ) =
     let
         maybeProductId =
             Maybe.map (\(Id opaqueId) -> opaqueId) options.productId
@@ -477,9 +481,9 @@ viewImageCarrousel { containerAttrs, listAttrs, imageContainerAttrs, imageAttrs 
                             [ ( "hidden", not options.showArrows )
                             , ( "opacity-0 scale-50 pointer-events-none", currentIntersectingIndex == 0 )
                             ]
-
-                        -- TODO - Probably need aria
                         , onClick (clickedScrollToImage (currentIntersectingIndex - 1))
+                        , ariaLabel <| t "shop.carrousel.previous"
+                        , ariaHidden (currentIntersectingIndex == 0)
                         ]
                         [ Icons.arrowDown "rotate-90"
                         ]
@@ -519,9 +523,9 @@ viewImageCarrousel { containerAttrs, listAttrs, imageContainerAttrs, imageAttrs 
                             [ ( "hidden", not options.showArrows )
                             , ( "opacity-0 scale-50 pointer-events-none", currentIntersectingIndex == List.length imageUrls - 1 )
                             ]
-
-                        -- TODO - Probably need aria
                         , onClick (clickedScrollToImage (currentIntersectingIndex + 1))
+                        , ariaLabel <| t "shop.carrousel.next"
+                        , ariaHidden (currentIntersectingIndex == List.length imageUrls - 1)
                         ]
                         [ Icons.arrowDown "-rotate-90" ]
                     ]
@@ -532,7 +536,6 @@ viewImageCarrousel { containerAttrs, listAttrs, imageContainerAttrs, imageAttrs 
             div [ class "absolute bottom-4 left-1/2 -translate-x-1/2 flex items-center gap-2 z-10" ]
                 (List.indexedMap
                     (\index _ ->
-                        -- TODO - Probably need aria
                         button
                             [ class "border-2 w-2 h-2 rounded-full transition-colors"
                             , classList
@@ -540,6 +543,7 @@ viewImageCarrousel { containerAttrs, listAttrs, imageContainerAttrs, imageAttrs 
                                 , ( "bg-white border-white", not (isCurrentIntersecting index) )
                                 ]
                             , onClickPreventAll (clickedScrollToImage index)
+                            , ariaLabel <| tr "shop.carrousel.index" [ ( "index", String.fromInt (index + 1) ) ]
                             ]
                             []
                     )

--- a/src/elm/Shop.elm
+++ b/src/elm/Shop.elm
@@ -396,7 +396,11 @@ type ImageId
 {-| This does not treat the case where there are no images. Treat it accordingly!
 -}
 viewImageCarrousel :
-    List (Html.Attribute msg)
+    { containerAttrs : List (Html.Attribute msg)
+    , listAttrs : List (Html.Attribute msg)
+    , imageContainerAttrs : List (Html.Attribute msg)
+    , imageAttrs : List (Html.Attribute msg)
+    }
     ->
         { showArrows : Bool
         , productId : Maybe Id
@@ -407,7 +411,7 @@ viewImageCarrousel :
         }
     -> ( String, List String )
     -> Html msg
-viewImageCarrousel extraAttrs options ( firstImage, otherImages ) =
+viewImageCarrousel { containerAttrs, listAttrs, imageContainerAttrs, imageAttrs } options ( firstImage, otherImages ) =
     let
         maybeProductId =
             Maybe.map (\(Id opaqueId) -> opaqueId) options.productId
@@ -459,7 +463,7 @@ viewImageCarrousel extraAttrs options ( firstImage, otherImages ) =
             options.currentIntersecting
                 |> Maybe.andThen indexFromImageId
     in
-    div (class "relative" :: extraAttrs)
+    div (class "relative" :: containerAttrs)
         [ case maybeCurrentIntersectingIndex of
             Nothing ->
                 text ""
@@ -480,20 +484,23 @@ viewImageCarrousel extraAttrs options ( firstImage, otherImages ) =
                         ]
                     ]
         , ul
-            [ class "flex h-full min-w-full overflow-x-scroll overflow-y-hidden snap-x scrollbar-hidden gap-x-4 rounded"
-            , id containerId
-            ]
+            (class "flex h-full min-w-full overflow-x-scroll overflow-y-hidden snap-x scrollbar-hidden"
+                :: id containerId
+                :: listAttrs
+            )
             (List.indexedMap
                 (\index image ->
                     div
-                        [ class "bg-gray-100 w-full h-full flex-shrink-0 snap-center snap-always grid place-items-center rounded"
-                        , id (imageId index)
-                        ]
+                        (class "w-full h-full flex-shrink-0 snap-center snap-always grid place-items-center"
+                            :: id (imageId index)
+                            :: imageContainerAttrs
+                        )
                         [ img
-                            [ src image
-                            , alt ""
-                            , class "object-cover object-center max-w-full max-h-full"
-                            ]
+                            (src image
+                                :: alt ""
+                                :: class "object-cover object-center max-w-full max-h-full"
+                                :: imageAttrs
+                            )
                             []
                         ]
                 )

--- a/src/elm/Shop.elm
+++ b/src/elm/Shop.elm
@@ -517,9 +517,7 @@ viewImageCarrousel extraAttrs options ( firstImage, otherImages ) =
             { targetSelectors =
                 List.indexedMap (\index _ -> "#" ++ imageId index) imageUrls
             , threshold = 0.01
-
-            -- TODO - We don't want to exclude any breakpoints here!
-            , breakpointToExclude = View.Components.Xl
+            , breakpointToExclude = Nothing
             , onStartedIntersecting = Just (ImageId >> options.onStartedIntersecting)
             , onStoppedIntersecting = Just (ImageId >> options.onStoppedIntersecting)
             }

--- a/src/elm/Shop.elm
+++ b/src/elm/Shop.elm
@@ -529,7 +529,7 @@ viewImageCarrousel { containerAttrs, listAttrs, imageContainerAttrs, imageAttrs 
             text ""
 
           else
-            div [ class "absolute bottom-4 left-1/2 -translate-x-1/2 flex items-center gap-2" ]
+            div [ class "absolute bottom-4 left-1/2 -translate-x-1/2 flex items-center gap-2 z-10" ]
                 (List.indexedMap
                     (\index _ ->
                         -- TODO - Probably need aria
@@ -537,7 +537,7 @@ viewImageCarrousel { containerAttrs, listAttrs, imageContainerAttrs, imageAttrs 
                             [ class "border-2 w-2 h-2 rounded-full transition-colors"
                             , classList
                                 [ ( "bg-white border-orange-500", isCurrentIntersecting index )
-                                , ( "bg-white/80 border-gray-400", not (isCurrentIntersecting index) )
+                                , ( "bg-white border-white", not (isCurrentIntersecting index) )
                                 ]
                             , onClickPreventAll (clickedScrollToImage index)
                             ]
@@ -545,6 +545,11 @@ viewImageCarrousel { containerAttrs, listAttrs, imageContainerAttrs, imageAttrs 
                     )
                     imageUrls
                 )
+        , if List.length imageUrls == 1 then
+            text ""
+
+          else
+            div [ class "bg-gradient-to-t from-black/40 to-transparent absolute bottom-0 left-0 right-0 h-10" ] []
         , View.Components.intersectionObserver
             { targetSelectors =
                 List.indexedMap (\index _ -> "#" ++ imageId index) imageUrls

--- a/src/elm/Shop.elm
+++ b/src/elm/Shop.elm
@@ -49,7 +49,7 @@ type alias Product =
     , creatorId : Eos.Name
     , price : Float
     , symbol : Symbol
-    , image : Maybe String
+    , images : List String
     , stockTracking : StockTracking
     , creator : Profile.Minimal
     }
@@ -94,7 +94,7 @@ type alias ProductPreview =
     , creator : Profile.Minimal
     , description : Markdown
     , id : Id
-    , image : Maybe String
+    , images : List String
     , price : Float
     , title : String
     }
@@ -143,10 +143,9 @@ productSelectionSet =
             , creatorId = creatorId
             , price = price
             , symbol = symbol
-            , image =
+            , images =
                 images
                     |> List.filter (not << String.isEmpty)
-                    |> List.head
             , stockTracking =
                 if trackStock then
                     case maybeUnits of
@@ -181,10 +180,9 @@ productPreviewSelectionSet =
             , creator = creator
             , description = description
             , id = id
-            , image =
+            , images =
                 images
                     |> List.filter (not << String.isEmpty)
-                    |> List.head
             , price = price
             , title = title
             }

--- a/src/elm/Shop.elm
+++ b/src/elm/Shop.elm
@@ -438,7 +438,8 @@ viewImageCarrousel { containerAttrs, listAttrs, imageContainerAttrs, imageAttrs 
         indexFromImageId (ImageId imgId) =
             case maybeProductId of
                 Nothing ->
-                    String.dropLeft (String.length "product-image-") imgId
+                    -- 14 == String.length "product-image-"
+                    String.dropLeft 14 imgId
                         |> String.toInt
 
                 Just productId ->

--- a/src/elm/Shop.elm
+++ b/src/elm/Shop.elm
@@ -42,6 +42,7 @@ import Json.Encode as Encode exposing (Value)
 import Markdown exposing (Markdown)
 import Profile
 import Url.Parser
+import Utils exposing (onClickPreventAll)
 import View.Components
 
 
@@ -398,6 +399,7 @@ viewImageCarrousel :
     List (Html.Attribute msg)
     ->
         { showArrows : Bool
+        , productId : Maybe Id
         , onScrollToImage : { containerId : String, imageId : String } -> msg
         , currentIntersecting : Maybe ImageId
         , onStartedIntersecting : ImageId -> msg
@@ -407,18 +409,37 @@ viewImageCarrousel :
     -> Html msg
 viewImageCarrousel extraAttrs options ( firstImage, otherImages ) =
     let
+        maybeProductId =
+            Maybe.map (\(Id opaqueId) -> opaqueId) options.productId
+
         imageUrls =
             firstImage :: otherImages
 
         containerId =
-            "image-carrousel"
+            case maybeProductId of
+                Nothing ->
+                    "image-carrousel"
+
+                Just productId ->
+                    "image-carrousel-" ++ String.fromInt productId
 
         imageId index =
-            "product-image-" ++ String.fromInt index
+            case maybeProductId of
+                Nothing ->
+                    "product-image-" ++ String.fromInt index
+
+                Just productId ->
+                    "product-image-" ++ String.fromInt productId ++ "-" ++ String.fromInt index
 
         indexFromImageId (ImageId imgId) =
-            String.dropLeft (String.length "product-image-") imgId
-                |> String.toInt
+            case maybeProductId of
+                Nothing ->
+                    String.dropLeft (String.length "product-image-") imgId
+                        |> String.toInt
+
+                Just productId ->
+                    String.dropLeft (String.length ("product-image-" ++ String.fromInt productId ++ "-")) imgId
+                        |> String.toInt
 
         clickedScrollToImage imageIndex =
             options.onScrollToImage
@@ -508,9 +529,9 @@ viewImageCarrousel extraAttrs options ( firstImage, otherImages ) =
                             [ class "border-2 w-2 h-2 rounded-full transition-colors"
                             , classList
                                 [ ( "bg-white border-orange-500", isCurrentIntersecting index )
-                                , ( "bg-white/80 border-white/80", not (isCurrentIntersecting index) )
+                                , ( "bg-white/80 border-gray-400", not (isCurrentIntersecting index) )
                                 ]
-                            , onClick (clickedScrollToImage index)
+                            , onClickPreventAll (clickedScrollToImage index)
                             ]
                             []
                     )

--- a/src/elm/View/Components.elm
+++ b/src/elm/View/Components.elm
@@ -482,7 +482,7 @@ by id you need to use `#` as a prefix.
 intersectionObserver :
     { targetSelectors : List String
     , threshold : Float
-    , breakpointToExclude : Breakpoint
+    , breakpointToExclude : Maybe Breakpoint
     , onStartedIntersecting : Maybe (String -> msg)
     , onStoppedIntersecting : Maybe (String -> msg)
     }
@@ -504,7 +504,14 @@ intersectionObserver options =
     node "intersection-observer"
         [ attribute "elm-target" (String.join " " options.targetSelectors)
         , attribute "elm-threshold" (String.fromFloat options.threshold)
-        , attribute "elm-max-width" (String.fromInt <| breakpointToPixels options.breakpointToExclude)
+        , attribute "elm-max-width"
+            (case options.breakpointToExclude of
+                Nothing ->
+                    "none"
+
+                Just breakpointToExclude ->
+                    String.fromInt <| breakpointToPixels breakpointToExclude
+            )
         , optionalEvent "started-intersecting" options.onStartedIntersecting
         , optionalEvent "stopped-intersecting" options.onStoppedIntersecting
         ]

--- a/src/index.js
+++ b/src/index.js
@@ -882,8 +882,9 @@ async function handleJavascriptPort (arg) {
 
       const targetLeft = document.getElementById(targetId).getBoundingClientRect().left
       const container = document.getElementById(containerId)
+      const offset = targetLeft - container.getBoundingClientRect().left
       container.scrollTo({
-        left: container.scrollLeft + targetLeft,
+        left: container.scrollLeft + offset,
         behavior: 'smooth'
       })
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -142,7 +142,8 @@ module.exports = {
       minHeight: {
         '25': '6.25rem',
         '36': '9rem',
-        '48': '12rem'
+        '48': '12rem',
+        '150': '37.5rem'
       },
       lineHeight: {
         caption: 0.75


### PR DESCRIPTION
## What issue does this PR close
Closes #731 

## Changes Proposed ( a list of new changes introduced by this PR)
- [x] Break product form into multiple steps
- [x] Restyle form
  - [x] Mobile
  - [x] Desktop
  - [x] Allow removing image
- [x] Use new modal to enter the form editing page and deletion button
- [x] Allow multiple images on form
- [x] Show multiple images on offer page
- [x] Show multiple images on shop listing
- [x] Show multiple images on search page
- [x] Translate texts

## How to test ( a list of instructions on how to test this PR)
- Create a new offer and check if the form is ok (note that not all fields will be added in this PR)
- Edit an existing offer and check if the form is ok
- Have an offer with multiple images
- Check that you can scroll through the product's images on the shop listing (both as guest and logged in)
- Check that you can scroll through the product's images on the product page
- Make sure offers with a single image and with no image also still look ok