### PR TITLE
fix(auth): add ADMIN to Permission enum so admins can log in

### DIFF
--- a/src/elm/Cambiatus/Enum/Permission.elm
+++ b/src/elm/Cambiatus/Enum/Permission.elm
@@ -9,6 +9,7 @@ import Json.Decode as Decode exposing (Decoder)
 
 {-| Permissions a role can have
 
+  - Admin - Role permission that grants full administrative access to the community
   - Award - Role permission that allows to award rewards on community actions
   - Claim - Role permission that allows to claim actions
   - Invite - Role permission that allows to create invitations to the community
@@ -19,7 +20,8 @@ import Json.Decode as Decode exposing (Decoder)
 
 -}
 type Permission
-    = Award
+    = Admin
+    | Award
     | Claim
     | Invite
     | Order
@@ -30,7 +32,7 @@ type Permission
 
 list : List Permission
 list =
-    [ Award, Claim, Invite, Order, Sell, Transfer, Verify ]
+    [ Admin, Award, Claim, Invite, Order, Sell, Transfer, Verify ]
 
 
 decoder : Decoder Permission
@@ -39,6 +41,9 @@ decoder =
         |> Decode.andThen
             (\string ->
                 case string of
+                    "ADMIN" ->
+                        Decode.succeed Admin
+
                     "AWARD" ->
                         Decode.succeed Award
 
@@ -70,6 +75,9 @@ decoder =
 toString : Permission -> String
 toString enum =
     case enum of
+        Admin ->
+            "ADMIN"
+
         Award ->
             "AWARD"
 
@@ -106,6 +114,9 @@ This can be useful for generating Strings to use for <select> menus to check whi
 fromString : String -> Maybe Permission
 fromString enumString =
     case enumString of
+        "ADMIN" ->
+            Just Admin
+
         "AWARD" ->
             Just Award
 


### PR DESCRIPTION
## Problem

Admin users got **"Authentication failed"** at login even though the backend `signIn` succeeded (valid token returned). The generated `Cambiatus.Enum.Permission` (last regenerated 2022-07-13, #786) is missing the `ADMIN` value the backend now returns for admin roles. elm-graphql enum decoders `Decode.fail` on unknown values, so decoding the signIn response for an admin profile failed → `RemoteData.Failure` → `auth.failed`.

Non-admin users are unaffected (no `ADMIN` permission in their payload) — which is why regular logins work after #982/#983 but admin logins didn't.

## Fix

Add the `Admin` variant to the Permission enum (type, list, decoder, toString, fromString). Surgical unblock; `yarn build` compiles clean (nothing pattern-matches Permission exhaustively).

## Follow-up

The generated schema is ~4 years stale. It should be fully regenerated (`yarn generate-graphql`) in a separate, reviewed change — there may be other drifted enums/fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)