### PR TITLE
Feature/copy base58 key

### DIFF
--- a/public/translations/amh-ETH.json
+++ b/public/translations/amh-ETH.json
@@ -65,6 +65,8 @@
     "send": "ላክ",
     "add": "ጨምር",
     "close": "ዝጋ",
+    "copy": "ቅዳ",
+    "export": "ወደ ውጪ ላክ",
     "loading": "እየጫነ ነዉ...",
     "try_again": "እንደገና ሞክር",
     "coming_soon": "በቅርብ ይመጣል",
@@ -1137,7 +1139,11 @@
     "account": {
       "title": "ቅንብሮች",
       "account_settings": "መለያ **ማደራጃ**",
-      "notification_settings": "**ኢ-ሜል** ማሳወቂያዎች"
+      "notification_settings": "**ኢ-ሜል** ማሳወቂያዎች",
+      "my_private_key": "የእኔ የግል ቁልፍ",
+      "export_private_key": "የግል ቁልፍ ወደ ውጭ ላክ",
+      "export_private_key_details": "ይህ የእርስዎ የግል ቁልፍ ነው፣ መለያዎን ወደ ለማስገባት ሊጠቀሙበት ይችላሉ ",
+      "copied_private_key": "የግል ቁልፍ ወደ ቅንጥብ ሰሌዳ ተቀድቷል።"
     },
     "community_info": {
       "title": "የማህበረሰብ መረጃ",

--- a/public/translations/cat-CAT.json
+++ b/public/translations/cat-CAT.json
@@ -65,6 +65,8 @@
     "send": "Enviar",
     "add": "Afegir",
     "close": "Tancar",
+    "copy": "Còpia",
+    "export": "Exporta",
     "loading": "Carregant...",
     "try_again": "Intenta de nou",
     "coming_soon": "Pròximament",
@@ -1178,7 +1180,11 @@
     "account": {
       "title": "Configuració",
       "account_settings": "**Configuració** del compte",
-      "notification_settings": "Notificacions per **correu electrònic**"
+      "notification_settings": "Notificacions per **correu electrònic**",
+      "my_private_key": "La meva clau privada",
+      "export_private_key": "Exporta la clau privada",
+      "export_private_key_details": "Aquesta és la vostra clau privada, que podeu utilitzar per importar el vostre compte al ",
+      "copied_private_key": "S'ha copiat la clau privada al porta-retalls"
     },
     "community_info": {
       "title": "Informació de la Comunitat",

--- a/public/translations/en-US.json
+++ b/public/translations/en-US.json
@@ -65,6 +65,8 @@
     "send": "Send",
     "add": "Add",
     "close": "Close",
+    "copy": "Copy to clipboard",
+    "export": "Export",
     "loading": "Loading...",
     "try_again": "Try again",
     "coming_soon": "Coming Soon",
@@ -1176,7 +1178,11 @@
     "account": {
       "title": "Settings",
       "account_settings": "Account **settings**",
-      "notification_settings": "**E-mail** notifications"
+      "notification_settings": "**E-mail** notifications",
+      "my_private_key": "My private key",
+      "export_private_key": "Export private key",
+      "export_private_key_details": "This is your private key, which you can use to import your account on ",
+      "copied_private_key": "Private key copied to clipboard"
     },
     "community_info": {
       "title": "Community Information",

--- a/public/translations/es-ES.json
+++ b/public/translations/es-ES.json
@@ -65,6 +65,8 @@
     "send": "Enviar",
     "add": "Añadir",
     "close": "Cerrar",
+    "copy": "Copiar",
+    "export": "Exportar",
     "loading": "Cargando...",
     "try_again": "Intenta de nuevo",
     "coming_soon": "Próximamente",
@@ -1179,7 +1181,11 @@
     "account": {
       "title": "Configuraciones",
       "account_settings": "**Configuraciones** de la cuenta",
-      "notification_settings": "Notificaciónes de **correo electrónico**"
+      "notification_settings": "Notificaciónes de **correo electrónico**",
+      "my_private_key": "Mi clave privada",
+      "export_private_key": "Exportar clave privada",
+      "export_private_key_details": "Esta es su clave privada, que puede usar para importar su cuenta a ",
+      "copied_private_key": "Clave privada copiada al portapapeles"
     },
     "community_info": {
       "title": "Informaciones de la Comunidad",

--- a/public/translations/pt-BR.json
+++ b/public/translations/pt-BR.json
@@ -65,6 +65,8 @@
     "send": "Enviar",
     "add": "Adicionar",
     "close": "Fechar",
+    "copy": "Copiar",
+    "export": "Exportar",
     "loading": "Carregando...",
     "try_again": "Tente novamente",
     "coming_soon": "Em Breve",
@@ -1182,7 +1184,11 @@
     "account": {
       "title": "Configurações",
       "account_settings": "**Configurações** da conta",
-      "notification_settings": "Notificações por **e-mail**"
+      "notification_settings": "Notificações por **e-mail**",
+      "my_private_key": "Minha chave privada",
+      "export_private_key": "Exportar chave privada",
+      "export_private_key_details": "Essa é a sua chave privada, que você pode usar para importar sua conta no ",
+      "copied_private_key": "Chave privada copiada para a área de transferência"
     },
     "community_info": {
       "title": "Informações da Comunidade",

--- a/src/elm/Auth.elm
+++ b/src/elm/Auth.elm
@@ -2,6 +2,7 @@ module Auth exposing
     ( ExternalMsg(..)
     , Model
     , Msg
+    , Status(..)
     , changeLastKnownPin
     , init
     , jsAddressToMsg

--- a/src/elm/Page/Settings.elm
+++ b/src/elm/Page/Settings.elm
@@ -488,6 +488,8 @@ viewExportToSimpleosModal loggedIn model =
                         , a
                             [ class "hover:underline text-orange-300"
                             , Html.Attributes.href "https://eosrio.io/simpleos/"
+                            , Html.Attributes.target "_blank"
+                            , Html.Attributes.rel "noopener"
                             ]
                             [ text "Simpleos" ]
                         ]

--- a/src/elm/Page/Settings.elm
+++ b/src/elm/Page/Settings.elm
@@ -179,8 +179,10 @@ update msg model loggedIn =
         CopiedPrivateKey ->
             { model | isExportToSimpleosModalVisible = False }
                 |> UR.init
-                -- TODO - I18N
-                |> UR.addExt (LoggedIn.ShowFeedback View.Feedback.Success "Copied private key to clipboard")
+                |> UR.addExt
+                    (LoggedIn.ShowFeedback View.Feedback.Success
+                        (loggedIn.shared.translators.t "settings.account.copied_private_key")
+                    )
 
         ClosedExportToSimpleosModal ->
             { model | isExportToSimpleosModalVisible = False }
@@ -471,16 +473,18 @@ viewExportToSimpleosModal : LoggedIn.Model -> Model -> Html Msg
 viewExportToSimpleosModal loggedIn model =
     case loggedIn.auth.status of
         Auth.WithPrivateKey privateKey ->
+            let
+                { t } =
+                    loggedIn.shared.translators
+            in
             View.Modal.initWith
                 { closeMsg = ClosedExportToSimpleosModal
                 , isVisible = model.isExportToSimpleosModalVisible
                 }
-                -- TODO - I18N
-                |> View.Modal.withHeader "Exportar para Simpleos"
+                |> View.Modal.withHeader (t "settings.account.export_private_key")
                 |> View.Modal.withBody
                     [ p []
-                        -- TODO - I18N
-                        [ text "Essa é sua chave privada, que você pode usar para importar sua conta no "
+                        [ text <| t "settings.account.export_private_key_details"
                         , a
                             [ class "hover:underline text-orange-300"
                             , Html.Attributes.href "https://eosrio.io/simpleos/"
@@ -514,14 +518,12 @@ viewExportToSimpleosModal loggedIn model =
                         [ class "modal-cancel"
                         , onClick ClosedExportToSimpleosModal
                         ]
-                        -- TODO - I18N
-                        [ text "Fechar" ]
+                        [ text <| t "menu.close" ]
                     , button
                         [ class "modal-accept"
                         , onClick ClickedCopyPrivateKey
                         ]
-                        -- TODO - I18N
-                        [ text "Copiar" ]
+                        [ text <| t "menu.copy" ]
                     ]
                 |> View.Modal.toHtml
 
@@ -589,14 +591,12 @@ viewAccountSettings loggedIn =
                 [ text <| t "profile.12words.button" ]
             ]
         , viewCardItem
-            -- TODO - I18N
-            [ text "My private key"
+            [ text <| t "settings.account.my_private_key"
             , button
                 [ class "button button-secondary flex-shrink-0 ml-4"
                 , onClick ClickedExportToSimpleos
                 ]
-                -- TODO - I18N
-                [ text "Export" ]
+                [ text <| t "menu.export" ]
             ]
         , viewCardItem
             [ text <| t "profile.pin.title"


### PR DESCRIPTION
## What issue does this PR close
Closes N/A.

## Changes Proposed ( a list of new changes introduced by this PR)
Add a button in the account settings page to export the user's private key. With it, they can import their account on Simpleos and perform actions outside the app!

## How to test ( a list of instructions on how to test this PR)
- Log into the app
- Go into your account settings page (hover over profile picture > settings)
- Click on the "Export" button, and copy your private key
- On [Simpleos](https://eosrio.io/simpleos/):
  - Connect to the staging network (custom chain > change endpoint to `https://staging.cambiatus.io`)
  - Import existing key > paste what you copied on the app
  - Success 🎉 
