### PR TITLE
Fix/disabled objectives page

### DIFF
--- a/public/translations/amh-ETH.json
+++ b/public/translations/amh-ETH.json
@@ -488,6 +488,7 @@
     },
     "objectives": {
       "title": "ግቦች",
+      "disabled_objectives_description": "የማህበረሰቡ አላማዎች ተሰናክለዋል",
       "earn": "ያሸንፉ",
       "complete_actions": "ማህበረሰቡ ተከታትሎ ያገኛቸው የተሟሉ ተግባራት",
       "objectives_and": "ዓላማዎች እና",

--- a/public/translations/cat-CAT.json
+++ b/public/translations/cat-CAT.json
@@ -530,6 +530,7 @@
     },
     "objectives": {
       "title": "Objectius",
+      "disabled_objectives_description": "Els objectius comunitaris estan desactivats",
       "earn": "Guanyar",
       "complete_actions": "Completa les accions que la comunitat ha traçat i guanya",
       "objectives_and": "Objectius i",

--- a/public/translations/en-US.json
+++ b/public/translations/en-US.json
@@ -526,6 +526,7 @@
     },
     "objectives": {
       "title": "Objectives",
+      "disabled_objectives_description": "The community objectives are disabled",
       "earn": "Earn",
       "complete_actions": "Complete actions the community has traced and earn",
       "objectives_and": "Objectives and",

--- a/public/translations/es-ES.json
+++ b/public/translations/es-ES.json
@@ -530,6 +530,7 @@
     },
     "objectives": {
       "title": "Objetivos",
+      "disabled_objectives_description": "Los objetivos de la comunidad están deshabilitados",
       "earn": "Ganar",
       "complete_actions": "Complete las acciones que la comunidad ha rastreado y gane",
       "objectives_and": "Objetivos y",

--- a/public/translations/pt-BR.json
+++ b/public/translations/pt-BR.json
@@ -534,6 +534,7 @@
     },
     "objectives": {
       "title": "Objetivos",
+      "not_found_description": "Os objetivos da habilidade estão desabilitados",
       "earn": "Ganhe",
       "complete_actions": "Complete ações que a comunidade traçou e ganhe",
       "objectives_and": "Objetivos e",

--- a/src/elm/Page/Community/About.elm
+++ b/src/elm/Page/Community/About.elm
@@ -409,11 +409,15 @@ viewCommunityCard ({ translators } as shared) community =
                                 ]
                         )
                 )
-            , a
-                [ class "button button-secondary w-full mt-8"
-                , Route.href (Route.CommunityObjectives Route.WithNoObjectiveSelected)
-                ]
-                [ text <| translators.tr "community.earn" [ ( "symbol", Eos.symbolToSymbolCodeString community.symbol ) ] ]
+            , if community.hasObjectives then
+                a
+                    [ class "button button-secondary w-full mt-8"
+                    , Route.href (Route.CommunityObjectives Route.WithNoObjectiveSelected)
+                    ]
+                    [ text <| translators.tr "community.earn" [ ( "symbol", Eos.symbolToSymbolCodeString community.symbol ) ] ]
+
+              else
+                text ""
             ]
         ]
 

--- a/src/elm/Page/Community/Settings/Features.elm
+++ b/src/elm/Page/Community/Settings/Features.elm
@@ -1,5 +1,6 @@
 module Page.Community.Settings.Features exposing (Model, Msg, init, jsAddressToMsg, msgToString, receiveBroadcast, update, view)
 
+import Browser.Dom
 import Cambiatus.Mutation
 import Community
 import Dict
@@ -18,6 +19,7 @@ import Page
 import Ports
 import RemoteData
 import Session.LoggedIn as LoggedIn exposing (External(..))
+import Task
 import UpdateResult as UR
 import View.Feedback as Feedback
 
@@ -25,7 +27,11 @@ import View.Feedback as Feedback
 init : LoggedIn.Model -> ( Model, Cmd Msg )
 init loggedIn =
     ( initModel
-    , LoggedIn.maybeInitWith CompletedLoadCommunity .selectedCommunity loggedIn
+    , Cmd.batch
+        [ LoggedIn.maybeInitWith CompletedLoadCommunity .selectedCommunity loggedIn
+        , Browser.Dom.setViewport 0 0
+            |> Task.perform (\_ -> NoOp)
+        ]
     )
 
 

--- a/src/elm/Page/Dashboard.elm
+++ b/src/elm/Page/Dashboard.elm
@@ -755,16 +755,20 @@ viewWelcomeCard ({ shared } as loggedIn) community balance =
                     ]
                 ]
             , ul [ class "px-4 pt-2 divide-y divide-y-gray-100" ]
-                [ listItem Icons.cambiatusCoin
-                    (not loggedIn.hasAcceptedCodeOfConduct)
-                    "w-5"
-                    (tr "dashboard.how_to_earn" [ ( "symbol", Eos.symbolToSymbolCodeString community.symbol ) ])
-                    (\attrs ->
-                        View.Components.disablableLink
-                            { isDisabled = not loggedIn.hasAcceptedCodeOfConduct }
-                            (Route.href (Route.CommunityObjectives Route.WithNoObjectiveSelected) :: attrs)
-                    )
-                    []
+                [ if community.hasObjectives then
+                    listItem Icons.cambiatusCoin
+                        (not loggedIn.hasAcceptedCodeOfConduct)
+                        "w-5"
+                        (tr "dashboard.how_to_earn" [ ( "symbol", Eos.symbolToSymbolCodeString community.symbol ) ])
+                        (\attrs ->
+                            View.Components.disablableLink
+                                { isDisabled = not loggedIn.hasAcceptedCodeOfConduct }
+                                (Route.href (Route.CommunityObjectives Route.WithNoObjectiveSelected) :: attrs)
+                        )
+                        []
+
+                  else
+                    text ""
                 , listItem Icons.profile
                     (not loggedIn.hasAcceptedCodeOfConduct)
                     "w-5 h-5"


### PR DESCRIPTION
## What issue does this PR close
Closes #783 

## Changes Proposed ( a list of new changes introduced by this PR)
When objectives are disabled:
- Hide link on the dashboard to the objectives page
- Hide link on the "About community" page to the objectives page
- Show Page not found on the objectives page

## How to test ( a list of instructions on how to test this PR)
- Make sure the buttons on dashboard and about community show up if the community has objectives
- Make sure the objectives page still looks right if objectives are enabled
- Disable objectives
- Make sure there are no links to the objectives page (on the dashboard and about community page)
- When entering `/community/objectives` manually, you should see a "Page not found" view, telling you that the community objectives are disabled