### PR TITLE
Use the clipboard API when the browser supports it

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1255,10 +1255,25 @@ async function handleJavascriptPort (arg) {
     }
     case 'copyToClipboard': {
       // We might need to want to change the dom before copying contents of the input
-      await new Promise(function (resolve) {
-        window.setTimeout(() => {
-          document.querySelector('#' + arg.data.id).select()
+      await new Promise(function (resolve, reject) {
+        window.setTimeout(async () => {
+          const element = document.getElementById(arg.data.id)
+          if (!element) {
+            reject(new Error('Element not found'))
+            return
+          }
+
+          // The clipboard API is not supported in all browsers
+          if (navigator.clipboard && navigator.clipboard.writeText && element.value) {
+            await navigator.clipboard.writeText(element.value)
+
+            resolve()
+            return
+          }
+
+          element.select()
           document.execCommand('copy')
+
           resolve()
         }, 0)
       })


### PR DESCRIPTION
## What issue does this PR close
Closes N/A. Fixes an issue brought up by Luiz on Slack: https://cambiatus.slack.com/archives/CA83HJAAD/p1663961056061889

## Changes Proposed ( a list of new changes introduced by this PR)
- Use the clipboard API to copy text when the browser supports it

## How to test ( a list of instructions on how to test this PR)
- Use a browser that doesn't support sharing (on macOS, only Safari does, so using Chrome, firefox, brave, etc. is fine)
- Go to the how to earn page
- Try to share an action
- Verify that the text is actually copied to the clipboard