### PR TITLE
Fix/image crop

### DIFF
--- a/src/customElements/imageCropper.js
+++ b/src/customElements/imageCropper.js
@@ -52,6 +52,7 @@ export default () => (
       }
 
       if (Object.values(allInputValues).some(x => x !== 0 && !x)) {
+        console.error('ImageCropper: missing input values', { cause: Object.keys(allInputValues).filter(x => !allInputValues[x]) })
         throw new Error('ImageCropper: missing input values', { cause: Object.keys(allInputValues).filter(x => !allInputValues[x]) })
       }
 

--- a/src/customElements/pointerListener.js
+++ b/src/customElements/pointerListener.js
@@ -6,15 +6,19 @@ export default () => (
       this.previousX = null
       this.previousY = null
 
-      this.listeners = {
-        'pointermove': (e) => {
+      this.documentListeners = {
+        'dragover': (e) => {
           if (this.previousX == null || this.previousY == null) {
             this.previousX = e.clientX
             this.previousY = e.clientY
             return
           }
 
-          this.dispatchEvent(new CustomEvent('document-pointermove', {
+          if (this.previousX == e.clientX && this.previousY == e.clientY) {
+            return
+          }
+
+          this.dispatchEvent(new CustomEvent('document-dragover', {
             detail: {
               clientX: e.clientX,
               clientY: e.clientY,
@@ -25,22 +29,45 @@ export default () => (
 
           this.previousX = e.clientX
           this.previousY = e.clientY
-        },
-        'pointerup': () => {
-          this.dispatchEvent(new CustomEvent('document-pointerup'))
         }
       }
 
-      Object.keys(this.listeners).forEach((key) => {
-        document.addEventListener(key, this.listeners[key])
+      this.elementListeners = {
+        'dragstart': (e) => {
+          this.dispatchEvent(new CustomEvent('element-dragstart'))
+
+          const dragImageElement = document.createElement('span')
+
+          dragImageElement.classList.add('sr-only')
+          dragImageElement.classList.add('pointer-events-none')
+          dragImageElement.setAttribute('aria-hidden', 'true')
+
+          e.dataTransfer.setDragImage(dragImageElement, 0, 0)
+        },
+        'dragend': () => {
+          this.dispatchEvent(new CustomEvent('element-dragend'))
+        }
+      }
+
+
+      Object.keys(this.documentListeners).forEach((key) => {
+        document.addEventListener(key, this.documentListeners[key])
+      })
+
+      Object.keys(this.elementListeners).forEach((key) => {
+        this.addEventListener(key, this.elementListeners[key])
       })
     }
 
     disconnectedCallback () {
-      Object.keys(this.listeners).forEach((key) => {
-        document.removeEventListener(key, this.listeners[key])
+      Object.keys(this.elementListeners).forEach((key) => {
+        this.removeEventListener(key, this.elementListeners[key])
       })
-      this.listeners = undefined
+
+      Object.keys(this.documentListeners).forEach((key) => {
+        document.removeEventListener(key, this.documentListeners[key])
+      })
+      this.documentListeners = undefined
     }
   }
 )

--- a/src/customElements/pointerListener.js
+++ b/src/customElements/pointerListener.js
@@ -6,6 +6,12 @@ export default () => (
       this.previousX = null
       this.previousY = null
 
+      this.dragImageElement = document.createElement('span')
+      this.dragImageElement.classList.add('sr-only')
+      this.dragImageElement.classList.add('pointer-events-none')
+      this.dragImageElement.setAttribute('aria-hidden', 'true')
+      document.body.appendChild(this.dragImageElement)
+
       this.documentListeners = {
         'dragover': (e) => {
           if (this.previousX == null || this.previousY == null) {
@@ -36,13 +42,7 @@ export default () => (
         'dragstart': (e) => {
           this.dispatchEvent(new CustomEvent('element-dragstart'))
 
-          const dragImageElement = document.createElement('span')
-
-          dragImageElement.classList.add('sr-only')
-          dragImageElement.classList.add('pointer-events-none')
-          dragImageElement.setAttribute('aria-hidden', 'true')
-
-          e.dataTransfer.setDragImage(dragImageElement, 0, 0)
+          e.dataTransfer.setDragImage(this.dragImageElement, 0, 0)
         },
         'dragend': () => {
           this.dispatchEvent(new CustomEvent('element-dragend'))
@@ -60,6 +60,10 @@ export default () => (
     }
 
     disconnectedCallback () {
+      if (this.dragImageElement && document.body.contains(this.dragImageElement)) {
+        document.body.removeChild(this.dragImageElement)
+      }
+
       Object.keys(this.elementListeners).forEach((key) => {
         this.removeEventListener(key, this.elementListeners[key])
       })

--- a/src/customElements/pointerListener.js
+++ b/src/customElements/pointerListener.js
@@ -14,13 +14,13 @@ export default () => (
 
       this.documentListeners = {
         'dragover': (e) => {
-          if (this.previousX == null || this.previousY == null) {
+          if (this.previousX === null || this.previousY === null) {
             this.previousX = e.clientX
             this.previousY = e.clientY
             return
           }
 
-          if (this.previousX == e.clientX && this.previousY == e.clientY) {
+          if (this.previousX === e.clientX && this.previousY === e.clientY) {
             return
           }
 
@@ -49,7 +49,6 @@ export default () => (
         }
       }
 
-
       Object.keys(this.documentListeners).forEach((key) => {
         document.addEventListener(key, this.documentListeners[key])
       })
@@ -71,6 +70,7 @@ export default () => (
       Object.keys(this.documentListeners).forEach((key) => {
         document.removeEventListener(key, this.documentListeners[key])
       })
+
       this.documentListeners = undefined
     }
   }

--- a/src/elm/View/ImageCropper.elm
+++ b/src/elm/View/ImageCropper.elm
@@ -329,7 +329,7 @@ view model { imageUrl, cropperAttributes } =
                 [ src imageUrl
                 , alt ""
                 , id entireImageId
-                , class "opacity-20 pointer-events-none select-none max-h-full"
+                , class "opacity-20 pointer-events-none select-none max-w-full max-h-[35vh] lg:max-h-[60vh]"
                 , Html.Events.on "load" (Json.Decode.succeed ImageLoaded)
                 ]
                 []

--- a/src/elm/View/ImageCropper.elm
+++ b/src/elm/View/ImageCropper.elm
@@ -229,7 +229,7 @@ update msg model =
                             ]
                     }
 
-        Dragged { x, y, previousX, previousY } ->
+        Dragged { x, y } ->
             case model.dimmensions of
                 Loading ->
                     UR.init model
@@ -247,14 +247,8 @@ update msg model =
                             | dimmensions =
                                 Loaded
                                     { dimmensions
-                                        | topOffset =
-                                            clamp dimmensions.container.top
-                                                (dimmensions.container.top + dimmensions.container.height - selection.height)
-                                                (dimmensions.topOffset + y - previousY)
-                                        , leftOffset =
-                                            clamp dimmensions.container.left
-                                                (dimmensions.container.left + dimmensions.container.width - selection.width)
-                                                (dimmensions.leftOffset + x - previousX)
+                                        | topOffset = y - selection.height / 2
+                                        , leftOffset = x - selection.width / 2
                                     }
                         }
                             |> UR.init

--- a/src/elm/View/ImageCropper.elm
+++ b/src/elm/View/ImageCropper.elm
@@ -235,25 +235,29 @@ update msg model =
                     UR.init model
 
                 Loaded dimmensions ->
-                    let
-                        selection =
-                            calculateSelectionDimmensions model dimmensions
-                    in
-                    { model
-                        | dimmensions =
-                            Loaded
-                                { dimmensions
-                                    | topOffset =
-                                        clamp dimmensions.container.top
-                                            (dimmensions.container.top + dimmensions.container.height - selection.height)
-                                            (dimmensions.topOffset + y - previousY)
-                                    , leftOffset =
-                                        clamp dimmensions.container.left
-                                            (dimmensions.container.left + dimmensions.container.width - selection.width)
-                                            (dimmensions.leftOffset + x - previousX)
-                                }
-                    }
-                        |> UR.init
+                    if not model.isDragging then
+                        UR.init model
+
+                    else
+                        let
+                            selection =
+                                calculateSelectionDimmensions model dimmensions
+                        in
+                        { model
+                            | dimmensions =
+                                Loaded
+                                    { dimmensions
+                                        | topOffset =
+                                            clamp dimmensions.container.top
+                                                (dimmensions.container.top + dimmensions.container.height - selection.height)
+                                                (dimmensions.topOffset + y - previousY)
+                                        , leftOffset =
+                                            clamp dimmensions.container.left
+                                                (dimmensions.container.left + dimmensions.container.width - selection.width)
+                                                (dimmensions.leftOffset + x - previousX)
+                                    }
+                        }
+                            |> UR.init
 
         ChangedDimmensions percentageString ->
             case model.dimmensions of

--- a/src/elm/View/ImageCropper.elm
+++ b/src/elm/View/ImageCropper.elm
@@ -4,7 +4,7 @@ import Browser.Dom
 import Dict
 import File
 import Html exposing (Html, button, div, img, input, node)
-import Html.Attributes exposing (alt, attribute, class, classList, id, src, style, type_, value)
+import Html.Attributes exposing (alt, attribute, class, classList, draggable, id, src, style, type_, value)
 import Html.Events
 import Icons
 import Json.Decode
@@ -377,14 +377,31 @@ viewCropper model dimmensions { imageUrl, cropperAttributes } =
         floatToPx offset =
             String.fromFloat offset ++ "px"
     in
-    [ div
+    [ View.Components.pointerListener
+        { document =
+            { onDragOver =
+                if model.isDragging then
+                    Just Dragged
+
+                else
+                    Nothing
+            }
+        , element =
+            { onDragStart =
+                Just
+                    { dragImage = Nothing
+                    , listener = StartedDragging
+                    }
+            , onDragEnd = Just StoppedDragging
+            }
+        }
         (class "absolute overflow-hidden border border-dashed border-gray-400 cursor-move z-20 select-none mx-auto"
             :: classList [ ( "transition-all origin-center", not model.isDragging && not model.isChangingDimmensions && not model.isReflowing ) ]
             :: style "top" (floatToPx topOffset)
             :: style "left" (floatToPx leftOffset)
             :: style "width" (floatToPx selection.width)
             :: style "height" (floatToPx selection.height)
-            :: onPointerDown StartedDragging
+            :: draggable "true"
             :: List.map (Html.Attributes.map Basics.never) cropperAttributes
         )
         [ img
@@ -401,14 +418,6 @@ viewCropper model dimmensions { imageUrl, cropperAttributes } =
             ]
             []
         ]
-    , if model.isDragging then
-        View.Components.pointerListener
-            { onPointerMove = Just Dragged
-            , onPointerUp = Just StoppedDragging
-            }
-
-      else
-        Html.text ""
     , node "image-cropper"
         [ if model.isRequestingCroppedImage then
             attribute "elm-generate-new-cropped-image" "true"

--- a/src/elm/View/ImageCropper.elm
+++ b/src/elm/View/ImageCropper.elm
@@ -513,17 +513,6 @@ calculateSelectionDimmensions model dimmensions =
     }
 
 
-onPointerDown : msg -> Html.Attribute msg
-onPointerDown msg =
-    Html.Events.custom "pointerdown"
-        (Json.Decode.succeed
-            { message = msg
-            , stopPropagation = True
-            , preventDefault = True
-            }
-        )
-
-
 msgToString : Msg -> List String
 msgToString msg =
     case msg of


### PR DESCRIPTION
## What issue does this PR close
Closes #775 

## Changes Proposed ( a list of new changes introduced by this PR)
- Add `draggable` attribute on the image cropper, and change event listeners used. This way it should work better on android devices
- Fix image's `max-height` so it doesn't use more space than it should, causing it to leave the cropper area

## How to test ( a list of instructions on how to test this PR)
- Try to crop an image, and check if it works as expected
