### PR TITLE
Enable form if some error happens editing objective

### DIFF
--- a/src/elm/Page/Community/Settings/ObjectiveEditor.elm
+++ b/src/elm/Page/Community/Settings/ObjectiveEditor.elm
@@ -873,7 +873,7 @@ update msg model loggedIn =
                         Authorized form (EditingObjective objective SavingEdit) ->
                             { model
                                 | status =
-                                    SavingEdit
+                                    Editing
                                         |> EditingObjective objective
                                         |> Authorized (Form.withDisabled False form)
                             }


### PR DESCRIPTION
## What issue does this PR close
Closes #674 

## Changes Proposed ( a list of new changes introduced by this PR)
- Fix line

## How to test ( a list of instructions on how to test this PR)
- Force an error when editing an objective. The form should be enabled again