### PR TITLE
Break words on markdown

### DIFF
--- a/src/customElements/focusTrap.js
+++ b/src/customElements/focusTrap.js
@@ -30,13 +30,9 @@ export default () => (
 
     connectedCallback () {
       let elementToFocus = this.focusables(this)[0]
-      const firstFocusableContainers = this.querySelectorAll(this.getAttribute('first-focus-container'))
-      for (const container of firstFocusableContainers) {
-        const focusables = this.focusables(container)
-        if (focusables.length > 0) {
-          elementToFocus = focusables[0]
-          break
-        }
+      const initialFocusId = this.getAttribute('initial-focus-id')
+      if (initialFocusId) {
+        elementToFocus = this.querySelector(`#${initialFocusId}`)
       }
 
       if (elementToFocus) {

--- a/src/elm/Markdown.elm
+++ b/src/elm/Markdown.elm
@@ -643,7 +643,7 @@ view attributes (Markdown content) =
             in
             case Markdown.Renderer.render renderer blocks of
                 Ok asHtml ->
-                    Html.div (Html.Attributes.class "markdown-viewer break-all sm:break-normal sm:break-words" :: attributes) asHtml
+                    Html.div (Html.Attributes.class "markdown-viewer break-words" :: attributes) asHtml
 
                 Err _ ->
                     Html.text ""

--- a/src/elm/Markdown.elm
+++ b/src/elm/Markdown.elm
@@ -643,7 +643,7 @@ view attributes (Markdown content) =
             in
             case Markdown.Renderer.render renderer blocks of
                 Ok asHtml ->
-                    Html.div (Html.Attributes.class "markdown-viewer" :: attributes) asHtml
+                    Html.div (Html.Attributes.class "markdown-viewer break-all sm:break-normal sm:break-words" :: attributes) asHtml
 
                 Err _ ->
                     Html.text ""

--- a/src/elm/Page/Community/About.elm
+++ b/src/elm/Page/Community/About.elm
@@ -198,7 +198,7 @@ view loggedIn model =
                             defaultCoverPhoto
                     , div [ class "container mx-auto px-4 py-10" ]
                         [ div
-                            [ class "grid lg:grid-cols-3 gap-6"
+                            [ class "grid grid-cols-1 lg:grid-cols-3 gap-6"
                             , classList [ ( "lg:grid-cols-6", not (showSupportersCard community) && not (showNewsCard community) ) ]
                             ]
                             [ viewCommunityCard loggedIn.shared community

--- a/src/elm/Page/Community/Objectives.elm
+++ b/src/elm/Page/Community/Objectives.elm
@@ -723,7 +723,12 @@ viewObjective loggedIn model objective =
                     ]
                     [ Icons.cambiatusCoin "text-blue fill-current flex-shrink-0 self-start mt-1"
                     , h3 [ title (Markdown.toRawString objective.description), class "max-w-[calc(100%-64px)]" ]
-                        [ Markdown.view [ class "font-bold px-4 line-clamp-4 self-start mt-1" ] objective.description ]
+                        [ Markdown.view
+                            [ class "font-bold px-4 self-start mt-1"
+                            , classList [ ( "line-clamp-4 hide-children-from-2", not isOpen ) ]
+                            ]
+                            objective.description
+                        ]
                     , span
                         [ class "ml-auto flex-shrink-0 transition-transform duration-150 motion-reduce:transition-none"
                         , classList

--- a/src/elm/Page/Community/Objectives.elm
+++ b/src/elm/Page/Community/Objectives.elm
@@ -722,7 +722,7 @@ viewObjective loggedIn model objective =
                     [ class "flex marker-hidden items-center bg-white rounded px-4 py-6 cursor-pointer"
                     ]
                     [ Icons.cambiatusCoin "text-blue fill-current flex-shrink-0 self-start mt-1"
-                    , h3 [ title (Markdown.toRawString objective.description) ]
+                    , h3 [ title (Markdown.toRawString objective.description), class "max-w-[calc(100%-64px)]" ]
                         [ Markdown.view [ class "font-bold px-4 line-clamp-4 self-start mt-1" ] objective.description ]
                     , span
                         [ class "ml-auto flex-shrink-0 transition-transform duration-150 motion-reduce:transition-none"

--- a/src/elm/Page/Community/Settings/Objectives.elm
+++ b/src/elm/Page/Community/Settings/Objectives.elm
@@ -243,7 +243,7 @@ viewAction ({ shared } as loggedIn) model objectiveId action =
     div [ class "flex flex-wrap sm:flex-nowrap mt-8 mb-4 relative bg-purple-500 rounded-lg px-4 py-5" ]
         [ div [ class "absolute top-0 left-0 right-0 -mt-6" ] [ Icons.flag "w-full fill-current text-green" ]
         , div [ class "w-full" ]
-            [ Markdown.view [ class "text-white truncate" ] action.description
+            [ Markdown.view [ class "text-white" ] action.description
             , div [ class "flex flex-wrap gap-y-4 gap-x-6 my-6 items-center" ]
                 [ div [ class "text-white" ]
                     [ p [ class "label text-green" ]

--- a/src/elm/Page/Join.elm
+++ b/src/elm/Page/Join.elm
@@ -217,7 +217,7 @@ view_ isGuest ({ translators } as shared) community model =
         [ class "bg-purple-500 flex-grow flex flex-col md:justify-center items-center p-4 lg:p-0"
         , classList [ ( "w-1/2", not isGuest ) ]
         ]
-        [ div [ class "bg-white rounded-b md:rounded lg:w-4/5 xl:w-7/12" ]
+        [ div [ class "bg-white rounded-b md:rounded w-full lg:w-4/5 xl:w-7/12" ]
             [ Community.communityPreviewImage False shared community
             , div [ class "p-4" ]
                 (Markdown.view [ class "text-gray-333 block mb-7" ] community.description

--- a/src/elm/Page/News.elm
+++ b/src/elm/Page/News.elm
@@ -467,7 +467,7 @@ viewReactionPicker { t } model news =
             [ Icons.smilingFace "fill-current text-gray-900 w-6 h-6"
             ]
         , View.Components.focusTrap
-            { firstFocusContainer = Nothing }
+            { initialFocusId = Nothing }
             []
             [ ul
                 [ class "absolute shadow grid gap-1 p-2 rounded-sm bg-white"

--- a/src/elm/Page/Profile.elm
+++ b/src/elm/Page/Profile.elm
@@ -926,8 +926,8 @@ viewProfile loggedIn profile =
                 ]
                 [ text_ "block_explorer.see" ]
     in
-    div [ class "p-4 bg-white border-white border-r w-full flex md:border-gray-500" ]
-        [ div [ class "w-full container mx-auto self-center md:max-w-lg" ]
+    div [ class "bg-white border-white border-r w-full flex md:border-gray-500" ]
+        [ div [ class "w-full p-4 max-w-screen container mx-auto self-center md:max-w-lg" ]
             (div [ class "pb-4 w-full" ]
                 [ div [ class "flex flex-wrap items-center justify-center mb-4" ]
                     [ Avatar.view profile.avatar "w-20 h-20 mr-6 xs-max:w-16 xs-max:h-16 xs-max:mr-3"

--- a/src/elm/Page/Shop/Viewer.elm
+++ b/src/elm/Page/Shop/Viewer.elm
@@ -600,7 +600,7 @@ view session model =
             in
             div [ class "flex flex-grow items-center relative bg-white md:bg-gray-100" ]
                 [ div [ class "absolute bg-white top-0 bottom-0 left-0 right-1/2 hidden md:block" ] []
-                , div [ class "container mx-auto px-4 my-4 md:my-10 md:isolate grid md:grid-cols-2" ]
+                , div [ class "container mx-auto px-4 my-4 md:my-10 md:isolate grid grid-cols-1 md:grid-cols-2" ]
                     [ div [ class "mb-6 md:mb-0 md:w-2/3 md:mx-auto" ]
                         [ case sale.images of
                             [] ->

--- a/src/elm/Page/ViewTransfer.elm
+++ b/src/elm/Page/ViewTransfer.elm
@@ -100,7 +100,7 @@ view loggedIn model =
                                     [ div [ class "bg-purple-500 absolute top-0 bottom-0 left-0 right-1/2 hidden lg:block" ] []
                                     , div [ class "bg-white absolute top-0 bottom-0 left-1/2 right-0 hidden lg:block" ] []
                                     , div
-                                        [ class "relative flex-grow grid mb-10 lg:container lg:mx-auto lg:px-4 lg:grid-cols-2 lg:py-10 lg:mb-0"
+                                        [ class "relative flex-grow grid grid-cols-1 mb-10 lg:container lg:mx-auto lg:px-4 lg:grid-cols-2 lg:py-10 lg:mb-0"
                                         , Html.Attributes.id "content-container"
                                         ]
                                         [ viewTransfer loggedIn transfer direction

--- a/src/elm/Session/LoggedIn.elm
+++ b/src/elm/Session/LoggedIn.elm
@@ -830,7 +830,7 @@ viewHeader page ({ shared } as model) profile_ =
                   else
                     text ""
                 , if model.showUserNav then
-                    View.Components.focusTrap { firstFocusContainer = Nothing }
+                    View.Components.focusTrap { initialFocusId = Nothing }
                         []
                         [ nav
                             [ class "absolute right-0 lg:w-full py-2 px-4 shadow-lg bg-white rounded-t-lg rounded-b-lg lg:rounded-t-none z-50" ]

--- a/src/elm/View/Components.elm
+++ b/src/elm/View/Components.elm
@@ -514,10 +514,10 @@ keyListener { acceptedKeys, toMsg, stopPropagation, preventDefault } =
         []
 
 
-focusTrap : { firstFocusContainer : Maybe String } -> List (Html.Attribute msg) -> List (Html msg) -> Html msg
-focusTrap { firstFocusContainer } attrs children =
+focusTrap : { initialFocusId : Maybe String } -> List (Html.Attribute msg) -> List (Html msg) -> Html msg
+focusTrap { initialFocusId } attrs children =
     node "focus-trap"
-        (optionalAttr "first-focus-container" firstFocusContainer :: attrs)
+        (optionalAttr "initial-focus-id" initialFocusId :: attrs)
         children
 
 

--- a/src/elm/View/Modal.elm
+++ b/src/elm/View/Modal.elm
@@ -34,6 +34,7 @@ and call `toHtml` at the end of the pipeline:
 
 import Html exposing (Html, button, div, h3, text)
 import Html.Attributes exposing (class, tabindex)
+import Html.Attributes.Aria exposing (ariaHidden)
 import Icons
 import Utils exposing (onClickNoBubble, onClickPreventAll)
 import View.Components
@@ -200,9 +201,16 @@ viewModalDetails options =
             , onClickPreventAll options.closeMsg
             ]
             options.preventScrolling
-        , View.Components.focusTrap { firstFocusContainer = Just ".modal-body, .modal-body-lg, .modal-footer" }
+        , View.Components.focusTrap { initialFocusId = Just "modal-first-focus" }
             (class content :: options.attrs)
             [ header
+            , button
+                [ Html.Attributes.id "modal-first-focus"
+                , tabindex -1
+                , class "sr-only"
+                , ariaHidden True
+                ]
+                []
             , body
             , footer
             ]

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -358,6 +358,10 @@ https://tailwindcss.com/docs/adding-new-utilities */
     flex-basis: 0;
   }
 
+  .max-w-screen {
+    max-width: 100vw;
+  }
+
   .fill-mode-none {
     animation-fill-mode: none;
   }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -259,8 +259,6 @@ body > * {
 }
 
 .modal-content-full {
-  @apply overflow-auto;
-
   max-height: 95%;
 }
 


### PR DESCRIPTION
## What issue does this PR close
Closes N/A. Fixes bugs reported by @juramos-2020 and @heltonlr on Slack:
- https://cambiatus.slack.com/archives/CA83HJAAD/p1658964275935869
- https://cambiatus.slack.com/archives/CA83HJAAD/p1659030193701669

## Changes Proposed ( a list of new changes introduced by this PR)
Break words when displaying markdown

## How to test ( a list of instructions on how to test this PR)
Create something in a rich text editor with long words that would normally not fit on your screen. Here's a list of all of the rich text we display:

- Action card (How to earn page and search)
- Claim modal (accessible by action card)
- Claim card (analysis page and my claims page)
- Community card (about community page)
- Objective accordion (How to earn page)
- Admin objective accordion (Objectives and actions settings page)
- Admin action card (Objetives and actions settings page)
- Sponsorship thank you text
- Claim details page (accessible through the analysis and my claims pages)
- Join page
- News
- Profile
- Shop items
- Transfers
