### PR TITLE
Enhancement/reorder categories

### DIFF
--- a/src/elm/Shop/Category.elm
+++ b/src/elm/Shop/Category.elm
@@ -3,7 +3,6 @@ module Shop.Category exposing
     , Model
     , Tree
     , addChild
-    , addChild2
     , create
     , delete
     , encodeId
@@ -122,34 +121,8 @@ updateMetadata model { metaTitle, metaDescription, metaKeywords } =
         )
 
 
-addChild : Tree -> Id -> SelectionSet decodesTo Cambiatus.Object.Category -> SelectionSet (Maybe decodesTo) RootMutation
-addChild tree newChildId =
-    let
-        toSubcategoryInput index categoryId =
-            { id = idToInt categoryId
-            , position = 0
-            }
-    in
-    Cambiatus.Mutation.category
-        (\optionals ->
-            { optionals
-                | categories =
-                    Tree.children tree
-                        |> List.map (Tree.label >> .id)
-                        |> (\childrenIds -> newChildId :: childrenIds)
-                        |> List.indexedMap toSubcategoryInput
-                        |> OptionalArgument.Present
-                , id =
-                    Tree.label tree
-                        |> .id
-                        |> idToInt
-                        |> OptionalArgument.Present
-            }
-        )
-
-
-addChild2 : Tree -> Id -> Int -> SelectionSet decodesTo Cambiatus.Object.Category -> SelectionSet (Maybe decodesTo) RootMutation
-addChild2 tree newChildId newChildPosition =
+addChild : Tree -> Id -> Int -> SelectionSet decodesTo Cambiatus.Object.Category -> SelectionSet (Maybe decodesTo) RootMutation
+addChild tree newChildId newChildPosition =
     let
         insertAt : Int -> a -> List a -> List a
         insertAt position element xs =

--- a/src/elm/Shop/Category.elm
+++ b/src/elm/Shop/Category.elm
@@ -151,13 +151,14 @@ addChild tree newChildId newChildPosition =
         )
 
 
-moveToRoot : Id -> SelectionSet decodesTo Cambiatus.Object.Category -> SelectionSet (Maybe decodesTo) RootMutation
-moveToRoot (Id id) =
+moveToRoot : Id -> Int -> SelectionSet decodesTo Cambiatus.Object.Category -> SelectionSet (Maybe decodesTo) RootMutation
+moveToRoot (Id id) position =
     Cambiatus.Mutation.category
         (\optionals ->
             { optionals
                 | id = OptionalArgument.Present id
                 , parentId = OptionalArgument.Null
+                , position = OptionalArgument.Present position
             }
         )
 

--- a/src/elm/Shop/Category.elm
+++ b/src/elm/Shop/Category.elm
@@ -7,7 +7,6 @@ module Shop.Category exposing
     , delete
     , encodeId
     , idFromString
-    , idSelectionSet
     , idToInt
     , idToString
     , moveToRoot

--- a/src/elm/Utils/Tree.elm
+++ b/src/elm/Utils/Tree.elm
@@ -1,7 +1,7 @@
 module Utils.Tree exposing
     ( findInForest, findZipperInForest, getAllAncestors
     , toFlatForest, fromFlatForest
-    , goDownWithoutChildren, goUp, InsertAt(..)
+    , goUp, goDown, InsertAt(..)
     , moveZipperToAfter, moveZipperToFirstChildOf, moveZipperToLastChildOf, moveZipperToFirstRootPosition
     )
 
@@ -20,7 +20,7 @@ module Utils.Tree exposing
 
 ## Traversing through the tree
 
-@docs goDownWithoutChildren, goUp, InsertAt
+@docs goUp, goDown, InsertAt
 
 
 ## Rearranging trees/zippers
@@ -82,17 +82,6 @@ fromFlatForest trees =
             Nothing
 
 
-goDownWithoutChildren : Tree.Zipper.Zipper a -> Maybe (Tree.Zipper.Zipper a)
-goDownWithoutChildren zipper =
-    case Tree.Zipper.nextSibling zipper of
-        Nothing ->
-            Tree.Zipper.parent zipper
-                |> Maybe.andThen Tree.Zipper.parent
-
-        Just firstSibling ->
-            Just firstSibling
-
-
 type InsertAt a
     = FirstRoot
     | After (Tree.Zipper.Zipper a)
@@ -125,6 +114,21 @@ goUp zipper =
 
                 Nothing ->
                     -- There is no previous sibling and no parent, so we are at the first root element
+                    Nothing
+
+
+goDown : Tree.Zipper.Zipper a -> Maybe (InsertAt a)
+goDown zipper =
+    case Tree.Zipper.nextSibling zipper of
+        Just nextSibling ->
+            Just (FirstChildOf nextSibling)
+
+        Nothing ->
+            case Tree.Zipper.parent zipper of
+                Just parent ->
+                    Just (After parent)
+
+                Nothing ->
                     Nothing
 
 

--- a/src/elm/Utils/Tree.elm
+++ b/src/elm/Utils/Tree.elm
@@ -2,7 +2,7 @@ module Utils.Tree exposing
     ( findInForest, findZipperInForest, getAllAncestors
     , toFlatForest, fromFlatForest
     , goUpWithoutChildren, goDownWithoutChildren
-    , moveZipperToAfter, moveZipperToFirstChildOf, moveZipperToFirstRootPosition
+    , moveZipperToAfter, moveZipperToFirstChildOf, moveZipperToLastChildOf, moveZipperToFirstRootPosition
     )
 
 {-| Helper functions that deal with Trees from zwilias/elm-rosetree
@@ -25,7 +25,7 @@ module Utils.Tree exposing
 
 ## Rearranging trees/zippers
 
-@docs moveZipperToAfter, moveZipperToFirstChildOf, moveZipperToFirstRootPosition
+@docs moveZipperToAfter, moveZipperToFirstChildOf, moveZipperToLastChildOf, moveZipperToFirstRootPosition
 
 -}
 
@@ -122,6 +122,17 @@ moveZipperToFirstChildOf target toId zipper =
         |> Maybe.andThen
             (Tree.Zipper.mapTree (Tree.prependChild (Tree.Zipper.tree zipper))
                 >> Tree.Zipper.firstChild
+            )
+
+
+moveZipperToLastChildOf : id -> (model -> id) -> Tree.Zipper.Zipper model -> Maybe (Tree.Zipper.Zipper model)
+moveZipperToLastChildOf target toId zipper =
+    zipper
+        |> Tree.Zipper.removeTree
+        |> Maybe.andThen (Tree.Zipper.findFromRoot (\model -> toId model == target))
+        |> Maybe.andThen
+            (Tree.Zipper.mapTree (Tree.appendChild (Tree.Zipper.tree zipper))
+                >> Tree.Zipper.lastChild
             )
 
 

--- a/src/elm/Utils/Tree.elm
+++ b/src/elm/Utils/Tree.elm
@@ -2,6 +2,7 @@ module Utils.Tree exposing
     ( findInForest, findZipperInForest, getAllAncestors
     , toFlatForest, fromFlatForest
     , goUpWithoutChildren, goDownWithoutChildren
+    , moveZipperToAfter
     )
 
 {-| Helper functions that deal with Trees from zwilias/elm-rosetree
@@ -20,6 +21,11 @@ module Utils.Tree exposing
 ## Traversing through the tree
 
 @docs goUpWithoutChildren, goDownWithoutChildren
+
+
+## Rearranging trees/zippers
+
+@docs moveZipperToAfter
 
 -}
 
@@ -98,3 +104,11 @@ goDownWithoutChildren zipper =
 
         Just firstSibling ->
             Just firstSibling
+
+
+moveZipperToAfter : id -> (model -> id) -> Tree.Zipper.Zipper model -> Maybe (Tree.Zipper.Zipper model)
+moveZipperToAfter target toId zipper =
+    zipper
+        |> Tree.Zipper.removeTree
+        |> Maybe.andThen (Tree.Zipper.findFromRoot (\model -> toId model == target))
+        |> Maybe.andThen (Tree.Zipper.append (Tree.Zipper.tree zipper) >> Tree.Zipper.nextSibling)

--- a/src/elm/Utils/Tree.elm
+++ b/src/elm/Utils/Tree.elm
@@ -2,7 +2,7 @@ module Utils.Tree exposing
     ( findInForest, findZipperInForest, getAllAncestors
     , toFlatForest, fromFlatForest
     , goUpWithoutChildren, goDownWithoutChildren
-    , moveZipperToAfter
+    , moveZipperToAfter, moveZipperToFirstChildOf
     )
 
 {-| Helper functions that deal with Trees from zwilias/elm-rosetree
@@ -25,7 +25,7 @@ module Utils.Tree exposing
 
 ## Rearranging trees/zippers
 
-@docs moveZipperToAfter
+@docs moveZipperToAfter, moveZipperToFirstChildOf
 
 -}
 
@@ -112,3 +112,14 @@ moveZipperToAfter target toId zipper =
         |> Tree.Zipper.removeTree
         |> Maybe.andThen (Tree.Zipper.findFromRoot (\model -> toId model == target))
         |> Maybe.andThen (Tree.Zipper.append (Tree.Zipper.tree zipper) >> Tree.Zipper.nextSibling)
+
+
+moveZipperToFirstChildOf : id -> (model -> id) -> Tree.Zipper.Zipper model -> Maybe (Tree.Zipper.Zipper model)
+moveZipperToFirstChildOf target toId zipper =
+    zipper
+        |> Tree.Zipper.removeTree
+        |> Maybe.andThen (Tree.Zipper.findFromRoot (\model -> toId model == target))
+        |> Maybe.andThen
+            (Tree.Zipper.mapTree (Tree.prependChild (Tree.Zipper.tree zipper))
+                >> Tree.Zipper.firstChild
+            )

--- a/src/elm/Utils/Tree.elm
+++ b/src/elm/Utils/Tree.elm
@@ -2,7 +2,7 @@ module Utils.Tree exposing
     ( findInForest, findZipperInForest, getAllAncestors
     , toFlatForest, fromFlatForest
     , goUpWithoutChildren, goDownWithoutChildren
-    , moveZipperToAfter, moveZipperToFirstChildOf
+    , moveZipperToAfter, moveZipperToFirstChildOf, moveZipperToFirstRootPosition
     )
 
 {-| Helper functions that deal with Trees from zwilias/elm-rosetree
@@ -25,7 +25,7 @@ module Utils.Tree exposing
 
 ## Rearranging trees/zippers
 
-@docs moveZipperToAfter, moveZipperToFirstChildOf
+@docs moveZipperToAfter, moveZipperToFirstChildOf, moveZipperToFirstRootPosition
 
 -}
 
@@ -122,4 +122,15 @@ moveZipperToFirstChildOf target toId zipper =
         |> Maybe.andThen
             (Tree.Zipper.mapTree (Tree.prependChild (Tree.Zipper.tree zipper))
                 >> Tree.Zipper.firstChild
+            )
+
+
+moveZipperToFirstRootPosition : Tree.Zipper.Zipper model -> Maybe (Tree.Zipper.Zipper model)
+moveZipperToFirstRootPosition zipper =
+    zipper
+        |> Tree.Zipper.removeTree
+        |> Maybe.andThen
+            (Tree.Zipper.root
+                >> Tree.Zipper.prepend (Tree.Zipper.tree zipper)
+                >> Tree.Zipper.previousSibling
             )

--- a/tests/Utils/TreeTests.elm
+++ b/tests/Utils/TreeTests.elm
@@ -17,6 +17,7 @@ all =
         , fromFlatForest
         , moveZipperToAfter
         , moveZipperToFirstChildOf
+        , moveZipperToFirstRootPosition
         ]
 
 
@@ -375,6 +376,74 @@ moveZipperToFirstChildOf =
                             , tree101
                             ]
                         , []
+                        )
+                    }
+        ]
+
+
+moveZipperToFirstRootPosition : Test
+moveZipperToFirstRootPosition =
+    let
+        go :
+            { startingPoint : Int
+            , expected : ( Tree.Tree Int, List (Tree.Tree Int) )
+            }
+            -> Expect.Expectation
+        go { startingPoint, expected } =
+            case Tree.Zipper.findFromRoot ((==) startingPoint) treesZipper of
+                Nothing ->
+                    Expect.fail ("Could not find starting point: " ++ String.fromInt startingPoint)
+
+                Just zipper ->
+                    case Utils.Tree.moveZipperToFirstRootPosition zipper of
+                        Nothing ->
+                            Expect.fail "returned Nothing"
+
+                        Just newZipper ->
+                            Expect.all
+                                [ Tree.Zipper.toForest
+                                    >> Expect.equal expected
+                                , Tree.Zipper.label
+                                    >> Expect.equal startingPoint
+                                ]
+                                newZipper
+    in
+    describe "moveZipperToFirstRootPosition"
+        [ test "no-op if zipper is already in first root position" <|
+            \_ ->
+                go
+                    { startingPoint = 0
+                    , expected = ( firstTree, [ secondTree ] )
+                    }
+        , test "can move root node to first root position" <|
+            \_ ->
+                go
+                    { startingPoint = 100
+                    , expected = ( secondTree, [ firstTree ] )
+                    }
+        , test "can move child node to first root position" <|
+            \_ ->
+                go
+                    { startingPoint = -1
+                    , expected =
+                        ( treeNegative1
+                        , [ Tree.tree 0 [ tree1 ]
+                          , secondTree
+                          ]
+                        )
+                    }
+        , test "can move grandchild to first root position" <|
+            \_ ->
+                go
+                    { startingPoint = -110
+                    , expected =
+                        ( Tree.tree -110 []
+                        , [ firstTree
+                          , Tree.tree 100
+                                [ Tree.tree -100 [ Tree.tree -120 [] ]
+                                , tree101
+                                ]
+                          ]
                         )
                     }
         ]

--- a/tests/Utils/TreeTests.elm
+++ b/tests/Utils/TreeTests.elm
@@ -17,6 +17,7 @@ all =
         , fromFlatForest
         , moveZipperToAfter
         , moveZipperToFirstChildOf
+        , moveZipperToLastChildOf
         , moveZipperToFirstRootPosition
         ]
 
@@ -356,6 +357,99 @@ moveZipperToFirstChildOf =
                                 [ firstTree
                                 , Tree.tree -110 []
                                 , Tree.tree -120 []
+                                ]
+                            , tree101
+                            ]
+                        , []
+                        )
+                    }
+        , test "can move to node that has no children" <|
+            \_ ->
+                go
+                    { startingPoint = 0
+                    , target = -110
+                    , expected =
+                        ( Tree.tree 100
+                            [ Tree.tree -100
+                                [ Tree.tree -110 [ firstTree ]
+                                , Tree.tree -120 []
+                                ]
+                            , tree101
+                            ]
+                        , []
+                        )
+                    }
+        ]
+
+
+moveZipperToLastChildOf : Test
+moveZipperToLastChildOf =
+    let
+        go :
+            { startingPoint : Int
+            , target : Int
+            , expected : ( Tree.Tree Int, List (Tree.Tree Int) )
+            }
+            -> Expect.Expectation
+        go { startingPoint, target, expected } =
+            case Tree.Zipper.findFromRoot ((==) startingPoint) treesZipper of
+                Nothing ->
+                    Expect.fail ("Could not find starting point: " ++ String.fromInt startingPoint)
+
+                Just zipper ->
+                    case Utils.Tree.moveZipperToLastChildOf target identity zipper of
+                        Nothing ->
+                            Expect.fail "returned Nothing"
+
+                        Just newZipper ->
+                            Expect.all
+                                [ Tree.Zipper.toForest
+                                    >> Expect.equal expected
+                                , Tree.Zipper.label
+                                    >> Expect.equal startingPoint
+                                ]
+                                newZipper
+    in
+    describe "moveZipperToLastChildOf"
+        [ test "can move to next sibling's last child" <|
+            \_ ->
+                go
+                    { startingPoint = 0
+                    , target = 100
+                    , expected =
+                        ( Tree.tree 100
+                            [ treeNegative100
+                            , tree101
+                            , firstTree
+                            ]
+                        , []
+                        )
+                    }
+        , test "can move to previous sibling's last child" <|
+            \_ ->
+                go
+                    { startingPoint = 100
+                    , target = 0
+                    , expected =
+                        ( Tree.tree 0
+                            [ treeNegative1
+                            , tree1
+                            , secondTree
+                            ]
+                        , []
+                        )
+                    }
+        , test "can move to sibling's grandchild" <|
+            \_ ->
+                go
+                    { startingPoint = 0
+                    , target = -100
+                    , expected =
+                        ( Tree.tree 100
+                            [ Tree.tree -100
+                                [ Tree.tree -110 []
+                                , Tree.tree -120 []
+                                , firstTree
                                 ]
                             , tree101
                             ]

--- a/tests/Utils/TreeTests.elm
+++ b/tests/Utils/TreeTests.elm
@@ -20,6 +20,7 @@ all =
         , moveZipperToLastChildOf
         , moveZipperToFirstRootPosition
         , goUp
+        , goDown
         ]
 
 
@@ -631,6 +632,73 @@ goUp =
                 go
                     { target = -100
                     , expected = Just (After 0)
+                    }
+        ]
+
+
+goDown : Test
+goDown =
+    let
+        go :
+            { target : Int
+            , expected : Maybe GoUpResult
+            }
+            -> Expect.Expectation
+        go { target, expected } =
+            case Tree.Zipper.findFromRoot ((==) target) treesZipper of
+                Nothing ->
+                    Expect.fail ("Could not find starting point: " ++ String.fromInt target)
+
+                Just zipper ->
+                    Utils.Tree.goDown zipper
+                        |> Expect.equal
+                            (case expected of
+                                Just FirstRoot ->
+                                    Utils.Tree.FirstRoot
+                                        |> Just
+
+                                Just (FirstChildOf label) ->
+                                    treesZipper
+                                        |> Tree.Zipper.findFromRoot ((==) label)
+                                        |> Maybe.withDefault treesZipper
+                                        |> Utils.Tree.FirstChildOf
+                                        |> Just
+
+                                Just (After label) ->
+                                    treesZipper
+                                        |> Tree.Zipper.findFromRoot ((==) label)
+                                        |> Maybe.withDefault treesZipper
+                                        |> Utils.Tree.After
+                                        |> Just
+
+                                Nothing ->
+                                    Nothing
+                            )
+    in
+    describe "goDown"
+        [ test "can go down to next sibling's first child" <|
+            \_ ->
+                go
+                    { target = 0
+                    , expected = Just (FirstChildOf 100)
+                    }
+        , test "can go down to be parent's next sibling" <|
+            \_ ->
+                go
+                    { target = 1
+                    , expected = Just (After 0)
+                    }
+        , test "can go down to next sibling's first child when next sibling has no children" <|
+            \_ ->
+                go
+                    { target = -10
+                    , expected = Just (FirstChildOf -20)
+                    }
+        , test "can not go down if it's the last root category" <|
+            \_ ->
+                go
+                    { target = 100
+                    , expected = Nothing
                     }
         ]
 

--- a/tests/Utils/TreeTests.elm
+++ b/tests/Utils/TreeTests.elm
@@ -16,6 +16,7 @@ all =
         , toFlatForest
         , fromFlatForest
         , moveZipperToAfter
+        , moveZipperToFirstChildOf
         ]
 
 
@@ -281,6 +282,99 @@ moveZipperToAfter =
                                 , tree101
                                 ]
                           ]
+                        )
+                    }
+        ]
+
+
+moveZipperToFirstChildOf : Test
+moveZipperToFirstChildOf =
+    let
+        go :
+            { startingPoint : Int
+            , target : Int
+            , expected : ( Tree.Tree Int, List (Tree.Tree Int) )
+            }
+            -> Expect.Expectation
+        go { startingPoint, target, expected } =
+            case Tree.Zipper.findFromRoot ((==) startingPoint) treesZipper of
+                Nothing ->
+                    Expect.fail ("Could not find starting point: " ++ String.fromInt startingPoint)
+
+                Just zipper ->
+                    case Utils.Tree.moveZipperToFirstChildOf target identity zipper of
+                        Nothing ->
+                            Expect.fail "returned Nothing"
+
+                        Just newZipper ->
+                            Expect.all
+                                [ Tree.Zipper.toForest
+                                    >> Expect.equal expected
+                                , Tree.Zipper.label
+                                    >> Expect.equal startingPoint
+                                ]
+                                newZipper
+    in
+    describe "moveZipperToFirstChildOf"
+        [ test "can move to next sibling's first child" <|
+            \_ ->
+                go
+                    { startingPoint = 0
+                    , target = 100
+                    , expected =
+                        ( Tree.tree 100
+                            [ firstTree
+                            , treeNegative100
+                            , tree101
+                            ]
+                        , []
+                        )
+                    }
+        , test "can move to previous sibling's first child" <|
+            \_ ->
+                go
+                    { startingPoint = 100
+                    , target = 0
+                    , expected =
+                        ( Tree.tree 0
+                            [ secondTree
+                            , treeNegative1
+                            , tree1
+                            ]
+                        , []
+                        )
+                    }
+        , test "can move to sibling's grandchild" <|
+            \_ ->
+                go
+                    { startingPoint = 0
+                    , target = -100
+                    , expected =
+                        ( Tree.tree 100
+                            [ Tree.tree -100
+                                [ firstTree
+                                , Tree.tree -110 []
+                                , Tree.tree -120 []
+                                ]
+                            , tree101
+                            ]
+                        , []
+                        )
+                    }
+        , test "can move to node that has no children" <|
+            \_ ->
+                go
+                    { startingPoint = 0
+                    , target = -110
+                    , expected =
+                        ( Tree.tree 100
+                            [ Tree.tree -100
+                                [ Tree.tree -110 [ firstTree ]
+                                , Tree.tree -120 []
+                                ]
+                            , tree101
+                            ]
+                        , []
                         )
                     }
         ]


### PR DESCRIPTION
## What issue does this PR close
Closes #780 

## Changes Proposed ( a list of new changes introduced by this PR)
- Fix category reordering by using the `position` field
- Recalculate the trees on the frontend for optimistic updates

## How to test ( a list of instructions on how to test this PR)
- Go to the categories settings page
- Try to reorder them by dragging and dropping, and by using the "move up" and "move down" buttons

## Still Pending
- While all the functionality is already done, the UI still needs some work
- The backend is having [some issues with reordering root categories](https://cambiatus.slack.com/archives/CA83HJAAD/p1662668937552109)