### PR TITLE
fix(auth): restore working seedPrivate for 12-word login

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -675,7 +675,7 @@ async function handleJavascriptPort(arg) {
     case "generateKeys": {
       const userLang = getUserLanguage();
       const [randomWords, hexRandomWords] = mnemonic.generateRandom(userLang);
-      const privateKey = ecc.seedPrivate(hexRandomWords);
+      const privateKey = mnemonic.seedPrivate(hexRandomWords);
       const publicKey = ecc.privateToPublic(privateKey);
 
       return {
@@ -690,7 +690,7 @@ async function handleJavascriptPort(arg) {
     }
     case "getAccountFrom12Words": {
       const { passphrase } = arg.data;
-      const privateKey = ecc.seedPrivate(mnemonic.toSeedHex(passphrase));
+      const privateKey = mnemonic.seedPrivate(mnemonic.toSeedHex(passphrase));
 
       if (!ecc.isValidPrivate(privateKey)) {
         return { error: "error.invalidKey" };

--- a/src/scripts/mnemonic.js
+++ b/src/scripts/mnemonic.js
@@ -1,4 +1,6 @@
 import * as bip39 from 'bip39'
+import { sha256, PrivateKey } from 'eosjs/dist/eosjs-key-conversions'
+import { KeyType, privateKeyToString } from 'eosjs/dist/eosjs-numeric'
 
 /***
  * Generates a random mnemonic
@@ -28,6 +30,21 @@ function toSeedHex (mnemonic) {
   return bip39.mnemonicToSeedSync(mnemonic).toString('hex')
 }
 
+/**
+ * Derive an EOS private key from a seed string.
+ *
+ * Replaces ecc.seedPrivate, which is a no-op stub in eosjs-ecc-migration
+ * (it only logs "Method deprecated" and returns undefined). Reproduces the
+ * legacy eosjs-ecc behaviour exactly: PrivateKey(sha256(seed)), returned as a
+ * legacy WIF string, so keys match what existing accounts registered with.
+ * @param {string} seed
+ * @returns {string} legacy WIF private key
+ */
+function seedPrivate (seed) {
+  const data = Uint8Array.from(sha256(seed))
+  return PrivateKey.fromString(privateKeyToString({ type: KeyType.k1, data })).toLegacyString()
+}
+
 // =========================================
 // Exports
 // =========================================
@@ -35,4 +52,5 @@ function toSeedHex (mnemonic) {
 export default {
   generateRandom,
   toSeedHex,
+  seedPrivate,
 }


### PR DESCRIPTION
## Problem

Production outage for **all from-scratch 12-word logins and new registrations**, all languages. Reported as a single Portuguese user (`maysalex1234`) unable to log in with valid 12 words; root cause is repo-wide.

The Vite migration (#978) switched `ecc` to `eosjs/dist/eosjs-ecc-migration`, where `seedPrivate` is a **no-op stub**:

```js
seedPrivate: function () { return console.error('Method deprecated') }  // returns undefined
```

So in `src/index.js`:
- `getAccountFrom12Words` → `ecc.seedPrivate(...)` → `undefined` → `ecc.isValidPrivate(undefined)` → `error.invalidKey`
- `generateKeys` (registration) → undefined private key

Existing users were unaffected because PIN login decrypts a stored key (`sjcl.decrypt`) and never calls `seedPrivate` — which masked the outage. Only new-device / cleared-storage logins and new signups break. Confirmed the stub is live in the deployed prod bundle (`vendor-blockchain`).

## Fix

Add a local `seedPrivate` in `src/scripts/mnemonic.js` that reproduces legacy `eosjs-ecc` exactly — `PrivateKey(sha256(seed))` returned as a legacy WIF — and call it from both sites.

## Verification

- Derived the public key from `maysalex1234`'s 12 words via the new `seedPrivate` → `EOS5hmk9bPey12gAbuGjGRiQferjxgAoyGAtXpwR7GaQKxhzDdTt2`. `get_key_accounts` on `app.cambiatus.io` returns `{"account_names":["maysalex1234"]}` → exact match.
- Keys are byte-identical to pre-#978 (legacy WIF, `5…`, len 51): **no user key migration needed**, accounts not compromised, keys not rotated.
- `yarn build` passes; new eosjs imports (`eosjs-key-conversions`, `eosjs-numeric`) resolve in the Vite bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)