### PR TITLE
Remove path, query and fragment from community url when sharing

### DIFF
--- a/src/elm/Page/Community/About.elm
+++ b/src/elm/Page/Community/About.elm
@@ -111,6 +111,7 @@ update msg model loggedIn =
                                         , ( "title", Encode.string community.name )
                                         , ( "url"
                                           , loggedIn.shared.url
+                                                |> urlToShareable
                                                 |> Url.toString
                                                 |> Encode.string
                                           )
@@ -336,7 +337,8 @@ viewCommunityCard ({ translators } as shared) community =
                         translators.tr "community.learn_about"
                             [ ( "community_name", community.name )
                             , ( "url"
-                              , Route.addRouteToUrl shared Route.CommunityAbout
+                              , shared.url
+                                    |> urlToShareable
                                     |> Url.toString
                               )
                             ]
@@ -592,6 +594,11 @@ showSupportersCard community =
 showNewsCard : Community.Model -> Bool
 showNewsCard community =
     community.hasNews
+
+
+urlToShareable : Url.Url -> Url.Url
+urlToShareable url =
+    { url | path = "", query = Nothing, fragment = Nothing }
 
 
 


### PR DESCRIPTION
## What issue does this PR close
Closes #755 

## Changes Proposed ( a list of new changes introduced by this PR)
- Remove path, query and fragment from community url when sharing

## How to test ( a list of instructions on how to test this PR)
- Share the community link
- Check that it points to the root (should look something like `https://buss.staging.cambiatus.io/`