### PR TITLE
Fix/category-creation-position

### DIFF
--- a/src/elm/Shop/Category.elm
+++ b/src/elm/Shop/Category.elm
@@ -44,6 +44,7 @@ type alias Model =
     , metaTitle : Maybe String
     , metaDescription : Maybe String
     , metaKeywords : List String
+    , position : Int
     }
 
 
@@ -54,10 +55,11 @@ create :
     , slug : Slug
     , image : Maybe String
     , parentId : Maybe Id
+    , position : Int
     }
     -> SelectionSet decodesTo Cambiatus.Object.Category
     -> SelectionSet (Maybe decodesTo) RootMutation
-create { icon, name, slug, description, image, parentId } =
+create { icon, name, slug, description, image, parentId, position } =
     Cambiatus.Mutation.category
         (\optionals ->
             { optionals
@@ -70,7 +72,7 @@ create { icon, name, slug, description, image, parentId } =
                 , name = OptionalArgument.Present name
                 , description = OptionalArgument.Present (Markdown.toRawString description)
                 , imageUri = OptionalArgument.fromMaybe image
-                , position = OptionalArgument.Present 0
+                , position = OptionalArgument.Present position
             }
         )
 
@@ -181,6 +183,7 @@ selectionSet =
                         >> Maybe.withDefault []
                     )
             )
+        |> SelectionSet.with Cambiatus.Object.Category.position
 
 
 
@@ -212,7 +215,7 @@ treesSelectionSet categoriesSelectionSet =
                             Nothing
                     )
                     children
-                    |> List.sortBy (Tree.label >> .name)
+                    |> List.sortBy (Tree.label >> .position)
                 )
     in
     categoriesSelectionSet selectionSet
@@ -227,7 +230,7 @@ treesSelectionSet categoriesSelectionSet =
                             Nothing
                     )
                     allCategories
-                    |> List.sortBy (Tree.label >> .name)
+                    |> List.sortBy (Tree.label >> .position)
             )
 
 


### PR DESCRIPTION
## What issue does this PR close
Closes N/A. We're talking about this on Slack: https://cambiatus.slack.com/archives/CA83HJAAD/p1660676306254949 and https://cambiatus.slack.com/archives/CA83HJAAD/p1660648202151329

## Changes Proposed ( a list of new changes introduced by this PR)
- Send the correct position (instead of always sending 0)
- Order categories by position

## How to test ( a list of instructions on how to test this PR)
Try to create new categories!