### PR TITLE
Show error if account already exists

### DIFF
--- a/src/elm/Form.elm
+++ b/src/elm/Form.elm
@@ -4,7 +4,7 @@ module Form exposing
     , optional, introspect, list, mapValues, mapOutput, withValidationStrategy, ValidationStrategy(..)
     , textField, richText, toggle, checkbox, radio, select, file, fileMultiple, datePicker, userPicker, userPickerMultiple, arbitrary, arbitraryWith, unsafeArbitrary
     , view, viewWithoutSubmit, Model, init, Msg, update, updateValues, getValue, hasFieldsLoading, msgToString
-    , withDisabled
+    , withDisabled, withShowAllErrors
     , isDisabled, isShowingAllErrors
     , parse
     )
@@ -88,7 +88,7 @@ documentation if you're stuck.
 
 ### Changing attributes and state
 
-@docs withDisabled
+@docs withDisabled, withShowAllErrors
 
 
 ### Checking attributes and state
@@ -1021,6 +1021,26 @@ when you want to disable the form after the user submits it.
 withDisabled : Bool -> Model values -> Model values
 withDisabled disabled (Model model) =
     Model { model | disabled = disabled }
+
+
+{-| Control whether the form should show all errors or not. This is useful when
+you want to show all errors after the user tried to submit the form, and you
+have some custom action that doesn't automatically trigger all of the errors.
+-}
+withShowAllErrors : Bool -> Model values -> Model values
+withShowAllErrors showAllErrors (Model model) =
+    let
+        (ErrorTracking errorTracking) =
+            model.errorTracking
+    in
+    Model
+        { model
+            | errorTracking =
+                ErrorTracking
+                    { errorTracking
+                        | showAllErrors = showAllErrors
+                    }
+        }
 
 
 {-| Checks if the form is disabled. It's useful to disable submit buttons when

--- a/src/elm/Page/Register.elm
+++ b/src/elm/Page/Register.elm
@@ -134,6 +134,19 @@ formOutputDecoder =
         ]
 
 
+withShowAllErrors : Bool -> FormModel -> FormModel
+withShowAllErrors showAllErrors formModel =
+    case formModel of
+        NaturalForm form ->
+            NaturalForm (Form.withShowAllErrors showAllErrors form)
+
+        JuridicalForm form ->
+            JuridicalForm (Form.withShowAllErrors showAllErrors form)
+
+        DefaultForm form ->
+            DefaultForm (Form.withShowAllErrors showAllErrors form)
+
+
 type alias SignUpFields =
     { name : String
     , email : String
@@ -619,7 +632,7 @@ update _ msg model ({ shared } as guest) =
                                         Set.insert (Eos.nameToString account)
                                             unavailableAccounts
                                     }
-                                    formModel
+                                    (withShowAllErrors True formModel)
 
                             _ ->
                                 model.status

--- a/src/elm/Page/Register/Common.elm
+++ b/src/elm/Page/Register/Common.elm
@@ -57,16 +57,18 @@ accountNameField ({ t } as translators) { unavailableAccounts } =
             { parser =
                 Form.Validate.succeed
                     >> Form.Validate.eosName
+                    >> Form.Validate.custom
+                        (\accountName ->
+                            if Set.member (Eos.Account.nameToString accountName) unavailableAccounts then
+                                Err (\translators_ -> translators_.t "error.alreadyTaken")
+
+                            else
+                                Ok accountName
+                        )
                     >> Form.Validate.validate translators
             , value = .account
             , update = \account input -> { input | account = account }
-            , externalError =
-                \{ account } ->
-                    if Set.member account unavailableAccounts then
-                        Just (t "error.alreadyTaken")
-
-                    else
-                        Nothing
+            , externalError = always Nothing
             }
 
 


### PR DESCRIPTION
## What issue does this PR close
Closes #821 

## Changes Proposed ( a list of new changes introduced by this PR)
- Show error when account name already exists on register page (we already had this, but something broke it - likely #658) 

## How to test ( a list of instructions on how to test this PR)
- Try to register with an account name that already exists (for example, the one from the issue: JujutestePtb)
- See error