### PR TITLE
Fix/null community logo

### DIFF
--- a/src/elm/Cambiatus/Mutation.elm
+++ b/src/elm/Cambiatus/Mutation.elm
@@ -264,7 +264,7 @@ type alias PreferenceOptionalArguments =
     }
 
 
-{-| [Auth required] A mutation to only the preferences of the logged user
+{-| [Auth required] A mutation to set the preferences of the logged user
 -}
 preference :
     (PreferenceOptionalArguments -> PreferenceOptionalArguments)

--- a/src/elm/Cambiatus/Object/Community.elm
+++ b/src/elm/Cambiatus/Object/Community.elm
@@ -150,9 +150,9 @@ issuer =
     Object.selectionForField "(Maybe String)" "issuer" [] (Decode.string |> Decode.nullable)
 
 
-logo : SelectionSet String Cambiatus.Object.Community
+logo : SelectionSet (Maybe String) Cambiatus.Object.Community
 logo =
-    Object.selectionForField "String" "logo" [] Decode.string
+    Object.selectionForField "(Maybe String)" "logo" [] (Decode.string |> Decode.nullable)
 
 
 maxSupply : SelectionSet (Maybe Float) Cambiatus.Object.Community

--- a/src/elm/Cambiatus/Object/CommunityPreview.elm
+++ b/src/elm/Cambiatus/Object/CommunityPreview.elm
@@ -44,9 +44,9 @@ hasShop =
     Object.selectionForField "Bool" "hasShop" [] Decode.bool
 
 
-logo : SelectionSet String Cambiatus.Object.CommunityPreview
+logo : SelectionSet (Maybe String) Cambiatus.Object.CommunityPreview
 logo =
-    Object.selectionForField "String" "logo" [] Decode.string
+    Object.selectionForField "(Maybe String)" "logo" [] (Decode.string |> Decode.nullable)
 
 
 memberCount : SelectionSet Int Cambiatus.Object.CommunityPreview

--- a/src/elm/Community.elm
+++ b/src/elm/Community.elm
@@ -57,6 +57,7 @@ import Cambiatus.Query as Query
 import Cambiatus.Scalar exposing (DateTime(..))
 import Cambiatus.Subscription as Subscription
 import Community.News
+import Constants
 import Contact
 import Eos
 import Eos.Account as Eos
@@ -332,7 +333,7 @@ communitiesSelectionSet =
         |> with Community.name
         |> with Community.description
         |> with (Eos.symbolSelectionSet Community.symbol)
-        |> with Community.logo
+        |> with (SelectionSet.withDefault Constants.defaultCommunityLogo Community.logo)
         |> with (Eos.nameSelectionSet Community.creator)
         |> with Community.memberCount
 
@@ -343,7 +344,7 @@ communitySelectionSet =
         |> with Community.name
         |> with (Markdown.selectionSet Community.description)
         |> with (Eos.symbolSelectionSet Community.symbol)
-        |> with Community.logo
+        |> with (SelectionSet.withDefault Constants.defaultCommunityLogo Community.logo)
         |> with (Community.subdomain Subdomain.name |> SelectionSet.map (Maybe.withDefault ""))
         |> with (Eos.nameSelectionSet Community.creator)
         |> with Community.inviterReward

--- a/src/elm/Community.elm
+++ b/src/elm/Community.elm
@@ -807,7 +807,7 @@ communityPreviewSelectionSet =
     SelectionSet.succeed CommunityPreview
         |> with CommunityPreview.name
         |> with (Markdown.selectionSet CommunityPreview.description)
-        |> with CommunityPreview.logo
+        |> with (SelectionSet.withDefault Constants.defaultCommunityLogo CommunityPreview.logo)
         |> with (Eos.symbolSelectionSet CommunityPreview.symbol)
         |> with (CommunityPreview.subdomain Subdomain.name |> SelectionSet.map (Maybe.withDefault ""))
         |> with CommunityPreview.hasShop

--- a/src/elm/Constants.elm
+++ b/src/elm/Constants.elm
@@ -1,0 +1,14 @@
+module Constants exposing (defaultCommunityLogo)
+
+{-| Here's where we store some constants that we can use in the app.
+
+It's usually better to have them in the module they make more sense in. For
+example, `defaultCommunityLogo` would be better in `Community.elm`, but if we
+put it there, we'd have some import cycles. We can use this module to avoid that.
+
+-}
+
+
+defaultCommunityLogo : String
+defaultCommunityLogo =
+    "https://cambiatus-uploads.s3.amazonaws.com/cambiatus-uploads/community_2.png"

--- a/src/elm/Notification.elm
+++ b/src/elm/Notification.elm
@@ -25,6 +25,7 @@ import Cambiatus.Query as Query
 import Cambiatus.Scalar exposing (DateTime(..))
 import Cambiatus.Union
 import Cambiatus.Union.NotificationType
+import Constants
 import Eos
 import Eos.Account as Eos
 import Graphql.Operation exposing (RootMutation, RootQuery)
@@ -194,6 +195,6 @@ saleHistorySelectionSet =
 logoSelectionSet : SelectionSet Community Cambiatus.Object.Community
 logoSelectionSet =
     SelectionSet.succeed Community
-        |> with Community.logo
+        |> with (SelectionSet.withDefault Constants.defaultCommunityLogo Community.logo)
         |> with (Eos.symbolSelectionSet Community.symbol)
         |> with (Community.subdomain Subdomain.name |> SelectionSet.map (Maybe.withDefault ""))

--- a/src/elm/Profile.elm
+++ b/src/elm/Profile.elm
@@ -35,6 +35,7 @@ import Cambiatus.Object.Subdomain as Subdomain
 import Cambiatus.Object.User as User
 import Cambiatus.Query
 import Cambiatus.Scalar exposing (DateTime(..), Id(..))
+import Constants
 import Dict exposing (Dict)
 import Eos exposing (Symbol)
 import Eos.Account as Eos
@@ -198,7 +199,7 @@ communityInfoSelectionSet =
     SelectionSet.succeed CommunityInfo
         |> with (Eos.symbolSelectionSet Community.symbol)
         |> with Community.name
-        |> with Community.logo
+        |> with (SelectionSet.withDefault Constants.defaultCommunityLogo Community.logo)
         |> with (Community.subdomain Subdomain.name |> SelectionSet.map (Maybe.withDefault ""))
         |> with Community.hasShop
         |> with Community.hasObjectives


### PR DESCRIPTION
## What issue does this PR close
Closes #810 

## Changes Proposed ( a list of new changes introduced by this PR)
- Update graphql schema
- Create a `Constants.elm` module, to hold the default community logo
- Update selectionsets so that the app compiles

## How to test ( a list of instructions on how to test this PR)
You can set a community's logo as null on staging, and check that that community shows the default logo.