### PR TITLE
Fix profile editor alignment

### DIFF
--- a/src/elm/Page/Profile/Editor.elm
+++ b/src/elm/Page/Profile/Editor.elm
@@ -163,7 +163,7 @@ interestsForm { t } =
                 |> Form.withGroup
                     [ class "flex" ]
                     (Form.Text.init { label = t "profile.edit.labels.interests", id = "interest-input" }
-                        |> Form.Text.withContainerAttrs [ class "w-full mb-4" ]
+                        |> Form.Text.withContainerAttrs [ class "w-full !mb-4" ]
                         |> Form.textField
                             { parser = Ok
                             , value = .interest
@@ -196,7 +196,7 @@ interestsForm { t } =
             (Form.introspect
                 (\values ->
                     Form.arbitrary
-                        (div [ class "flex flex-wrap mb-4 gap-x-4 gap-y-2" ]
+                        (div [ class "flex flex-wrap mb-10 gap-x-4 gap-y-2" ]
                             (List.map viewInterest values.interests)
                         )
                 )


### PR DESCRIPTION
## What issue does this PR close
Closes #802 

## Changes Proposed ( a list of new changes introduced by this PR)
- Fix margins so that the interests form is correctly aligned

## How to test ( a list of instructions on how to test this PR)
- Go to the profile editor page
- See that the "Add" button is aligned with the interests input
