### PR TITLE
Show error message if balance is too low

### DIFF
--- a/public/translations/amh-ETH.json
+++ b/public/translations/amh-ETH.json
@@ -890,7 +890,8 @@
         "unitEmpty": "ክፍሎች ባዶ መሆን አይችሉም",
         "unitTooLow": "ክፍሉ በጣም ትንሽ ነዉ, ቢያንስ 1 መሆን አለበት ",
         "unitTooHigh": "በቂ ክፍሎች የሉም",
-        "unitNotOnlyNumbers": "፤አባላት ብቻ ይፈቀዳል"
+        "unitNotOnlyNumbers": "፤አባላት ብቻ ይፈቀዳል",
+        "balanceTooLow": "ለዚህ ግዢ በቂ {{symbol}} የለዎትም። ተጨማሪ {{symbol}} ለማግኘት የንጥሎቹን መጠን ለመቀነስ ወይም ድርጊቶችን ለማጠናቀቅ ይሞክሩ።"
       }
     },
     "delete": "ሰርዝ",

--- a/public/translations/cat-CAT.json
+++ b/public/translations/cat-CAT.json
@@ -932,7 +932,8 @@
         "unitEmpty": "La unitat no pot estar buida",
         "unitTooLow": "La unitat és massa baixa, ha de ser com a mínim 1",
         "unitTooHigh": "No hi ha prou unitats disponibles",
-        "unitNotOnlyNumbers": "Només es permeten números"
+        "unitNotOnlyNumbers": "Només es permeten números",
+        "balanceTooLow": "No tens prou {{symbol}} per a aquesta compra. Intenta reduir la quantitat d'elements o completa accions per guanyar més {{symbol}}."
       }
     },
     "delete": "Eliminar",

--- a/public/translations/en-US.json
+++ b/public/translations/en-US.json
@@ -929,7 +929,8 @@
         "unitEmpty": "Unit cannot be empty",
         "unitTooLow": "Unit is too low, must be at least 1",
         "unitTooHigh": "Not enough units available",
-        "unitNotOnlyNumbers": "Only numbers are allowed"
+        "unitNotOnlyNumbers": "Only numbers are allowed",
+        "balanceTooLow": "You don't have enough {{symbol}} for this purchase. Try lowering the amount of units or completing actions to earn more {{symbol}}."
       }
     },
     "delete": "Delete",

--- a/public/translations/es-ES.json
+++ b/public/translations/es-ES.json
@@ -932,7 +932,8 @@
         "unitEmpty": "La unidad no puede estar vacía",
         "unitTooLow": "La unidad es demasiado baja, debe ser al menos 1",
         "unitTooHigh": "No hay suficientes unidades disponibles",
-        "unitNotOnlyNumbers": "Solo se permiten números"
+        "unitNotOnlyNumbers": "Solo se permiten números",
+        "balanceTooLow": "No tienes suficiente {{symbol}} para esta compra. Intenta disminuir la cantidad de elementos o completar acciones para ganar más {{symbol}}."
       }
     },
     "delete": "Eliminar",

--- a/public/translations/pt-BR.json
+++ b/public/translations/pt-BR.json
@@ -936,7 +936,8 @@
         "unitEmpty": "Unidade não pode estar vazia",
         "unitTooLow": "A unidade é muito baixa, deve ser pelo menos 1",
         "unitTooHigh": "Unidades insuficientes disponíveis",
-        "unitNotOnlyNumbers": "Somente números são permitidos"
+        "unitNotOnlyNumbers": "Somente números são permitidos",
+        "balanceTooLow": "Você não possui {{symbol}} o suficiente para esta compra. Tente diminuir a quantidade de itens ou complete ações para ganhar mais {{symbol}}."
       }
     },
     "delete": "Excluir",


### PR DESCRIPTION
## What issue does this PR close
Closes #822 

## Changes Proposed ( a list of new changes introduced by this PR)
- If the user tries to buy a product but doesn't have enough balance (including the community's minimum balance), show an error message instead of actually trying to buy the product.

## How to test ( a list of instructions on how to test this PR)
- Go to the shop
- Buy an item, and make sure it still works ok
- Try to buy something that you don't have enough balance to buy (keep in mind some communities allow for negative balance), and see new error