### PR TITLE
Fix/debounce search

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -7,6 +7,7 @@
     "dependencies": {
         "direct": {
             "CurrySoftware/elm-datepicker": "4.0.0",
+            "Gizra/elm-debouncer": "2.0.0",
             "NeoVier/elm-mask": "2.0.4",
             "NoRedInk/elm-json-decode-pipeline": "1.0.0",
             "NoRedInk/elm-simple-fuzzy": "1.0.3",

--- a/src/elm/Search.elm
+++ b/src/elm/Search.elm
@@ -115,7 +115,7 @@ sendSearchQuery selectedCommunity queryString =
     in
     RequestQuery
         (Cambiatus.Query.search req (searchResultSelectionSet queryString))
-        GotSearchResults
+        (GotSearchResults { for = queryString })
 
 
 searchResultSelectionSet : String -> SelectionSet SearchResults Cambiatus.Object.SearchResult
@@ -165,7 +165,7 @@ type Msg
     | InputFocused
     | GotRecentSearches String
     | RecentQueryClicked String
-    | GotSearchResults FoundData
+    | GotSearchResults { for : String } FoundData
     | QuerySubmitted
     | TabActivated ActiveTab
     | GotFormMsg (Form.Msg FormInput)
@@ -233,14 +233,17 @@ update shared symbol model msg =
                 _ ->
                     UR.init model
 
-        GotSearchResults res ->
+        GotSearchResults { for } res ->
             { model
                 | state =
                     if String.isEmpty (Form.getValue .query model.form) then
                         model.state
 
-                    else
+                    else if for == Form.getValue .query model.form then
                         ResultsShowed res Nothing
+
+                    else
+                        model.state
             }
                 |> UR.init
 


### PR DESCRIPTION
## What issue does this PR close
Closes #758 

## Changes Proposed ( a list of new changes introduced by this PR)
- Only show result from search query if it comes from the string currently present in the input field
- Use `Gizra/elm-debouncer` so we don't fire multiple queries that will end up being discarded anyway

## How to test ( a list of instructions on how to test this PR)
You need a combination of keystrokes that can cause the bug (described in the issue). You can try to find one [here](https://cambiatus.netlify.app/). An example in the Buss community is having `ac` in the search, then deleting `c` and typing it again quickly.

You can then test that combination in the deploy of this PR.
