### PR TITLE
Enhancement/analysis page masonry

### DIFF
--- a/src/customElements/masonryLayout.js
+++ b/src/customElements/masonryLayout.js
@@ -21,7 +21,7 @@ export default () => (
       window.addEventListener('resize', this.resizeItems)
 
       this.domNodeListener = (e) => {
-        this.resizeItem(e.target);
+        this.resizeItem(e.target)
       }
 
       this.addEventListener('DOMNodeInserted', this.domNodeListener)

--- a/src/customElements/masonryLayout.js
+++ b/src/customElements/masonryLayout.js
@@ -19,10 +19,17 @@ export default () => (
         image.addEventListener('load', () => this.resizeItems()))
 
       window.addEventListener('resize', this.resizeItems)
+
+      this.domNodeListener = (e) => {
+        this.resizeItem(e.target);
+      }
+
+      this.addEventListener('DOMNodeInserted', this.domNodeListener)
     }
 
     disconnectedCallback () {
       window.removeEventListener('resize', this.resizeItems)
+      this.removeEventListener('DOMNodeInserted', this.domNodeListener)
     }
 
     transitionWithParent () {
@@ -53,6 +60,10 @@ export default () => (
     }
 
     resizeItem (item) {
+      if (!item || !item.getBoundingClientRect) {
+        return
+      }
+
       const rowGap = parseInt(window.getComputedStyle(this).getPropertyValue('grid-row-gap'))
       const rowHeight = parseInt(window.getComputedStyle(this).getPropertyValue('grid-auto-rows'))
       const currentHeight = item.getBoundingClientRect().height

--- a/src/elm/Claim.elm
+++ b/src/elm/Claim.elm
@@ -408,8 +408,8 @@ updateProfileSummaries externalMsg claimProfileSummaries =
 
 {-| Claim card with a short claim overview. Used on Dashboard and Analysis pages.
 -}
-viewClaimCard : LoggedIn.Model -> ClaimProfileSummaries -> Model -> Html Msg
-viewClaimCard loggedIn profileSummaries claim =
+viewClaimCard : List (Html.Attribute Msg) -> LoggedIn.Model -> ClaimProfileSummaries -> Model -> Html Msg
+viewClaimCard attributes loggedIn profileSummaries claim =
     let
         { t, tr } =
             loggedIn.shared.translators
@@ -454,7 +454,7 @@ viewClaimCard loggedIn profileSummaries claim =
             else
                 tr "claim.days_ago" [ ( "day_count", String.fromInt claimAging ) ]
     in
-    div [ class "w-full sm:w-1/2 lg:w-1/3 xl:w-1/4 px-2" ]
+    div attributes
         [ viewClaimModal loggedIn profileSummaries claim
         , div
             [ class "flex flex-col p-4 my-2 rounded-lg bg-white hover:shadow cursor-pointer"

--- a/src/elm/Page/Dashboard/Analysis.elm
+++ b/src/elm/Page/Dashboard/Analysis.elm
@@ -228,7 +228,7 @@ viewContent loggedIn { claims, profileSummaries, pageInfo } model =
         (if List.length claims > 0 then
             [ View.Components.masonryLayout [ View.Components.Sm ]
                 { transitionWithParent = False }
-                [ class "grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-x-4 mb-4" ]
+                [ class "grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-x-4 mb-4 sm:auto-rows-[5px]" ]
                 (List.map3 viewClaim
                     profileSummaries
                     (List.range 0 (List.length claims))

--- a/src/elm/Page/Dashboard/Analysis.elm
+++ b/src/elm/Page/Dashboard/Analysis.elm
@@ -228,7 +228,7 @@ viewContent loggedIn { claims, profileSummaries, pageInfo } model =
         (if List.length claims > 0 then
             [ View.Components.masonryLayout [ View.Components.Sm ]
                 { transitionWithParent = False }
-                [ class "grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-x-4 mb-4" ]
+                [ class "grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-x-4 mb-4" ]
                 (List.map3 viewClaim
                     profileSummaries
                     (List.range 0 (List.length claims))

--- a/src/elm/Page/Dashboard/Analysis.elm
+++ b/src/elm/Page/Dashboard/Analysis.elm
@@ -221,24 +221,25 @@ viewContent : LoggedIn.Model -> LoadedModel -> Model -> List (Html Msg)
 viewContent loggedIn { claims, profileSummaries, pageInfo } model =
     let
         viewClaim profileSummary claimIndex claim =
-            Claim.viewClaimCard loggedIn profileSummary claim
+            Claim.viewClaimCard [ class "w-full self-start" ] loggedIn profileSummary claim
                 |> Html.map (ClaimMsg claimIndex)
     in
     [ div [ class "container mx-auto px-4 mb-10" ]
-        [ if List.length claims > 0 then
-            div []
-                [ div [ class "flex flex-wrap -mx-2" ]
-                    (List.map3 viewClaim
-                        profileSummaries
-                        (List.range 0 (List.length claims))
-                        claims
-                    )
-                , viewPagination loggedIn pageInfo
-                ]
+        (if List.length claims > 0 then
+            [ View.Components.masonryLayout [ View.Components.Sm ]
+                { transitionWithParent = False }
+                [ class "grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-x-4 mb-4" ]
+                (List.map3 viewClaim
+                    profileSummaries
+                    (List.range 0 (List.length claims))
+                    claims
+                )
+            , viewPagination loggedIn pageInfo
+            ]
 
-          else
-            viewEmptyResults loggedIn
-        ]
+         else
+            [ viewEmptyResults loggedIn ]
+        )
     , let
         viewVoteModal claimId isApproving isLoading =
             Claim.viewVoteClaimModal

--- a/src/elm/Page/Profile/Claims.elm
+++ b/src/elm/Page/Profile/Claims.elm
@@ -26,7 +26,6 @@ import Graphql.SelectionSet exposing (SelectionSet)
 import Html exposing (Html, a, button, div, img, li, text, ul)
 import Html.Attributes exposing (class, classList, src)
 import Html.Events exposing (onClick)
-import Html.Keyed
 import Icons
 import Json.Decode as Decode exposing (Value)
 import Json.Encode as Encode
@@ -38,6 +37,7 @@ import Session.LoggedIn as LoggedIn
 import Session.Shared exposing (Shared)
 import Time
 import UpdateResult as UR
+import View.Components
 import View.Feedback as Feedback
 import View.Modal as Modal
 import View.TabSelector
@@ -348,7 +348,7 @@ viewResults loggedIn profileSummaries claims model =
     let
         viewClaim profileSummary claimIndex claim =
             ( String.fromInt claim.id
-            , Claim.viewClaimCard [ class "w-full sm:w-1/2 lg:w-1/3 xl:w-1/4 px-2" ] loggedIn profileSummary claim
+            , Claim.viewClaimCard [ class "w-full self-start" ] loggedIn profileSummary claim
                 |> Html.map (ClaimMsg claimIndex)
             )
 
@@ -365,7 +365,9 @@ viewResults loggedIn profileSummaries claims model =
     in
     div [ class "container mx-auto px-4 mb-10" ]
         [ if List.length claimsList > 0 then
-            Html.Keyed.ul [ class "flex flex-wrap -mx-2 pt-4" ]
+            View.Components.keyedMasonryLayout [ View.Components.Sm ]
+                { transitionWithParent = False }
+                [ class "grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-x-4 mb-4" ]
                 (claimsList
                     |> orderFunction
                     |> List.map3 viewClaim

--- a/src/elm/Page/Profile/Claims.elm
+++ b/src/elm/Page/Profile/Claims.elm
@@ -367,7 +367,7 @@ viewResults loggedIn profileSummaries claims model =
         [ if List.length claimsList > 0 then
             View.Components.keyedMasonryLayout [ View.Components.Sm ]
                 { transitionWithParent = False }
-                [ class "grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-x-4 mb-4" ]
+                [ class "grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-x-4 mb-4 sm:auto-rows-[5px]" ]
                 (claimsList
                     |> orderFunction
                     |> List.map3 viewClaim

--- a/src/elm/Page/Profile/Claims.elm
+++ b/src/elm/Page/Profile/Claims.elm
@@ -348,7 +348,7 @@ viewResults loggedIn profileSummaries claims model =
     let
         viewClaim profileSummary claimIndex claim =
             ( String.fromInt claim.id
-            , Claim.viewClaimCard loggedIn profileSummary claim
+            , Claim.viewClaimCard [ class "w-full sm:w-1/2 lg:w-1/3 xl:w-1/4 px-2" ] loggedIn profileSummary claim
                 |> Html.map (ClaimMsg claimIndex)
             )
 

--- a/src/elm/View/Components.elm
+++ b/src/elm/View/Components.elm
@@ -1,6 +1,6 @@
 module View.Components exposing
     ( loadingLogoAnimated, loadingLogoAnimatedFluid, loadingLogoWithCustomText, loadingLogoWithNoText
-    , dialogBubble, masonryLayout, Breakpoint(..)
+    , dialogBubble, masonryLayout, keyedMasonryLayout, Breakpoint(..)
     , tooltip, pdfViewer, PdfViewerFileType(..), dateViewer, infiniteList, ElementToTrack(..), label, disablableLink
     , bgNoScroll, PreventScroll(..), keyListener, Key(..), focusTrap, intersectionObserver, pointerListener
     )
@@ -16,7 +16,7 @@ state or configuration, such as loading indicators and containers
 
 # Containers
 
-@docs dialogBubble, masonryLayout, Breakpoint
+@docs dialogBubble, masonryLayout, keyedMasonryLayout, Breakpoint
 
 
 ## Helper types
@@ -38,6 +38,7 @@ state or configuration, such as loading indicators and containers
 import Html exposing (Html, div, img, node, p, span, text)
 import Html.Attributes exposing (attribute, class, for, src)
 import Html.Events exposing (on)
+import Html.Keyed
 import Icons
 import Json.Decode
 import Time
@@ -107,6 +108,8 @@ magic. If you're changing `gap-y` or `auto-rows`, test it very well, since the
 accuracy of this component depends on those properties. If you want vertical
 gutters, give each child element a `mb-*` class and this element a negative bottom margin.
 
+If the elements are buggy, try to include `self-start` in them.
+
 You must provide at least one `Breakpoint` to specify screen sizes this should
 work as a masonry layout.
 
@@ -117,7 +120,41 @@ masonryLayout :
     -> List (Html.Attribute msg)
     -> List (Html msg)
     -> Html msg
-masonryLayout breakpoints { transitionWithParent } attrs children =
+masonryLayout breakpoints transitionWithParent attrs children =
+    node "masonry-layout"
+        (masonryLayoutAttributes breakpoints transitionWithParent attrs)
+        children
+
+
+{-| Create a masonry layout, similar to Pinterest. This uses CSS Grid + some JS
+magic. If you're changing `gap-y` or `auto-rows`, test it very well, since the
+accuracy of this component depends on those properties. If you want vertical
+gutters, give each child element a `mb-*` class and this element a negative bottom margin.
+
+If the elements are buggy, try to include `self-start` in them.
+
+You must provide at least one `Breakpoint` to specify screen sizes this should
+work as a masonry layout.
+
+-}
+keyedMasonryLayout :
+    List Breakpoint
+    -> { transitionWithParent : Bool }
+    -> List (Html.Attribute msg)
+    -> List ( String, Html msg )
+    -> Html msg
+keyedMasonryLayout breakpoints transitionWithParent attrs children =
+    Html.Keyed.node "masonry-layout"
+        (masonryLayoutAttributes breakpoints transitionWithParent attrs)
+        children
+
+
+masonryLayoutAttributes :
+    List Breakpoint
+    -> { transitionWithParent : Bool }
+    -> List (Html.Attribute msg)
+    -> List (Html.Attribute msg)
+masonryLayoutAttributes breakpoints { transitionWithParent } attrs =
     let
         classesForBreakpoint breakpoint =
             case breakpoint of
@@ -131,15 +168,12 @@ masonryLayout breakpoints { transitionWithParent } attrs children =
                 Xl ->
                     "xl:gap-y-0 xl:grid xl:auto-rows-[1px]"
     in
-    node "masonry-layout"
-        ((List.map classesForBreakpoint breakpoints
-            |> String.join " "
-            |> class
-         )
-            :: attribute "elm-transition-with-parent" (boolToString transitionWithParent)
-            :: attrs
-        )
-        children
+    (List.map classesForBreakpoint breakpoints
+        |> String.join " "
+        |> class
+    )
+        :: attribute "elm-transition-with-parent" (boolToString transitionWithParent)
+        :: attrs
 
 
 


### PR DESCRIPTION
## What issue does this PR close
Closes #795 

## Changes Proposed ( a list of new changes introduced by this PR)
- Use masonry layout in analysis page
- Use masonry layout in "My claims" page

## How to test ( a list of instructions on how to test this PR)
- Go to the analysis page (`/dashboard/analysis`) and see the new layout, with differently-sized cards fitting into each other
- Do the same in the "My claims" page (`/profile/:username/claims`)