### PR TITLE
Enhancement/12 words sanitize

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@tailwindcss/forms": "^0.4.0",
     "@tailwindcss/line-clamp": "^0.3.1",
     "babel-runtime": "^6.26.0",
-    "bip39": "^2.6.0",
+    "bip39": "^3.0.4",
     "copy-webpack-plugin": "^5.0.4",
     "create-elm-app": "^4.0.0",
     "css-loader": "^0.28.9",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@tailwindcss/forms": "^0.4.0",
     "@tailwindcss/line-clamp": "^0.3.1",
     "babel-runtime": "^6.26.0",
-    "bip39": "^2.5.0",
+    "bip39": "^2.6.0",
     "copy-webpack-plugin": "^5.0.4",
     "create-elm-app": "^4.0.0",
     "css-loader": "^0.28.9",

--- a/public/translations/amh-ETH.json
+++ b/public/translations/amh-ETH.json
@@ -173,6 +173,8 @@
           "notPassphraseError": "እባኮን , 12 ቃላትን ያስገቡ",
           "notLatinLettersError": "እባኮን , የላትን ፊደል ብቻ ይጠቀሙ",
           "atLeastThreeLettersError": "ሁሉም ቃላት ቢያንስ 3 ፊደል ያላቸዉ መሆን አለበት",
+          "invalid_word": "{{word}} ትክክለኛ ቃል አይደለም። የእርስዎን 12 ቃላት ይፈትሹ እና እንደገና ይሞክሩ።",
+          "invalid_words": "እነዚህ ቃላት ልክ አይደሉም፡ {{words}}። የእርስዎን 12 ቃላት ይፈትሹ እና እንደገና ይሞክሩ።",
           "paste": "ለጥፍ",
           "pasted": "ተለጠፈ"
         }

--- a/public/translations/cat-CAT.json
+++ b/public/translations/cat-CAT.json
@@ -207,6 +207,8 @@
           "notPassphraseError": "Introduïu 12 paraules",
           "notLatinLettersError": "Si us plau, utilitzeu només lletres bàsiques llatines",
           "atLeastThreeLettersError": "Totes les paraules han de tenir almenys 3 lletres",
+          "invalid_word": "{{word}} no és una paraula vàlida. Comprova les teves 12 paraules i torna-ho a provar.",
+          "invalid_words": "Aquestes paraules no són vàlides: {{words}}. Comprova les teves 12 paraules i torna-ho a provar.",
           "paste": "Enganxa",
           "pasted": "Enganxat"
         }

--- a/public/translations/en-US.json
+++ b/public/translations/en-US.json
@@ -207,6 +207,8 @@
           "notPassphraseError": "Please, enter 12 words",
           "notLatinLettersError": "Please, use only basic Latin letters",
           "atLeastThreeLettersError": "All words should have at least 3 letters",
+          "invalid_word": "{{word}} is not a valid word. Check your 12 words and try again.",
+          "invalid_words": "These words are not valid: {{words}}. Check your 12 words and try again.",
           "paste": "Paste",
           "pasted": "Pasted"
         }

--- a/public/translations/es-ES.json
+++ b/public/translations/es-ES.json
@@ -207,6 +207,8 @@
           "notPassphraseError": "Por favor, ingrese sus 12 palabras",
           "notLatinLettersError": "Por favor, use solo letras",
           "atLeastThreeLettersError": "Todas las palabras deben tener al menos 3 letras.",
+          "invalid_word": "{{word}} no es una palabra válida. Revisa tus 12 palabras e inténtalo de nuevo.",
+          "invalid_words": "Estas palabras no son válidas: {{words}}. Revisa tus 12 palabras e inténtalo de nuevo.",
           "paste": "Pegar",
           "pasted": "Pegado"
         }

--- a/public/translations/pt-BR.json
+++ b/public/translations/pt-BR.json
@@ -212,6 +212,8 @@
           "notPassphraseError": "Por favor, digite 12 palavras",
           "notLatinLettersError": "Por favor, use apenas letras",
           "atLeastThreeLettersError": "Todas as palavras devem ter ao menos 3 letras",
+          "invalid_word": "{{word}} não é uma palavra válida. Verifique suas 12 palavras e tente novamente",
+          "invalid_words": "Essas palavras não são válidas: {{words}}. Verifique suas 12 palavras e tente novamente",
           "paste": "Colar",
           "pasted": "Colado"
         }

--- a/src/elm/Form.elm
+++ b/src/elm/Form.elm
@@ -5,7 +5,7 @@ module Form exposing
     , textField, richText, toggle, checkbox, radio, select, file, fileMultiple, datePicker, userPicker, userPickerMultiple, arbitrary, arbitraryWith, unsafeArbitrary
     , view, viewWithoutSubmit, Model, init, Msg, update, updateValues, getValue, hasFieldsLoading, msgToString
     , withDisabled
-    , isDisabled
+    , isDisabled, isShowingAllErrors
     , parse
     )
 
@@ -93,7 +93,7 @@ documentation if you're stuck.
 
 ### Checking attributes and state
 
-@docs isDisabled
+@docs isDisabled, isShowingAllErrors
 
 
 ## Validating
@@ -1030,6 +1030,18 @@ the form is disabled.
 isDisabled : Model values -> Bool
 isDisabled (Model model) =
     model.disabled
+
+
+{-| Checks if the form is showing all errors. This will be true after the user
+tried to submit the form. It can be useful to conditionally validate the form.
+-}
+isShowingAllErrors : Model values -> Bool
+isShowingAllErrors (Model model) =
+    let
+        (ErrorTracking errorTracking) =
+            model.errorTracking
+    in
+    errorTracking.showAllErrors
 
 
 {-| Determines which errors we should show. This is opaque so it can't be

--- a/src/elm/Form/Text.elm
+++ b/src/elm/Form/Text.elm
@@ -1,7 +1,7 @@
 module Form.Text exposing
     ( init, Options
     , withPlaceholder, withElements, withCurrency, withCounter, Counter(..)
-    , withDisabled, withCounterAttrs, withErrorAttrs, withExtraAttrs, withContainerAttrs, withLabelAttrs
+    , withDisabled, withCounterAttrs, withErrorAttrs, withExtraAttrs, withContainerAttrs, withInputContainerAttrs, withLabelAttrs
     , withType, asNumeric, withInputElement, InputType(..), InputElement(..)
     , withMask, withAllowedChars
     , getId, getErrorAttrs, getSubmitOnEnter
@@ -34,7 +34,7 @@ placeholders, localization and character counters. Use it within a `Form.Form`:
 
 ## Adding attributes
 
-@docs withDisabled, withCounterAttrs, withErrorAttrs, withExtraAttrs, withContainerAttrs, withLabelAttrs
+@docs withDisabled, withCounterAttrs, withErrorAttrs, withExtraAttrs, withContainerAttrs, withInputContainerAttrs, withLabelAttrs
 
 
 ## Changing types
@@ -82,6 +82,7 @@ type Options msg
         , labelAttrs : List (Html.Attribute msg)
         , extraAttrs : List (Html.Attribute msg)
         , containerAttrs : List (Html.Attribute msg)
+        , inputContainerAttrs : List (Html.Attribute msg)
         , extraElements : List (ViewConfig msg -> Html msg)
         , errorAttrs : List (Html.Attribute msg)
         , counterAttrs : List (Html.Attribute msg)
@@ -106,6 +107,7 @@ init { label, id } =
         , labelAttrs = []
         , extraAttrs = []
         , containerAttrs = []
+        , inputContainerAttrs = []
         , errorAttrs = []
         , counterAttrs = []
         , extraElements = []
@@ -311,6 +313,13 @@ withContainerAttrs attrs (Options options) =
     Options { options | containerAttrs = options.containerAttrs ++ attrs }
 
 
+{-| Adds attributes to the element that contains the input
+-}
+withInputContainerAttrs : List (Html.Attribute msg) -> Options msg -> Options msg
+withInputContainerAttrs attrs (Options options) =
+    Options { options | inputContainerAttrs = options.inputContainerAttrs ++ attrs }
+
+
 {-| Adds attributes to the field error
 -}
 withErrorAttrs : List (Html.Attribute msg) -> Options msg -> Options msg
@@ -493,7 +502,7 @@ viewInput (Options options) ({ onChange, value, hasError, onBlur, translators, i
                     , Html.text ""
                     )
     in
-    div [ class "relative" ]
+    div (class "relative" :: options.inputContainerAttrs)
         (inputElement
             (id options.id
                 :: onInput (beforeChangeEvent >> onChange)

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -1392,7 +1392,7 @@ changeRouteTo maybeRoute model =
 
         Just (Route.Login maybeInvitation maybeRedirect) ->
             Login.init
-                >> updateStatusWith (Login maybeRedirect) GotLoginMsg model
+                >> updateGuestUResult (Login maybeRedirect) GotLoginMsg model
                 |> withGuest maybeInvitation maybeRedirect
 
         Just (Route.News config) ->

--- a/src/elm/Page/Login.elm
+++ b/src/elm/Page/Login.elm
@@ -720,7 +720,8 @@ passphraseValidator =
             else
                 Err (\translators_ -> translators_.t "auth.login.wordsMode.input.atLeastThreeLettersError")
     in
-    Form.Validate.custom has12Words
+    Form.Validate.map String.toLower
+        >> Form.Validate.custom has12Words
         >> Form.Validate.custom wordsHave3Letters
         >> Form.Validate.map Passphrase
 

--- a/src/elm/Page/Login.elm
+++ b/src/elm/Page/Login.elm
@@ -132,7 +132,7 @@ passphraseForm ({ translators } as shared) { hasPasted, hasTriedSubmitting } =
         viewPasteButton =
             if shared.canReadClipboard then
                 button
-                    [ class "absolute bottom-4 left-1/2 -translate-x-1/2 button"
+                    [ class "absolute bottom-4 left-1/2 -translate-x-1/2 button z-10"
                     , classList
                         [ ( "button-secondary", not hasPasted )
                         , ( "button-primary", hasPasted )

--- a/src/elm/Session/Shared.elm
+++ b/src/elm/Session/Shared.elm
@@ -1,5 +1,6 @@
 module Session.Shared exposing
-    ( Shared
+    ( Bip39Status(..)
+    , Shared
     , TranslationStatus(..)
     , Translators
     , init
@@ -25,6 +26,7 @@ import Html.Events exposing (onClick)
 import Http
 import I18Next exposing (Translations, initialTranslations)
 import Ports
+import Set exposing (Set)
 import Time exposing (Posix)
 import Translation
 import Url exposing (Url)
@@ -54,6 +56,12 @@ type alias Shared =
     , selectedCommunity : Maybe Eos.Symbol
     , pinVisibility : Bool
     , hasSeenSponsorModal : Bool
+
+    -- Bip39 is what we use to generate the 12 words to login. We store them in
+    -- Shared so that we don't need more HTTP requests than necessary (or to
+    -- store the words hardcoded into Elm code, increasing the bundle size).
+    -- We use Bip39 in the login page to validate the 12 words
+    , bip39 : Bip39Status
     }
 
 
@@ -96,6 +104,7 @@ init ({ maybeAccount, endpoints, allowCommunityCreation, tokenContract, communit
       , selectedCommunity = flags.selectedCommunity
       , pinVisibility = flags.pinVisibility
       , hasSeenSponsorModal = flags.hasSeenSponsorModal
+      , bip39 = Bip39NotLoaded
       }
     , case environment of
         Environment.Production ->
@@ -104,6 +113,11 @@ init ({ maybeAccount, endpoints, allowCommunityCreation, tokenContract, communit
         _ ->
             Cmd.none
     )
+
+
+type Bip39Status
+    = Bip39Loaded (Set String)
+    | Bip39NotLoaded
 
 
 type TranslationStatus

--- a/src/elm/Session/Shared.elm
+++ b/src/elm/Session/Shared.elm
@@ -116,7 +116,7 @@ init ({ maybeAccount, endpoints, allowCommunityCreation, tokenContract, communit
 
 
 type Bip39Status
-    = Bip39Loaded (Set String)
+    = Bip39Loaded { english : Set String, portuguese : Set String, spanish : Set String }
     | Bip39NotLoaded
 
 

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ import pdfDefinition from './scripts/pdfDefinition'
 import './styles/main.css'
 import pdfFonts from './vfs_fonts'
 import { register as registerCustomElements } from './customElements/index'
+import bip39 from 'bip39'
 
 // =========================================
 // Initial constants
@@ -1417,6 +1418,9 @@ async function handleJavascriptPort (arg) {
       document.querySelector('body').classList.remove(className)
 
       return {}
+    }
+    case 'getBip39': {
+      return { bip39: bip39.wordlists.EN }
     }
     default: {
       return { error: `No treatment found for Elm port ${arg.data.name}` }

--- a/src/index.js
+++ b/src/index.js
@@ -1420,7 +1420,11 @@ async function handleJavascriptPort (arg) {
       return {}
     }
     case 'getBip39': {
-      return { bip39: bip39.wordlists.EN }
+      return {
+        english: bip39.wordlists.english,
+        portuguese: bip39.wordlists.portuguese,
+        spanish: bip39.wordlists.spanish
+      }
     }
     default: {
       return { error: `No treatment found for Elm port ${arg.data.name}` }

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ import pdfDefinition from './scripts/pdfDefinition'
 import './styles/main.css'
 import pdfFonts from './vfs_fonts'
 import { register as registerCustomElements } from './customElements/index'
-import bip39 from 'bip39'
+import { wordlists as bip39Wordlists } from 'bip39'
 
 // =========================================
 // Initial constants
@@ -1421,9 +1421,9 @@ async function handleJavascriptPort (arg) {
     }
     case 'getBip39': {
       return {
-        english: bip39.wordlists.english,
-        portuguese: bip39.wordlists.portuguese,
-        spanish: bip39.wordlists.spanish
+        english: bip39Wordlists.english,
+        portuguese: bip39Wordlists.portuguese,
+        spanish: bip39Wordlists.spanish
       }
     }
     default: {

--- a/src/scripts/mnemonic.js
+++ b/src/scripts/mnemonic.js
@@ -1,20 +1,4 @@
-import bip39 from 'bip39'
-import ecc from 'eosjs-ecc'
-import scrypt from 'scrypt-async'
-
-/***
- * Generates a mnemonic from a string
- * @param password
- */
-function generateFrom (password) {
-  return new Promise(resolve => {
-    hash(password).then(hash => {
-      const mnemonic = bip39.entropyToMnemonic(hash)
-
-      resolve([mnemonic, bip39.mnemonicToSeedHex(mnemonic)])
-    })
-  })
-}
+import * as bip39 from 'bip39'
 
 /***
  * Generates a random mnemonic
@@ -37,11 +21,11 @@ function generateRandom (userLocale) {
       break;
   }
 
-  const strength = null
-  const rng = null
+  const strength = undefined
+  const rng = undefined
 
   const mnemonic = bip39.generateMnemonic(strength, rng, wordlist)
-  return [mnemonic, bip39.mnemonicToSeedHex(mnemonic)]
+  return [mnemonic, toSeedHex(mnemonic)]
 }
 
 /**
@@ -49,71 +33,7 @@ function generateRandom (userLocale) {
  * @param {} mnemonic
  */
 function toSeedHex (mnemonic) {
-  return bip39.mnemonicToSeedHex(mnemonic)
-}
-
-/**
- * Hashes a text using a random salt
- * @param {} text
- */
-function hash (text) {
-  hashWithSalt(text, newSalt())
-}
-
-/***
- * Hashes a text using salt
- * @param text
- * @returns {Promise(string)}
- */
-function hashWithSalt (text, salt) {
-  return new Promise(async resolve => {
-    // We don't need a salt here, because this is a non-saved(!) hash,
-    // which is used to create a seed that is used to encrypt
-    // the keychain using AES which has it's own salt.
-    scrypt(
-      text,
-      salt,
-      {
-        N: 16384,
-        r: 8,
-        p: 1,
-        dkLen: 16,
-        encoding: 'hex'
-      },
-      derivedKey => {
-        resolve(derivedKey)
-      }
-    )
-  })
-}
-
-// =========================================
-// Generators
-// =========================================
-
-function newSalt () {
-  return ecc.sha256(text(32))
-}
-
-function rand () {
-  const arr = new Uint32Array(1)
-  window.crypto.getRandomValues(arr)
-  return arr[0] / (0xffffffff + 1)
-}
-
-/***
- * Generates a random string of specified size
- * @param size - The length of the string to generate
- * @returns {string} - The generated random string
- */
-function text (length) {
-  let text = ''
-  const possible =
-    'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
-  for (let i = 0; i < length; i++) {
-    text += possible.charAt(Math.floor(rand() * possible.length))
-  }
-  return text
+  return bip39.mnemonicToSeedSync(mnemonic).toString('hex')
 }
 
 // =========================================
@@ -121,9 +41,6 @@ function text (length) {
 // =========================================
 
 export default {
-  generateFrom,
   generateRandom,
   toSeedHex,
-  hash,
-  hashWithSalt
 }

--- a/src/scripts/mnemonic.js
+++ b/src/scripts/mnemonic.js
@@ -18,13 +18,28 @@ function generateFrom (password) {
 
 /***
  * Generates a random mnemonic
- * @param {string} userLang - User's language.
+ * @param {string} userLocale - User's locale.
  * @returns {[string,string]}
  */
-function generateRandom (userLang) {
+function generateRandom (userLocale) {
+  const userLang = userLocale.toLowerCase().split('-')[0]
+
+  let wordlist = bip39.wordlists.english
+  switch (userLang) {
+    case 'es':
+      wordlist = bip39.wordlists.spanish
+      break;
+    case 'pt':
+      wordlist = bip39.wordlists.portuguese
+      break;
+
+    default:
+      break;
+  }
+
   const strength = null
   const rng = null
-  const wordlist = (userLang === 'es') ? bip39.wordlists.spanish : null
+
   const mnemonic = bip39.generateMnemonic(strength, rng, wordlist)
   return [mnemonic, bip39.mnemonicToSeedHex(mnemonic)]
 }

--- a/src/scripts/mnemonic.js
+++ b/src/scripts/mnemonic.js
@@ -6,19 +6,11 @@ import * as bip39 from 'bip39'
  * @returns {[string,string]}
  */
 function generateRandom (userLocale) {
-  const userLang = userLocale.toLowerCase().split('-')[0]
-
   let wordlist = bip39.wordlists.english
-  switch (userLang) {
-    case 'es':
-      wordlist = bip39.wordlists.spanish
-      break;
-    case 'pt':
-      wordlist = bip39.wordlists.portuguese
-      break;
-
-    default:
-      break;
+  if (userLocale.toLowerCase().startsWith('es')) {
+    wordlist = bip39.wordlists.spanish
+  } else if (userLocale.toLowerCase().startsWith('pt')) {
+    wordlist = bip39.wordlists.portuguese
   }
 
   const strength = undefined

--- a/yarn.lock
+++ b/yarn.lock
@@ -1167,6 +1167,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.13.tgz#ee1128e881b874c371374c1f72201893616417c9"
   integrity sha512-rouEWBImiRaSJsVA+ITTFM6ZxibuAlTuNOCyxVbwreu6k6+ujs7DfnU9o+PShFhET78pMBl3eH+AGSI5eOTkPA==
 
+"@types/node@11.11.6":
+  version "11.11.6"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-11.11.6.tgz#df929d1bb2eee5afdda598a41930fe50b43eaa6a"
+  integrity sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ==
+
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz#d3357479a0fdfdd5907fe67e17e0a85c906e1301"
@@ -2185,16 +2190,15 @@ binwrap@^0.2.3:
     tar "^6.1.0"
     unzip-stream "^0.3.1"
 
-bip39@^2.6.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/bip39/-/bip39-2.6.0.tgz#9e3a720b42ec8b3fbe4038f1e445317b6a99321c"
-  integrity sha512-RrnQRG2EgEoqO24ea+Q/fftuPUZLmrEM3qNhhGsA3PbaXaCW791LTzPuVyx/VprXQcTbPJ3K3UeTna8ZnVl2sg==
+bip39@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/bip39/-/bip39-3.0.4.tgz#5b11fed966840b5e1b8539f0f54ab6392969b2a0"
+  integrity sha512-YZKQlb752TrUWqHWj7XAwCSjYEgGAk+/Aas3V7NyjQeZYsztO8JnQUaCWhcnL4T+jL8nvB8typ2jRPzTlgugNw==
   dependencies:
+    "@types/node" "11.11.6"
     create-hash "^1.1.0"
     pbkdf2 "^3.0.9"
     randombytes "^2.0.1"
-    safe-buffer "^5.0.1"
-    unorm "^1.3.3"
 
 bl@^4.1.0:
   version "4.1.0"
@@ -13595,11 +13599,6 @@ universalify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
   integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
-
-unorm@^1.3.3:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/unorm/-/unorm-1.6.0.tgz#029b289661fba714f1a9af439eb51d9b16c205af"
-  integrity sha512-b2/KCUlYZUeA7JFUuRJZPUtr4gZvBh7tavtv4fvk4+KV9pfGiR6CQAQAWl49ZpR3ts2dk4FYkP7EIgDJoiOLDA==
 
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2185,7 +2185,7 @@ binwrap@^0.2.3:
     tar "^6.1.0"
     unzip-stream "^0.3.1"
 
-bip39@^2.5.0:
+bip39@^2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/bip39/-/bip39-2.6.0.tgz#9e3a720b42ec8b3fbe4038f1e445317b6a99321c"
   integrity sha512-RrnQRG2EgEoqO24ea+Q/fftuPUZLmrEM3qNhhGsA3PbaXaCW791LTzPuVyx/VprXQcTbPJ3K3UeTna8ZnVl2sg==
@@ -9765,10 +9765,21 @@ path-type@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-4.0.0.tgz#84ed01c0a7ba380afe09d90a8c180dcd9d03043b"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
-pbkdf2@^3.0.3, pbkdf2@^3.0.9:
+pbkdf2@^3.0.3:
   version "3.0.17"
   resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.0.17.tgz#976c206530617b14ebb32114239f7b09336e93a6"
   integrity sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==
+  dependencies:
+    create-hash "^1.1.2"
+    create-hmac "^1.1.4"
+    ripemd160 "^2.0.1"
+    safe-buffer "^5.0.1"
+    sha.js "^2.4.8"
+
+pbkdf2@^3.0.9:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.1.2.tgz#dd822aa0887580e52f1a039dc3eda108efae3075"
+  integrity sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==
   dependencies:
     create-hash "^1.1.2"
     create-hmac "^1.1.4"


### PR DESCRIPTION
## What issue does this PR close
Closes #815 

## Changes Proposed ( a list of new changes introduced by this PR)
- Lowercase the 12 words
- Use `bip39` to validate the words. It'll be much easier to spot typos!
- Include the Bip39 Portuguese wordlist. Users can now have their 12 words in Portuguese!
- Fix usage of bip39 Spanish wordlist. Users can now have their 12 words in Spanish!

## How to test ( a list of instructions on how to test this PR)
- Go to the login page
- Try to login with your regular words, but make parts of it uppercase
- Write 12 random words and see how many bip39 words you can guess 😉 
- Create an account with the app in Spanish. Make sure your 12 words are in Spanish. Do the same for portuguese