### PR TITLE
fix(auth): bundle bip39 wordlists for register + login validation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,6 @@ import pdfDefinition from "./scripts/pdfDefinition";
 import "./styles/main.css";
 import pdfFonts from "./vfs_fonts";
 import { register as registerCustomElements } from "./customElements/index";
-import * as bip39 from "bip39";
 import * as matomo from "./utils/matomo";
 import { Socket as PhoenixSocket } from "phoenix";
 import * as ElmDebugger from "elm-debug-transformer";
@@ -1506,9 +1505,9 @@ async function handleJavascriptPort(arg) {
       };
 
       return {
-        english: normalize(bip39.wordlists.english),
-        portuguese: normalize(bip39.wordlists.portuguese),
-        spanish: normalize(bip39.wordlists.spanish),
+        english: normalize(mnemonic.wordlists.english),
+        portuguese: normalize(mnemonic.wordlists.portuguese),
+        spanish: normalize(mnemonic.wordlists.spanish),
       };
     }
     case "addMatomoScript": {

--- a/src/scripts/mnemonic.js
+++ b/src/scripts/mnemonic.js
@@ -1,6 +1,14 @@
 import * as bip39 from 'bip39'
 import { sha256, PrivateKey } from 'eosjs/dist/eosjs-key-conversions'
 import { KeyType, privateKeyToString } from 'eosjs/dist/eosjs-numeric'
+import english from 'bip39/src/wordlists/english.json'
+import portuguese from 'bip39/src/wordlists/portuguese.json'
+import spanish from 'bip39/src/wordlists/spanish.json'
+
+// bip39 loads its wordlist JSONs through try/catch require()s (see bip39
+// src/_wordlists.js), which the production bundler drops — so bip39.wordlists.*
+// is undefined in the browser. Import the JSONs directly so they're bundled.
+const wordlists = { english, portuguese, spanish }
 
 /***
  * Generates a random mnemonic
@@ -8,11 +16,11 @@ import { KeyType, privateKeyToString } from 'eosjs/dist/eosjs-numeric'
  * @returns {[string,string]}
  */
 function generateRandom (userLocale) {
-  let wordlist = bip39.wordlists.english
+  let wordlist = wordlists.english
   if (userLocale.toLowerCase().startsWith('es')) {
-    wordlist = bip39.wordlists.spanish
+    wordlist = wordlists.spanish
   } else if (userLocale.toLowerCase().startsWith('pt')) {
-    wordlist = bip39.wordlists.portuguese
+    wordlist = wordlists.portuguese
   }
 
   const strength = undefined
@@ -53,4 +61,5 @@ export default {
   generateRandom,
   toSeedHex,
   seedPrivate,
+  wordlists,
 }


### PR DESCRIPTION
## Problem

bip39 loads its wordlist JSONs via `try/catch require()`s (`bip39/src/_wordlists.js`), which the Vite/Rollup production build drops — so `bip39.wordlists` is **empty in the browser bundle** (zero wordlist words; the bundle even carries bip39's `"A wordlist is required … could not be found"` throw string). Live in prod since the Vite build was cut over (#981), same root-cause family as #982.

Two consequences:
- **`getBip39`** → `bip39.wordlists.english.map(...)` on `undefined` → `Cannot read properties of undefined (reading 'map')` at login init. Killed invalid-word highlighting. (Login itself still worked — the validator skips when the list fails to load.)
- **Registration** → `generateRandom` passed an undefined wordlist to `bip39.generateMnemonic`, which **throws** → new signups can't produce a passphrase.

## Fix

Import the english/portuguese/spanish wordlist JSONs directly so the bundler includes them; route `generateRandom` and `getBip39` through them; drop the now-unused `bip39` import from `index.js`.

## Verification

- Built bundle now contains all three wordlists (`abandon`/`fardado`/`abdomen`/`yogur`/`zurdo` present).
- `yarn build` clean; index chunk grows ~55 KiB (the three JSONs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)