### PR TITLE
Emit Vite assets under /static/ for production nginx

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -42,6 +42,9 @@ export default defineConfig({
 
   build: {
     outDir: "dist",
+    // Emit hashed JS/CSS under /static/ instead of the default /assets/, which
+    // nginx proxies to the backend in production.
+    assetsDir: "static",
     sourcemap: true,
     // Increase chunk size warning limit for Elm apps
     chunkSizeWarningLimit: 1000,


### PR DESCRIPTION
Production nginx (`server_name *.cambiatus.io`) proxies `/assets/` to the backend API. Vite emits hashed JS/CSS under `/assets/` by default, so on the first Vite prod deploy the app bundles would be proxied to the backend (404) instead of served as static files.

Set `build.assetsDir` to `"static"` so bundles are emitted under `/static/` — served statically by nginx, exactly as the previous webpack build was.

Verified locally: `dist/static/*.js|css`, `index.html` references `/static/...`, zero `/assets/` references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)