### PR TITLE
Fix/action proof code

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -37,6 +37,7 @@
             "justinmimbs/time-extra": "1.1.0",
             "krisajenkins/remotedata": "6.0.1",
             "pdamoc/elm-hashids": "1.0.4",
+            "pzp1997/assoc-list": "1.0.0",
             "robinheghan/elm-phone-numbers": "1.0.0",
             "robinheghan/murmur3": "1.0.0",
             "rtfeldman/elm-iso8601-date-strings": "1.1.3",

--- a/src/customElements/bgNoScroll.js
+++ b/src/customElements/bgNoScroll.js
@@ -5,6 +5,7 @@ export default () => (
     constructor () {
       super()
 
+      this._preventScrollingClasses = []
       this._classesHandledByOthers = []
     }
 

--- a/src/elm/Action.elm
+++ b/src/elm/Action.elm
@@ -162,8 +162,11 @@ update isPinConfirmed permissions shared selectedCommunity accName msg model =
             , proof :
                 Maybe
                     { photo : String
-                    , code : String
-                    , time : Time.Posix
+                    , proofCode :
+                        Maybe
+                            { code : String
+                            , time : Time.Posix
+                            }
                     }
             }
             -> Model
@@ -234,8 +237,11 @@ update isPinConfirmed permissions shared selectedCommunity accName msg model =
                                 , proof =
                                     Just
                                         { photo = image
-                                        , code = code
-                                        , time = time
+                                        , proofCode =
+                                            Just
+                                                { code = code
+                                                , time = time
+                                                }
                                         }
                                 }
 
@@ -839,8 +845,11 @@ type alias ClaimedAction =
     , proof :
         Maybe
             { photo : String
-            , code : String
-            , time : Time.Posix
+            , proofCode :
+                Maybe
+                    { code : String
+                    , time : Time.Posix
+                    }
             }
     }
 
@@ -853,15 +862,22 @@ encodeClaimAction c =
                 |> Maybe.map getter
                 |> Maybe.withDefault default
                 |> encoder
+
+        encodeProofCodeItem getter default encoder =
+            c.proof
+                |> Maybe.andThen .proofCode
+                |> Maybe.map getter
+                |> Maybe.withDefault default
+                |> encoder
     in
     Encode.object
         [ ( "community_id", Eos.encodeSymbol c.communityId )
         , ( "action_id", Encode.int c.actionId )
         , ( "maker", Eos.encodeName c.claimer )
         , ( "proof_photo", encodeProofItem .photo "" Encode.string )
-        , ( "proof_code", encodeProofItem .code "" Encode.string )
+        , ( "proof_code", encodeProofCodeItem .code "" Encode.string )
         , ( "proof_time"
-          , encodeProofItem (.time >> Time.posixToMillis >> (\time -> time // 1000))
+          , encodeProofCodeItem (.time >> Time.posixToMillis >> (\time -> time // 1000))
                 0
                 Encode.int
           )

--- a/src/elm/Action.elm
+++ b/src/elm/Action.elm
@@ -682,21 +682,25 @@ viewClaimWithProofs ((Proof photoStatus proofCode) as proof) ({ t } as translato
             , action.photoProofInstructions
                 |> Maybe.withDefault Markdown.empty
                 |> Markdown.view [ class "mb-4" ]
-            , case proofCode of
-                Just { code_, secondsAfterClaim, availabilityPeriod } ->
-                    case code_ of
-                        Just c ->
-                            viewProofCode
-                                translators
-                                c
-                                secondsAfterClaim
-                                availabilityPeriod
+            , if action.hasProofCode then
+                case proofCode of
+                    Just { code_, secondsAfterClaim, availabilityPeriod } ->
+                        case code_ of
+                            Just c ->
+                                viewProofCode
+                                    translators
+                                    c
+                                    secondsAfterClaim
+                                    availabilityPeriod
 
-                        _ ->
-                            text ""
+                            _ ->
+                                text ""
 
-                _ ->
-                    text ""
+                    _ ->
+                        text ""
+
+              else
+                text ""
             , Form.view []
                 translators
                 (\submitButton ->

--- a/src/elm/Claim.elm
+++ b/src/elm/Claim.elm
@@ -1007,7 +1007,7 @@ viewClaimModal ({ shared, accountName } as loggedIn) profileSummaries claim =
 
         claimRoute =
             Route.Claim
-                claim.action.objective.id
+                (Action.objectiveIdToInt claim.action.objective.id)
                 claim.action.id
                 claim.id
 

--- a/src/elm/Community.elm
+++ b/src/elm/Community.elm
@@ -446,7 +446,7 @@ addPhotosMutation symbol photos =
 
 
 type alias Objective =
-    { id : Int
+    { id : Action.ObjectiveId
     , description : Markdown
     , creator : Eos.Name
     , actions : List Action
@@ -458,7 +458,7 @@ type alias Objective =
 objectiveSelectionSet : SelectionSet Objective Cambiatus.Object.Objective
 objectiveSelectionSet =
     SelectionSet.succeed Objective
-        |> with Objective.id
+        |> with Action.objectiveIdSelectionSet
         |> with (Markdown.selectionSet Objective.description)
         |> with (Eos.nameSelectionSet Objective.creatorId)
         |> with (Objective.actions identity Action.selectionSet)
@@ -485,7 +485,7 @@ encodeCreateObjectiveAction c =
 
 type alias UpdateObjectiveAction =
     { communityId : Eos.Symbol
-    , objectiveId : Int
+    , objectiveId : Action.ObjectiveId
     , description : Markdown
     , editor : Eos.Name
     }
@@ -495,7 +495,7 @@ encodeUpdateObjectiveAction : UpdateObjectiveAction -> Value
 encodeUpdateObjectiveAction c =
     Encode.object
         [ ( "community_id", Eos.encodeSymbol c.communityId )
-        , ( "objective_id", Encode.int c.objectiveId )
+        , ( "objective_id", Action.encodeObjectiveId c.objectiveId )
         , ( "description", Markdown.encode c.description )
         , ( "editor", Eos.encodeName c.editor )
         ]

--- a/src/elm/Form/UserPicker.elm
+++ b/src/elm/Form/UserPicker.elm
@@ -66,7 +66,7 @@ This is how you actually use this component!
 import Avatar
 import Eos.Account
 import Html exposing (Html, button, div, li, span, ul)
-import Html.Attributes exposing (class, classList, disabled, type_)
+import Html.Attributes exposing (class, classList, disabled, id, type_)
 import Html.Attributes.Aria exposing (ariaLabel)
 import Html.Events exposing (onClick)
 import Icons
@@ -299,9 +299,10 @@ view ((Options options) as wrappedOptions) viewConfig toMsg =
             |> Html.map (toMsg << GotSelectMsg)
         , viewConfig.error
         , ul [ class "mt-4 flex flex-wrap gap-6" ]
-            (List.map
-                (viewSelectedProfile wrappedOptions viewConfig
-                    >> Html.map toMsg
+            (List.indexedMap
+                (\index profile ->
+                    viewSelectedProfile index wrappedOptions viewConfig profile
+                        |> Html.map toMsg
                 )
                 selectedProfiles
             )
@@ -309,11 +310,12 @@ view ((Options options) as wrappedOptions) viewConfig toMsg =
 
 
 viewSelectedProfile :
-    Options msg
+    Int
+    -> Options msg
     -> ViewConfig msg
     -> ProfileWithSummary
     -> Html Msg
-viewSelectedProfile (Options options) viewConfig { profile, summary } =
+viewSelectedProfile index (Options options) viewConfig { profile, summary } =
     let
         (Model model) =
             viewConfig.value
@@ -321,7 +323,7 @@ viewSelectedProfile (Options options) viewConfig { profile, summary } =
         addRelativeSelector =
             case options.profileSummarySelectors.relative of
                 Nothing ->
-                    Profile.Summary.withRelativeSelector ("#" ++ model.id ++ " ~ ul")
+                    Profile.Summary.withRelativeSelector ("#" ++ model.id ++ "-" ++ String.fromInt index)
 
                 Just selector ->
                     Profile.Summary.withRelativeSelector selector
@@ -337,6 +339,7 @@ viewSelectedProfile (Options options) viewConfig { profile, summary } =
     li
         [ class "flex flex-col items-center"
         , classList [ ( "relative", options.areProfilesRelative ) ]
+        , id (model.id ++ "-" ++ String.fromInt index)
         ]
         [ summary
             |> addRelativeSelector

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -1,5 +1,6 @@
 module Main exposing (main)
 
+import Action
 import Api.Graphql
 import Browser exposing (Document)
 import Browser.Navigation as Nav
@@ -1093,15 +1094,15 @@ statusToRoute status session =
                     Just Route.CommunitySettingsNewObjective
 
                 Just objectiveId ->
-                    Just (Route.CommunitySettingsEditObjective objectiveId)
+                    Just (Route.CommunitySettingsEditObjective (Action.objectiveIdToInt objectiveId))
 
         CommunitySettingsActionEditor subModel ->
             case subModel.actionId of
                 Nothing ->
-                    Just (Route.CommunitySettingsNewAction subModel.objectiveId)
+                    Just (Route.CommunitySettingsNewAction (Action.objectiveIdToInt subModel.objectiveId))
 
                 Just actionId ->
-                    Just (Route.CommunitySettingsEditAction subModel.objectiveId actionId)
+                    Just (Route.CommunitySettingsEditAction (Action.objectiveIdToInt subModel.objectiveId) actionId)
 
         CommunitySettingsContacts _ ->
             Just Route.CommunitySettingsContacts
@@ -1520,17 +1521,17 @@ changeRouteTo maybeRoute model =
                 |> withLoggedIn Route.CommunitySettingsNewObjective
 
         Just (Route.CommunitySettingsEditObjective objectiveId) ->
-            (\l -> CommunitySettingsObjectiveEditor.initEdit l objectiveId)
+            (\l -> CommunitySettingsObjectiveEditor.initEdit l (Action.objectiveIdFromInt objectiveId))
                 >> updateStatusWith CommunitySettingsObjectiveEditor GotCommunitySettingsObjectiveEditorMsg model
                 |> withLoggedIn (Route.CommunitySettingsEditObjective objectiveId)
 
         Just (Route.CommunitySettingsNewAction objectiveId) ->
-            (\l -> CommunitySettingsActionEditor.init l objectiveId Nothing)
+            (\l -> CommunitySettingsActionEditor.init l (Action.objectiveIdFromInt objectiveId) Nothing)
                 >> updateLoggedInUResult CommunitySettingsActionEditor GotCommunitySettingsActionEditorMsg model
                 |> withLoggedIn (Route.CommunitySettingsNewAction objectiveId)
 
         Just (Route.CommunitySettingsEditAction objectiveId actionId) ->
-            (\l -> CommunitySettingsActionEditor.init l objectiveId (Just actionId))
+            (\l -> CommunitySettingsActionEditor.init l (Action.objectiveIdFromInt objectiveId) (Just actionId))
                 >> updateLoggedInUResult CommunitySettingsActionEditor GotCommunitySettingsActionEditorMsg model
                 |> withLoggedIn (Route.CommunitySettingsEditAction objectiveId actionId)
 

--- a/src/elm/Page/Community/Settings/ActionEditor.elm
+++ b/src/elm/Page/Community/Settings/ActionEditor.elm
@@ -54,15 +54,11 @@ import View.Feedback as Feedback
 -- INIT
 
 
-type alias ObjectiveId =
-    Int
-
-
 type alias ActionId =
     Int
 
 
-init : LoggedIn.Model -> ObjectiveId -> Maybe ActionId -> UpdateResult
+init : LoggedIn.Model -> Action.ObjectiveId -> Maybe ActionId -> UpdateResult
 init _ objectiveId actionId =
     { objectiveId = objectiveId
     , actionId = actionId
@@ -77,7 +73,7 @@ init _ objectiveId actionId =
 
 
 type alias Model =
-    { objectiveId : ObjectiveId
+    { objectiveId : Action.ObjectiveId
     , actionId : Maybe ActionId
     , status : Status
     }
@@ -393,7 +389,7 @@ upsertAction { markAsCompleted } msg maybeAction loggedIn model formOutput =
                     Encode.object
                         [ ( "community_id", Eos.encodeSymbol formOutput.reward.symbol )
                         , ( "action_id", Encode.int (Maybe.withDefault 0 model.actionId) )
-                        , ( "objective_id", Encode.int model.objectiveId )
+                        , ( "objective_id", Action.encodeObjectiveId model.objectiveId )
                         , ( "creator", Eos.encodeName loggedIn.accountName )
                         , ( "description", Markdown.encode formOutput.description )
                         , ( "reward", Eos.encodeAsset formOutput.reward )

--- a/src/elm/Page/Community/Settings/ActionEditor.elm
+++ b/src/elm/Page/Community/Settings/ActionEditor.elm
@@ -119,7 +119,12 @@ initFormInput shared maybeAction =
                 |> Form.RichText.initModel "description-editor"
         , reward =
             maybeAction
-                |> Maybe.map (.reward >> String.fromFloat)
+                |> Maybe.map
+                    (\action ->
+                        Eos.formatSymbolAmount shared.translators
+                            action.objective.community.symbol
+                            action.reward
+                    )
                 |> Maybe.withDefault ""
         , useDateValidation =
             maybeAction
@@ -173,7 +178,12 @@ initFormInput shared maybeAction =
                     }
             , verifierReward =
                 maybeAction
-                    |> Maybe.map (.verifierReward >> String.fromFloat)
+                    |> Maybe.map
+                        (\action ->
+                            Eos.formatSymbolAmount shared.translators
+                                action.objective.community.symbol
+                                action.verifierReward
+                        )
                     |> Maybe.withDefault ""
             , fileValidation =
                 { useFileValidation =

--- a/src/elm/View/Components.elm
+++ b/src/elm/View/Components.elm
@@ -385,10 +385,10 @@ bgNoScroll attrs preventScroll =
         preventScrollClass =
             case preventScroll of
                 PreventScrollOnMobile ->
-                    "overflow-hidden fixed w-full h-full md:overflow-auto"
+                    "overflow-hidden fixed w-full h-full md:overflow-auto md:static md:w-auto md:h-auto"
 
                 PreventScrollAlways ->
-                    "overflow-hidden fixed w-full h-full"
+                    "overflow-hidden fixed w-full h-full md:static md:w-auto md:h-auto"
     in
     node "bg-no-scroll"
         (attribute "elm-prevent-scroll-class" preventScrollClass

--- a/tests/TestHelpers/Random.elm
+++ b/tests/TestHelpers/Random.elm
@@ -272,7 +272,7 @@ minimalProfile =
 actionObjective : Random.Generator Action.Objective
 actionObjective =
     Random.constant Action.Objective
-        |> with (Random.int 0 Random.maxInt)
+        |> with (Random.int 0 Random.maxInt |> Random.map Action.objectiveIdFromInt)
         |> with (Markdown.generator string)
         |> with (symbol |> Random.map (\symbol_ -> { symbol = symbol_ }))
         |> with Random.Extra.bool

--- a/tests/TestHelpers/Shrink.elm
+++ b/tests/TestHelpers/Shrink.elm
@@ -100,10 +100,15 @@ minimalProfile profile =
 -- ACTION
 
 
+objectiveId : Shrinker Action.ObjectiveId
+objectiveId =
+    Shrink.convert Action.objectiveIdFromInt Action.objectiveIdToInt int
+
+
 actionObjective : Shrinker Action.Objective
 actionObjective objective =
     noShrink Action.Objective
-        |> andMap (int objective.id)
+        |> andMap (objectiveId objective.id)
         |> andMap (Markdown.shrink objective.description)
         |> andMap (noShrink objective.community)
         |> andMap (bool objective.isCompleted)


### PR DESCRIPTION
## What issue does this PR close
Closes #761 

## Changes Proposed ( a list of new changes introduced by this PR)
- Hide proof code on objectives page for actions that don't require proof code
- Hide proof code when claiming through the search bar for actions that don't require proof code

## How to test ( a list of instructions on how to test this PR)
Try this on the objectives page and through the search bar:
1. Try to claim an action that required proof code (and therefore proof photo). You should see the proof code and proof photo
2. Try to claim an action that doesn't require proof code, but requires proof photo. You should see the proof photo, but not the proof code
3. Try to claim an action that doesn't require proof code or proof photo. You shouldn't see any of them.

You should be able to claim the action in all circumstances