### PR TITLE
chore(graphql): regenerate schema from current backend

### DIFF
--- a/src/elm/Cambiatus/Enum/ClaimStatus.elm
+++ b/src/elm/Cambiatus/Enum/ClaimStatus.elm
@@ -43,8 +43,8 @@ decoder =
 {-| Convert from the union type representing the Enum to a string that the GraphQL server will recognize.
 -}
 toString : ClaimStatus -> String
-toString enum =
-    case enum of
+toString enum____ =
+    case enum____ of
         Approved ->
             "APPROVED"
 
@@ -67,8 +67,8 @@ This can be useful for generating Strings to use for <select> menus to check whi
 
 -}
 fromString : String -> Maybe ClaimStatus
-fromString enumString =
-    case enumString of
+fromString enumString____ =
+    case enumString____ of
         "APPROVED" ->
             Just Approved
 

--- a/src/elm/Cambiatus/Enum/ContactType.elm
+++ b/src/elm/Cambiatus/Enum/ContactType.elm
@@ -63,8 +63,8 @@ decoder =
 {-| Convert from the union type representing the Enum to a string that the GraphQL server will recognize.
 -}
 toString : ContactType -> String
-toString enum =
-    case enum of
+toString enum____ =
+    case enum____ of
         Email ->
             "EMAIL"
 
@@ -96,8 +96,8 @@ This can be useful for generating Strings to use for <select> menus to check whi
 
 -}
 fromString : String -> Maybe ContactType
-fromString enumString =
-    case enumString of
+fromString enumString____ =
+    case enumString____ of
         "EMAIL" ->
             Just Email
 

--- a/src/elm/Cambiatus/Enum/ContributionStatusType.elm
+++ b/src/elm/Cambiatus/Enum/ContributionStatusType.elm
@@ -58,8 +58,8 @@ decoder =
 {-| Convert from the union type representing the Enum to a string that the GraphQL server will recognize.
 -}
 toString : ContributionStatusType -> String
-toString enum =
-    case enum of
+toString enum____ =
+    case enum____ of
         Approved ->
             "APPROVED"
 
@@ -88,8 +88,8 @@ This can be useful for generating Strings to use for <select> menus to check whi
 
 -}
 fromString : String -> Maybe ContributionStatusType
-fromString enumString =
-    case enumString of
+fromString enumString____ =
+    case enumString____ of
         "APPROVED" ->
             Just Approved
 

--- a/src/elm/Cambiatus/Enum/CurrencyType.elm
+++ b/src/elm/Cambiatus/Enum/CurrencyType.elm
@@ -63,8 +63,8 @@ decoder =
 {-| Convert from the union type representing the Enum to a string that the GraphQL server will recognize.
 -}
 toString : CurrencyType -> String
-toString enum =
-    case enum of
+toString enum____ =
+    case enum____ of
         Brl ->
             "BRL"
 
@@ -96,8 +96,8 @@ This can be useful for generating Strings to use for <select> menus to check whi
 
 -}
 fromString : String -> Maybe CurrencyType
-fromString enumString =
-    case enumString of
+fromString enumString____ =
+    case enumString____ of
         "BRL" ->
             Just Brl
 

--- a/src/elm/Cambiatus/Enum/Direction.elm
+++ b/src/elm/Cambiatus/Enum/Direction.elm
@@ -43,8 +43,8 @@ decoder =
 {-| Convert from the union type representing the Enum to a string that the GraphQL server will recognize.
 -}
 toString : Direction -> String
-toString enum =
-    case enum of
+toString enum____ =
+    case enum____ of
         Asc ->
             "ASC"
 
@@ -64,8 +64,8 @@ This can be useful for generating Strings to use for <select> menus to check whi
 
 -}
 fromString : String -> Maybe Direction
-fromString enumString =
-    case enumString of
+fromString enumString____ =
+    case enumString____ of
         "ASC" ->
             Just Asc
 

--- a/src/elm/Cambiatus/Enum/Language.elm
+++ b/src/elm/Cambiatus/Enum/Language.elm
@@ -53,8 +53,8 @@ decoder =
 {-| Convert from the union type representing the Enum to a string that the GraphQL server will recognize.
 -}
 toString : Language -> String
-toString enum =
-    case enum of
+toString enum____ =
+    case enum____ of
         Amheth ->
             "AMHETH"
 
@@ -80,8 +80,8 @@ This can be useful for generating Strings to use for <select> menus to check whi
 
 -}
 fromString : String -> Maybe Language
-fromString enumString =
-    case enumString of
+fromString enumString____ =
+    case enumString____ of
         "AMHETH" ->
             Just Amheth
 

--- a/src/elm/Cambiatus/Enum/OrderByFields.elm
+++ b/src/elm/Cambiatus/Enum/OrderByFields.elm
@@ -48,8 +48,8 @@ decoder =
 {-| Convert from the union type representing the Enum to a string that the GraphQL server will recognize.
 -}
 toString : OrderByFields -> String
-toString enum =
-    case enum of
+toString enum____ =
+    case enum____ of
         Account ->
             "account"
 
@@ -72,8 +72,8 @@ This can be useful for generating Strings to use for <select> menus to check whi
 
 -}
 fromString : String -> Maybe OrderByFields
-fromString enumString =
-    case enumString of
+fromString enumString____ =
+    case enumString____ of
         "account" ->
             Just Account
 

--- a/src/elm/Cambiatus/Enum/PaymentMethodType.elm
+++ b/src/elm/Cambiatus/Enum/PaymentMethodType.elm
@@ -53,8 +53,8 @@ decoder =
 {-| Convert from the union type representing the Enum to a string that the GraphQL server will recognize.
 -}
 toString : PaymentMethodType -> String
-toString enum =
-    case enum of
+toString enum____ =
+    case enum____ of
         Bitcoin ->
             "BITCOIN"
 
@@ -80,8 +80,8 @@ This can be useful for generating Strings to use for <select> menus to check whi
 
 -}
 fromString : String -> Maybe PaymentMethodType
-fromString enumString =
-    case enumString of
+fromString enumString____ =
+    case enumString____ of
         "BITCOIN" ->
             Just Bitcoin
 

--- a/src/elm/Cambiatus/Enum/Permission.elm
+++ b/src/elm/Cambiatus/Enum/Permission.elm
@@ -9,7 +9,7 @@ import Json.Decode as Decode exposing (Decoder)
 
 {-| Permissions a role can have
 
-  - Admin - Role permission that grants full administrative access to the community
+  - Admin - Role permission that grants community admin access
   - Award - Role permission that allows to award rewards on community actions
   - Claim - Role permission that allows to claim actions
   - Invite - Role permission that allows to create invitations to the community
@@ -73,8 +73,8 @@ decoder =
 {-| Convert from the union type representing the Enum to a string that the GraphQL server will recognize.
 -}
 toString : Permission -> String
-toString enum =
-    case enum of
+toString enum____ =
+    case enum____ of
         Admin ->
             "ADMIN"
 
@@ -112,8 +112,8 @@ This can be useful for generating Strings to use for <select> menus to check whi
 
 -}
 fromString : String -> Maybe Permission
-fromString enumString =
-    case enumString of
+fromString enumString____ =
+    case enumString____ of
         "ADMIN" ->
             Just Admin
 

--- a/src/elm/Cambiatus/Enum/ReactionEnum.elm
+++ b/src/elm/Cambiatus/Enum/ReactionEnum.elm
@@ -69,8 +69,8 @@ decoder =
 {-| Convert from the union type representing the Enum to a string that the GraphQL server will recognize.
 -}
 toString : ReactionEnum -> String
-toString enum =
-    case enum of
+toString enum____ =
+    case enum____ of
         ClappingHands ->
             "CLAPPING_HANDS"
 
@@ -114,8 +114,8 @@ This can be useful for generating Strings to use for <select> menus to check whi
 
 -}
 fromString : String -> Maybe ReactionEnum
-fromString enumString =
-    case enumString of
+fromString enumString____ =
+    case enumString____ of
         "CLAPPING_HANDS" ->
             Just ClappingHands
 

--- a/src/elm/Cambiatus/Enum/SearchByFields.elm
+++ b/src/elm/Cambiatus/Enum/SearchByFields.elm
@@ -53,8 +53,8 @@ decoder =
 {-| Convert from the union type representing the Enum to a string that the GraphQL server will recognize.
 -}
 toString : SearchByFields -> String
-toString enum =
-    case enum of
+toString enum____ =
+    case enum____ of
         Account ->
             "account"
 
@@ -80,8 +80,8 @@ This can be useful for generating Strings to use for <select> menus to check whi
 
 -}
 fromString : String -> Maybe SearchByFields
-fromString enumString =
-    case enumString of
+fromString enumString____ =
+    case enumString____ of
         "account" ->
             Just Account
 

--- a/src/elm/Cambiatus/Enum/TransferDirectionValue.elm
+++ b/src/elm/Cambiatus/Enum/TransferDirectionValue.elm
@@ -43,8 +43,8 @@ decoder =
 {-| Convert from the union type representing the Enum to a string that the GraphQL server will recognize.
 -}
 toString : TransferDirectionValue -> String
-toString enum =
-    case enum of
+toString enum____ =
+    case enum____ of
         Receiving ->
             "RECEIVING"
 
@@ -64,8 +64,8 @@ This can be useful for generating Strings to use for <select> menus to check whi
 
 -}
 fromString : String -> Maybe TransferDirectionValue
-fromString enumString =
-    case enumString of
+fromString enumString____ =
+    case enumString____ of
         "RECEIVING" ->
             Just Receiving
 

--- a/src/elm/Cambiatus/Enum/VerificationType.elm
+++ b/src/elm/Cambiatus/Enum/VerificationType.elm
@@ -10,7 +10,7 @@ import Json.Decode as Decode exposing (Decoder)
 {-| Action verification types
 
   - Automatic - An action that is verified automatically
-  - Claimable - An action that needs be mannually verified
+  - Claimable - An action that needs be manually verified
 
 -}
 type VerificationType
@@ -43,8 +43,8 @@ decoder =
 {-| Convert from the union type representing the Enum to a string that the GraphQL server will recognize.
 -}
 toString : VerificationType -> String
-toString enum =
-    case enum of
+toString enum____ =
+    case enum____ of
         Automatic ->
             "AUTOMATIC"
 
@@ -64,8 +64,8 @@ This can be useful for generating Strings to use for <select> menus to check whi
 
 -}
 fromString : String -> Maybe VerificationType
-fromString enumString =
-    case enumString of
+fromString enumString____ =
+    case enumString____ of
         "AUTOMATIC" ->
             Just Automatic
 

--- a/src/elm/Cambiatus/InputObject.elm
+++ b/src/elm/Cambiatus/InputObject.elm
@@ -26,13 +26,13 @@ import Json.Decode as Decode
 buildActionsInput :
     (ActionsInputOptionalFields -> ActionsInputOptionalFields)
     -> ActionsInput
-buildActionsInput fillOptionals =
+buildActionsInput fillOptionals____ =
     let
-        optionals =
-            fillOptionals
+        optionals____ =
+            fillOptionals____
                 { creator = Absent, isCompleted = Absent, validator = Absent, verificationType = Absent }
     in
-    { creator = optionals.creator, isCompleted = optionals.isCompleted, validator = optionals.validator, verificationType = optionals.verificationType }
+    { creator = optionals____.creator, isCompleted = optionals____.isCompleted, validator = optionals____.validator, verificationType = optionals____.verificationType }
 
 
 type alias ActionsInputOptionalFields =
@@ -56,22 +56,22 @@ type alias ActionsInput =
 {-| Encode a ActionsInput into a value that can be used as an argument.
 -}
 encodeActionsInput : ActionsInput -> Value
-encodeActionsInput input =
+encodeActionsInput input____ =
     Encode.maybeObject
-        [ ( "creator", Encode.string |> Encode.optional input.creator ), ( "isCompleted", Encode.bool |> Encode.optional input.isCompleted ), ( "validator", Encode.string |> Encode.optional input.validator ), ( "verificationType", Encode.enum Cambiatus.Enum.VerificationType.toString |> Encode.optional input.verificationType ) ]
+        [ ( "creator", Encode.string |> Encode.optional input____.creator ), ( "isCompleted", Encode.bool |> Encode.optional input____.isCompleted ), ( "validator", Encode.string |> Encode.optional input____.validator ), ( "verificationType", Encode.enum Cambiatus.Enum.VerificationType.toString |> Encode.optional input____.verificationType ) ]
 
 
 buildAddressUpdateInput :
     AddressUpdateInputRequiredFields
     -> (AddressUpdateInputOptionalFields -> AddressUpdateInputOptionalFields)
     -> AddressUpdateInput
-buildAddressUpdateInput required fillOptionals =
+buildAddressUpdateInput required____ fillOptionals____ =
     let
-        optionals =
-            fillOptionals
+        optionals____ =
+            fillOptionals____
                 { number = Absent }
     in
-    { cityId = required.cityId, countryId = required.countryId, neighborhoodId = required.neighborhoodId, number = optionals.number, stateId = required.stateId, street = required.street, zip = required.zip }
+    { cityId = required____.cityId, countryId = required____.countryId, neighborhoodId = required____.neighborhoodId, number = optionals____.number, stateId = required____.stateId, street = required____.street, zip = required____.zip }
 
 
 type alias AddressUpdateInputRequiredFields =
@@ -104,21 +104,21 @@ type alias AddressUpdateInput =
 {-| Encode a AddressUpdateInput into a value that can be used as an argument.
 -}
 encodeAddressUpdateInput : AddressUpdateInput -> Value
-encodeAddressUpdateInput input =
+encodeAddressUpdateInput input____ =
     Encode.maybeObject
-        [ ( "cityId", (Cambiatus.ScalarCodecs.codecs |> Cambiatus.Scalar.unwrapEncoder .codecId) input.cityId |> Just ), ( "countryId", (Cambiatus.ScalarCodecs.codecs |> Cambiatus.Scalar.unwrapEncoder .codecId) input.countryId |> Just ), ( "neighborhoodId", (Cambiatus.ScalarCodecs.codecs |> Cambiatus.Scalar.unwrapEncoder .codecId) input.neighborhoodId |> Just ), ( "number", Encode.string |> Encode.optional input.number ), ( "stateId", (Cambiatus.ScalarCodecs.codecs |> Cambiatus.Scalar.unwrapEncoder .codecId) input.stateId |> Just ), ( "street", Encode.string input.street |> Just ), ( "zip", Encode.string input.zip |> Just ) ]
+        [ ( "cityId", (Cambiatus.ScalarCodecs.codecs |> Cambiatus.Scalar.unwrapEncoder .codecId) input____.cityId |> Just ), ( "countryId", (Cambiatus.ScalarCodecs.codecs |> Cambiatus.Scalar.unwrapEncoder .codecId) input____.countryId |> Just ), ( "neighborhoodId", (Cambiatus.ScalarCodecs.codecs |> Cambiatus.Scalar.unwrapEncoder .codecId) input____.neighborhoodId |> Just ), ( "number", Encode.string |> Encode.optional input____.number ), ( "stateId", (Cambiatus.ScalarCodecs.codecs |> Cambiatus.Scalar.unwrapEncoder .codecId) input____.stateId |> Just ), ( "street", Encode.string input____.street |> Just ), ( "zip", Encode.string input____.zip |> Just ) ]
 
 
 buildChecksInput :
     (ChecksInputOptionalFields -> ChecksInputOptionalFields)
     -> ChecksInput
-buildChecksInput fillOptionals =
+buildChecksInput fillOptionals____ =
     let
-        optionals =
-            fillOptionals
+        optionals____ =
+            fillOptionals____
                 { validator = Absent }
     in
-    { validator = optionals.validator }
+    { validator = optionals____.validator }
 
 
 type alias ChecksInputOptionalFields =
@@ -134,21 +134,21 @@ type alias ChecksInput =
 {-| Encode a ChecksInput into a value that can be used as an argument.
 -}
 encodeChecksInput : ChecksInput -> Value
-encodeChecksInput input =
+encodeChecksInput input____ =
     Encode.maybeObject
-        [ ( "validator", Encode.string |> Encode.optional input.validator ) ]
+        [ ( "validator", Encode.string |> Encode.optional input____.validator ) ]
 
 
 buildClaimsFilter :
     (ClaimsFilterOptionalFields -> ClaimsFilterOptionalFields)
     -> ClaimsFilter
-buildClaimsFilter fillOptionals =
+buildClaimsFilter fillOptionals____ =
     let
-        optionals =
-            fillOptionals
+        optionals____ =
+            fillOptionals____
                 { claimer = Absent, direction = Absent, status = Absent }
     in
-    { claimer = optionals.claimer, direction = optionals.direction, status = optionals.status }
+    { claimer = optionals____.claimer, direction = optionals____.direction, status = optionals____.status }
 
 
 type alias ClaimsFilterOptionalFields =
@@ -170,21 +170,21 @@ type alias ClaimsFilter =
 {-| Encode a ClaimsFilter into a value that can be used as an argument.
 -}
 encodeClaimsFilter : ClaimsFilter -> Value
-encodeClaimsFilter input =
+encodeClaimsFilter input____ =
     Encode.maybeObject
-        [ ( "claimer", Encode.string |> Encode.optional input.claimer ), ( "direction", Encode.enum Cambiatus.Enum.Direction.toString |> Encode.optional input.direction ), ( "status", Encode.string |> Encode.optional input.status ) ]
+        [ ( "claimer", Encode.string |> Encode.optional input____.claimer ), ( "direction", Encode.enum Cambiatus.Enum.Direction.toString |> Encode.optional input____.direction ), ( "status", Encode.string |> Encode.optional input____.status ) ]
 
 
 buildCommunityUpdateInput :
     (CommunityUpdateInputOptionalFields -> CommunityUpdateInputOptionalFields)
     -> CommunityUpdateInput
-buildCommunityUpdateInput fillOptionals =
+buildCommunityUpdateInput fillOptionals____ =
     let
-        optionals =
-            fillOptionals
+        optionals____ =
+            fillOptionals____
                 { contacts = Absent, hasNews = Absent }
     in
-    { contacts = optionals.contacts, hasNews = optionals.hasNews }
+    { contacts = optionals____.contacts, hasNews = optionals____.hasNews }
 
 
 type alias CommunityUpdateInputOptionalFields =
@@ -204,21 +204,21 @@ type alias CommunityUpdateInput =
 {-| Encode a CommunityUpdateInput into a value that can be used as an argument.
 -}
 encodeCommunityUpdateInput : CommunityUpdateInput -> Value
-encodeCommunityUpdateInput input =
+encodeCommunityUpdateInput input____ =
     Encode.maybeObject
-        [ ( "contacts", (encodeContactInput |> Encode.list) |> Encode.optional input.contacts ), ( "hasNews", Encode.bool |> Encode.optional input.hasNews ) ]
+        [ ( "contacts", (encodeContactInput |> Encode.list) |> Encode.optional input____.contacts ), ( "hasNews", Encode.bool |> Encode.optional input____.hasNews ) ]
 
 
 buildContactInput :
     (ContactInputOptionalFields -> ContactInputOptionalFields)
     -> ContactInput
-buildContactInput fillOptionals =
+buildContactInput fillOptionals____ =
     let
-        optionals =
-            fillOptionals
+        optionals____ =
+            fillOptionals____
                 { externalId = Absent, label = Absent, type_ = Absent }
     in
-    { externalId = optionals.externalId, label = optionals.label, type_ = optionals.type_ }
+    { externalId = optionals____.externalId, label = optionals____.label, type_ = optionals____.type_ }
 
 
 type alias ContactInputOptionalFields =
@@ -240,16 +240,16 @@ type alias ContactInput =
 {-| Encode a ContactInput into a value that can be used as an argument.
 -}
 encodeContactInput : ContactInput -> Value
-encodeContactInput input =
+encodeContactInput input____ =
     Encode.maybeObject
-        [ ( "externalId", Encode.string |> Encode.optional input.externalId ), ( "label", Encode.string |> Encode.optional input.label ), ( "type", Encode.enum Cambiatus.Enum.ContactType.toString |> Encode.optional input.type_ ) ]
+        [ ( "externalId", Encode.string |> Encode.optional input____.externalId ), ( "label", Encode.string |> Encode.optional input____.label ), ( "type", Encode.enum Cambiatus.Enum.ContactType.toString |> Encode.optional input____.type_ ) ]
 
 
 buildCountryInput :
     CountryInputRequiredFields
     -> CountryInput
-buildCountryInput required =
-    { name = required.name }
+buildCountryInput required____ =
+    { name = required____.name }
 
 
 type alias CountryInputRequiredFields =
@@ -265,16 +265,16 @@ type alias CountryInput =
 {-| Encode a CountryInput into a value that can be used as an argument.
 -}
 encodeCountryInput : CountryInput -> Value
-encodeCountryInput input =
+encodeCountryInput input____ =
     Encode.maybeObject
-        [ ( "name", Encode.string input.name |> Just ) ]
+        [ ( "name", Encode.string input____.name |> Just ) ]
 
 
 buildKycDataUpdateInput :
     KycDataUpdateInputRequiredFields
     -> KycDataUpdateInput
-buildKycDataUpdateInput required =
-    { countryId = required.countryId, document = required.document, documentType = required.documentType, phone = required.phone, userType = required.userType }
+buildKycDataUpdateInput required____ =
+    { countryId = required____.countryId, document = required____.document, documentType = required____.documentType, phone = required____.phone, userType = required____.userType }
 
 
 type alias KycDataUpdateInputRequiredFields =
@@ -300,21 +300,21 @@ type alias KycDataUpdateInput =
 {-| Encode a KycDataUpdateInput into a value that can be used as an argument.
 -}
 encodeKycDataUpdateInput : KycDataUpdateInput -> Value
-encodeKycDataUpdateInput input =
+encodeKycDataUpdateInput input____ =
     Encode.maybeObject
-        [ ( "countryId", (Cambiatus.ScalarCodecs.codecs |> Cambiatus.Scalar.unwrapEncoder .codecId) input.countryId |> Just ), ( "document", Encode.string input.document |> Just ), ( "documentType", Encode.string input.documentType |> Just ), ( "phone", Encode.string input.phone |> Just ), ( "userType", Encode.string input.userType |> Just ) ]
+        [ ( "countryId", (Cambiatus.ScalarCodecs.codecs |> Cambiatus.Scalar.unwrapEncoder .codecId) input____.countryId |> Just ), ( "document", Encode.string input____.document |> Just ), ( "documentType", Encode.string input____.documentType |> Just ), ( "phone", Encode.string input____.phone |> Just ), ( "userType", Encode.string input____.userType |> Just ) ]
 
 
 buildMembersFilterInput :
     (MembersFilterInputOptionalFields -> MembersFilterInputOptionalFields)
     -> MembersFilterInput
-buildMembersFilterInput fillOptionals =
+buildMembersFilterInput fillOptionals____ =
     let
-        optionals =
-            fillOptionals
+        optionals____ =
+            fillOptionals____
                 { orderDirection = Absent, orderMembersBy = Absent, searchMembersBy = Absent, searchString = Absent }
     in
-    { orderDirection = optionals.orderDirection, orderMembersBy = optionals.orderMembersBy, searchMembersBy = optionals.searchMembersBy, searchString = optionals.searchString }
+    { orderDirection = optionals____.orderDirection, orderMembersBy = optionals____.orderMembersBy, searchMembersBy = optionals____.searchMembersBy, searchString = optionals____.searchString }
 
 
 type alias MembersFilterInputOptionalFields =
@@ -338,16 +338,16 @@ type alias MembersFilterInput =
 {-| Encode a MembersFilterInput into a value that can be used as an argument.
 -}
 encodeMembersFilterInput : MembersFilterInput -> Value
-encodeMembersFilterInput input =
+encodeMembersFilterInput input____ =
     Encode.maybeObject
-        [ ( "orderDirection", Encode.enum Cambiatus.Enum.Direction.toString |> Encode.optional input.orderDirection ), ( "orderMembersBy", Encode.enum Cambiatus.Enum.OrderByFields.toString |> Encode.optional input.orderMembersBy ), ( "searchMembersBy", (Encode.enum Cambiatus.Enum.SearchByFields.toString |> Encode.maybe |> Encode.list) |> Encode.optional input.searchMembersBy ), ( "searchString", Encode.string |> Encode.optional input.searchString ) ]
+        [ ( "orderDirection", Encode.enum Cambiatus.Enum.Direction.toString |> Encode.optional input____.orderDirection ), ( "orderMembersBy", Encode.enum Cambiatus.Enum.OrderByFields.toString |> Encode.optional input____.orderMembersBy ), ( "searchMembersBy", (Encode.enum Cambiatus.Enum.SearchByFields.toString |> Encode.maybe |> Encode.list) |> Encode.optional input____.searchMembersBy ), ( "searchString", Encode.string |> Encode.optional input____.searchString ) ]
 
 
 buildNewCommunityInput :
     NewCommunityInputRequiredFields
     -> NewCommunityInput
-buildNewCommunityInput required =
-    { symbol = required.symbol }
+buildNewCommunityInput required____ =
+    { symbol = required____.symbol }
 
 
 type alias NewCommunityInputRequiredFields =
@@ -363,21 +363,21 @@ type alias NewCommunityInput =
 {-| Encode a NewCommunityInput into a value that can be used as an argument.
 -}
 encodeNewCommunityInput : NewCommunityInput -> Value
-encodeNewCommunityInput input =
+encodeNewCommunityInput input____ =
     Encode.maybeObject
-        [ ( "symbol", Encode.string input.symbol |> Just ) ]
+        [ ( "symbol", Encode.string input____.symbol |> Just ) ]
 
 
 buildProductsFilterInput :
     (ProductsFilterInputOptionalFields -> ProductsFilterInputOptionalFields)
     -> ProductsFilterInput
-buildProductsFilterInput fillOptionals =
+buildProductsFilterInput fillOptionals____ =
     let
-        optionals =
-            fillOptionals
+        optionals____ =
+            fillOptionals____
                 { account = Absent, categoriesIds = Absent, inStock = Absent }
     in
-    { account = optionals.account, categoriesIds = optionals.categoriesIds, inStock = optionals.inStock }
+    { account = optionals____.account, categoriesIds = optionals____.categoriesIds, inStock = optionals____.inStock }
 
 
 type alias ProductsFilterInputOptionalFields =
@@ -399,16 +399,16 @@ type alias ProductsFilterInput =
 {-| Encode a ProductsFilterInput into a value that can be used as an argument.
 -}
 encodeProductsFilterInput : ProductsFilterInput -> Value
-encodeProductsFilterInput input =
+encodeProductsFilterInput input____ =
     Encode.maybeObject
-        [ ( "account", Encode.string |> Encode.optional input.account ), ( "categoriesIds", (Encode.int |> Encode.maybe |> Encode.list) |> Encode.optional input.categoriesIds ), ( "inStock", Encode.bool |> Encode.optional input.inStock ) ]
+        [ ( "account", Encode.string |> Encode.optional input____.account ), ( "categoriesIds", (Encode.int |> Encode.maybe |> Encode.list) |> Encode.optional input____.categoriesIds ), ( "inStock", Encode.bool |> Encode.optional input____.inStock ) ]
 
 
 buildPushSubscriptionInput :
     PushSubscriptionInputRequiredFields
     -> PushSubscriptionInput
-buildPushSubscriptionInput required =
-    { authKey = required.authKey, endpoint = required.endpoint, pKey = required.pKey }
+buildPushSubscriptionInput required____ =
+    { authKey = required____.authKey, endpoint = required____.endpoint, pKey = required____.pKey }
 
 
 type alias PushSubscriptionInputRequiredFields =
@@ -430,16 +430,16 @@ type alias PushSubscriptionInput =
 {-| Encode a PushSubscriptionInput into a value that can be used as an argument.
 -}
 encodePushSubscriptionInput : PushSubscriptionInput -> Value
-encodePushSubscriptionInput input =
+encodePushSubscriptionInput input____ =
     Encode.maybeObject
-        [ ( "authKey", Encode.string input.authKey |> Just ), ( "endpoint", Encode.string input.endpoint |> Just ), ( "pKey", Encode.string input.pKey |> Just ) ]
+        [ ( "authKey", Encode.string input____.authKey |> Just ), ( "endpoint", Encode.string input____.endpoint |> Just ), ( "pKey", Encode.string input____.pKey |> Just ) ]
 
 
 buildReadNotificationInput :
     ReadNotificationInputRequiredFields
     -> ReadNotificationInput
-buildReadNotificationInput required =
-    { id = required.id }
+buildReadNotificationInput required____ =
+    { id = required____.id }
 
 
 type alias ReadNotificationInputRequiredFields =
@@ -455,16 +455,16 @@ type alias ReadNotificationInput =
 {-| Encode a ReadNotificationInput into a value that can be used as an argument.
 -}
 encodeReadNotificationInput : ReadNotificationInput -> Value
-encodeReadNotificationInput input =
+encodeReadNotificationInput input____ =
     Encode.maybeObject
-        [ ( "id", Encode.int input.id |> Just ) ]
+        [ ( "id", Encode.int input____.id |> Just ) ]
 
 
 buildSubcategoryInput :
     SubcategoryInputRequiredFields
     -> SubcategoryInput
-buildSubcategoryInput required =
-    { id = required.id, position = required.position }
+buildSubcategoryInput required____ =
+    { id = required____.id, position = required____.position }
 
 
 type alias SubcategoryInputRequiredFields =
@@ -484,21 +484,21 @@ type alias SubcategoryInput =
 {-| Encode a SubcategoryInput into a value that can be used as an argument.
 -}
 encodeSubcategoryInput : SubcategoryInput -> Value
-encodeSubcategoryInput input =
+encodeSubcategoryInput input____ =
     Encode.maybeObject
-        [ ( "id", Encode.int input.id |> Just ), ( "position", Encode.int input.position |> Just ) ]
+        [ ( "id", Encode.int input____.id |> Just ), ( "position", Encode.int input____.position |> Just ) ]
 
 
 buildTransferDirection :
     (TransferDirectionOptionalFields -> TransferDirectionOptionalFields)
     -> TransferDirection
-buildTransferDirection fillOptionals =
+buildTransferDirection fillOptionals____ =
     let
-        optionals =
-            fillOptionals
+        optionals____ =
+            fillOptionals____
                 { direction = Absent, otherAccount = Absent }
     in
-    { direction = optionals.direction, otherAccount = optionals.otherAccount }
+    { direction = optionals____.direction, otherAccount = optionals____.otherAccount }
 
 
 type alias TransferDirectionOptionalFields =
@@ -518,21 +518,21 @@ type alias TransferDirection =
 {-| Encode a TransferDirection into a value that can be used as an argument.
 -}
 encodeTransferDirection : TransferDirection -> Value
-encodeTransferDirection input =
+encodeTransferDirection input____ =
     Encode.maybeObject
-        [ ( "direction", Encode.enum Cambiatus.Enum.TransferDirectionValue.toString |> Encode.optional input.direction ), ( "otherAccount", Encode.string |> Encode.optional input.otherAccount ) ]
+        [ ( "direction", Encode.enum Cambiatus.Enum.TransferDirectionValue.toString |> Encode.optional input____.direction ), ( "otherAccount", Encode.string |> Encode.optional input____.otherAccount ) ]
 
 
 buildTransferFilter :
     (TransferFilterOptionalFields -> TransferFilterOptionalFields)
     -> TransferFilter
-buildTransferFilter fillOptionals =
+buildTransferFilter fillOptionals____ =
     let
-        optionals =
-            fillOptionals
+        optionals____ =
+            fillOptionals____
                 { communityId = Absent, date = Absent, direction = Absent }
     in
-    { communityId = optionals.communityId, date = optionals.date, direction = optionals.direction }
+    { communityId = optionals____.communityId, date = optionals____.date, direction = optionals____.direction }
 
 
 type alias TransferFilterOptionalFields =
@@ -554,16 +554,16 @@ type alias TransferFilter =
 {-| Encode a TransferFilter into a value that can be used as an argument.
 -}
 encodeTransferFilter : TransferFilter -> Value
-encodeTransferFilter input =
+encodeTransferFilter input____ =
     Encode.maybeObject
-        [ ( "communityId", Encode.string |> Encode.optional input.communityId ), ( "date", (Cambiatus.ScalarCodecs.codecs |> Cambiatus.Scalar.unwrapEncoder .codecDate) |> Encode.optional input.date ), ( "direction", encodeTransferDirection |> Encode.optional input.direction ) ]
+        [ ( "communityId", Encode.string |> Encode.optional input____.communityId ), ( "date", (Cambiatus.ScalarCodecs.codecs |> Cambiatus.Scalar.unwrapEncoder .codecDate) |> Encode.optional input____.date ), ( "direction", encodeTransferDirection |> Encode.optional input____.direction ) ]
 
 
 buildTransferSucceedInput :
     TransferSucceedInputRequiredFields
     -> TransferSucceedInput
-buildTransferSucceedInput required =
-    { from = required.from, symbol = required.symbol, to = required.to }
+buildTransferSucceedInput required____ =
+    { from = required____.from, symbol = required____.symbol, to = required____.to }
 
 
 type alias TransferSucceedInputRequiredFields =
@@ -585,16 +585,16 @@ type alias TransferSucceedInput =
 {-| Encode a TransferSucceedInput into a value that can be used as an argument.
 -}
 encodeTransferSucceedInput : TransferSucceedInput -> Value
-encodeTransferSucceedInput input =
+encodeTransferSucceedInput input____ =
     Encode.maybeObject
-        [ ( "from", Encode.string input.from |> Just ), ( "symbol", Encode.string input.symbol |> Just ), ( "to", Encode.string input.to |> Just ) ]
+        [ ( "from", Encode.string input____.from |> Just ), ( "symbol", Encode.string input____.symbol |> Just ), ( "to", Encode.string input____.to |> Just ) ]
 
 
 buildUnreadNotificationsSubscriptionInput :
     UnreadNotificationsSubscriptionInputRequiredFields
     -> UnreadNotificationsSubscriptionInput
-buildUnreadNotificationsSubscriptionInput required =
-    { account = required.account }
+buildUnreadNotificationsSubscriptionInput required____ =
+    { account = required____.account }
 
 
 type alias UnreadNotificationsSubscriptionInputRequiredFields =
@@ -610,21 +610,21 @@ type alias UnreadNotificationsSubscriptionInput =
 {-| Encode a UnreadNotificationsSubscriptionInput into a value that can be used as an argument.
 -}
 encodeUnreadNotificationsSubscriptionInput : UnreadNotificationsSubscriptionInput -> Value
-encodeUnreadNotificationsSubscriptionInput input =
+encodeUnreadNotificationsSubscriptionInput input____ =
     Encode.maybeObject
-        [ ( "account", Encode.string input.account |> Just ) ]
+        [ ( "account", Encode.string input____.account |> Just ) ]
 
 
 buildUserUpdateInput :
     (UserUpdateInputOptionalFields -> UserUpdateInputOptionalFields)
     -> UserUpdateInput
-buildUserUpdateInput fillOptionals =
+buildUserUpdateInput fillOptionals____ =
     let
-        optionals =
-            fillOptionals
+        optionals____ =
+            fillOptionals____
                 { avatar = Absent, bio = Absent, claimNotification = Absent, contacts = Absent, digest = Absent, email = Absent, interests = Absent, location = Absent, name = Absent, transferNotification = Absent }
     in
-    { avatar = optionals.avatar, bio = optionals.bio, claimNotification = optionals.claimNotification, contacts = optionals.contacts, digest = optionals.digest, email = optionals.email, interests = optionals.interests, location = optionals.location, name = optionals.name, transferNotification = optionals.transferNotification }
+    { avatar = optionals____.avatar, bio = optionals____.bio, claimNotification = optionals____.claimNotification, contacts = optionals____.contacts, digest = optionals____.digest, email = optionals____.email, interests = optionals____.interests, location = optionals____.location, name = optionals____.name, transferNotification = optionals____.transferNotification }
 
 
 type alias UserUpdateInputOptionalFields =
@@ -660,6 +660,6 @@ type alias UserUpdateInput =
 {-| Encode a UserUpdateInput into a value that can be used as an argument.
 -}
 encodeUserUpdateInput : UserUpdateInput -> Value
-encodeUserUpdateInput input =
+encodeUserUpdateInput input____ =
     Encode.maybeObject
-        [ ( "avatar", Encode.string |> Encode.optional input.avatar ), ( "bio", Encode.string |> Encode.optional input.bio ), ( "claimNotification", Encode.bool |> Encode.optional input.claimNotification ), ( "contacts", (encodeContactInput |> Encode.list) |> Encode.optional input.contacts ), ( "digest", Encode.bool |> Encode.optional input.digest ), ( "email", Encode.string |> Encode.optional input.email ), ( "interests", Encode.string |> Encode.optional input.interests ), ( "location", Encode.string |> Encode.optional input.location ), ( "name", Encode.string |> Encode.optional input.name ), ( "transferNotification", Encode.bool |> Encode.optional input.transferNotification ) ]
+        [ ( "avatar", Encode.string |> Encode.optional input____.avatar ), ( "bio", Encode.string |> Encode.optional input____.bio ), ( "claimNotification", Encode.bool |> Encode.optional input____.claimNotification ), ( "contacts", (encodeContactInput |> Encode.list) |> Encode.optional input____.contacts ), ( "digest", Encode.bool |> Encode.optional input____.digest ), ( "email", Encode.string |> Encode.optional input____.email ), ( "interests", Encode.string |> Encode.optional input____.interests ), ( "location", Encode.string |> Encode.optional input____.location ), ( "name", Encode.string |> Encode.optional input____.name ), ( "transferNotification", Encode.bool |> Encode.optional input____.transferNotification ) ]

--- a/src/elm/Cambiatus/Mutation.elm
+++ b/src/elm/Cambiatus/Mutation.elm
@@ -27,8 +27,8 @@ import Json.Decode as Decode exposing (Decoder)
 acceptTerms :
     SelectionSet decodesTo Cambiatus.Object.User
     -> SelectionSet (Maybe decodesTo) RootMutation
-acceptTerms object_ =
-    Object.selectionForCompositeField "acceptTerms" [] object_ (identity >> Decode.nullable)
+acceptTerms object____ =
+    Object.selectionForCompositeField "acceptTerms" [] object____ (Basics.identity >> Decode.nullable)
 
 
 type alias AddCommunityPhotosRequiredArguments =
@@ -43,8 +43,8 @@ addCommunityPhotos :
     AddCommunityPhotosRequiredArguments
     -> SelectionSet decodesTo Cambiatus.Object.Community
     -> SelectionSet (Maybe decodesTo) RootMutation
-addCommunityPhotos requiredArgs object_ =
-    Object.selectionForCompositeField "addCommunityPhotos" [ Argument.required "symbol" requiredArgs.symbol Encode.string, Argument.required "urls" requiredArgs.urls (Encode.string |> Encode.list) ] object_ (identity >> Decode.nullable)
+addCommunityPhotos requiredArgs____ object____ =
+    Object.selectionForCompositeField "addCommunityPhotos" [ Argument.required "symbol" requiredArgs____.symbol Encode.string, Argument.required "urls" requiredArgs____.urls (Encode.string |> Encode.list) ] object____ (Basics.identity >> Decode.nullable)
 
 
 type alias CategoryOptionalArguments =
@@ -73,16 +73,16 @@ category :
     (CategoryOptionalArguments -> CategoryOptionalArguments)
     -> SelectionSet decodesTo Cambiatus.Object.Category
     -> SelectionSet (Maybe decodesTo) RootMutation
-category fillInOptionals object_ =
+category fillInOptionals____ object____ =
     let
-        filledInOptionals =
-            fillInOptionals { categories = Absent, description = Absent, iconUri = Absent, id = Absent, imageUri = Absent, metaDescription = Absent, metaKeywords = Absent, metaTitle = Absent, name = Absent, parentId = Absent, position = Absent, slug = Absent }
+        filledInOptionals____ =
+            fillInOptionals____ { categories = Absent, description = Absent, iconUri = Absent, id = Absent, imageUri = Absent, metaDescription = Absent, metaKeywords = Absent, metaTitle = Absent, name = Absent, parentId = Absent, position = Absent, slug = Absent }
 
-        optionalArgs =
-            [ Argument.optional "categories" filledInOptionals.categories (Cambiatus.InputObject.encodeSubcategoryInput |> Encode.list), Argument.optional "description" filledInOptionals.description Encode.string, Argument.optional "iconUri" filledInOptionals.iconUri Encode.string, Argument.optional "id" filledInOptionals.id Encode.int, Argument.optional "imageUri" filledInOptionals.imageUri Encode.string, Argument.optional "metaDescription" filledInOptionals.metaDescription Encode.string, Argument.optional "metaKeywords" filledInOptionals.metaKeywords Encode.string, Argument.optional "metaTitle" filledInOptionals.metaTitle Encode.string, Argument.optional "name" filledInOptionals.name Encode.string, Argument.optional "parentId" filledInOptionals.parentId Encode.int, Argument.optional "position" filledInOptionals.position Encode.int, Argument.optional "slug" filledInOptionals.slug Encode.string ]
-                |> List.filterMap identity
+        optionalArgs____ =
+            [ Argument.optional "categories" filledInOptionals____.categories (Cambiatus.InputObject.encodeSubcategoryInput |> Encode.list), Argument.optional "description" filledInOptionals____.description Encode.string, Argument.optional "iconUri" filledInOptionals____.iconUri Encode.string, Argument.optional "id" filledInOptionals____.id Encode.int, Argument.optional "imageUri" filledInOptionals____.imageUri Encode.string, Argument.optional "metaDescription" filledInOptionals____.metaDescription Encode.string, Argument.optional "metaKeywords" filledInOptionals____.metaKeywords Encode.string, Argument.optional "metaTitle" filledInOptionals____.metaTitle Encode.string, Argument.optional "name" filledInOptionals____.name Encode.string, Argument.optional "parentId" filledInOptionals____.parentId Encode.int, Argument.optional "position" filledInOptionals____.position Encode.int, Argument.optional "slug" filledInOptionals____.slug Encode.string ]
+                |> List.filterMap Basics.identity
     in
-    Object.selectionForCompositeField "category" optionalArgs object_ (identity >> Decode.nullable)
+    Object.selectionForCompositeField "category" optionalArgs____ object____ (Basics.identity >> Decode.nullable)
 
 
 type alias CommunityRequiredArguments =
@@ -95,8 +95,8 @@ community :
     CommunityRequiredArguments
     -> SelectionSet decodesTo Cambiatus.Object.Community
     -> SelectionSet (Maybe decodesTo) RootMutation
-community requiredArgs object_ =
-    Object.selectionForCompositeField "community" [ Argument.required "input" requiredArgs.input Cambiatus.InputObject.encodeCommunityUpdateInput ] object_ (identity >> Decode.nullable)
+community requiredArgs____ object____ =
+    Object.selectionForCompositeField "community" [ Argument.required "input" requiredArgs____.input Cambiatus.InputObject.encodeCommunityUpdateInput ] object____ (Basics.identity >> Decode.nullable)
 
 
 type alias CompleteObjectiveRequiredArguments =
@@ -109,8 +109,8 @@ completeObjective :
     CompleteObjectiveRequiredArguments
     -> SelectionSet decodesTo Cambiatus.Object.Objective
     -> SelectionSet (Maybe decodesTo) RootMutation
-completeObjective requiredArgs object_ =
-    Object.selectionForCompositeField "completeObjective" [ Argument.required "id" requiredArgs.id Encode.int ] object_ (identity >> Decode.nullable)
+completeObjective requiredArgs____ object____ =
+    Object.selectionForCompositeField "completeObjective" [ Argument.required "id" requiredArgs____.id Encode.int ] object____ (Basics.identity >> Decode.nullable)
 
 
 type alias ContributionRequiredArguments =
@@ -125,8 +125,8 @@ contribution :
     ContributionRequiredArguments
     -> SelectionSet decodesTo Cambiatus.Object.Contribution
     -> SelectionSet (Maybe decodesTo) RootMutation
-contribution requiredArgs object_ =
-    Object.selectionForCompositeField "contribution" [ Argument.required "amount" requiredArgs.amount Encode.float, Argument.required "currency" requiredArgs.currency (Encode.enum Cambiatus.Enum.CurrencyType.toString) ] object_ (identity >> Decode.nullable)
+contribution requiredArgs____ object____ =
+    Object.selectionForCompositeField "contribution" [ Argument.required "amount" requiredArgs____.amount Encode.float, Argument.required "currency" requiredArgs____.currency (Encode.enum Cambiatus.Enum.CurrencyType.toString) ] object____ (Basics.identity >> Decode.nullable)
 
 
 {-| [Auth required] A mutation to delete user's address data
@@ -134,8 +134,8 @@ contribution requiredArgs object_ =
 deleteAddress :
     SelectionSet decodesTo Cambiatus.Object.DeleteStatus
     -> SelectionSet (Maybe decodesTo) RootMutation
-deleteAddress object_ =
-    Object.selectionForCompositeField "deleteAddress" [] object_ (identity >> Decode.nullable)
+deleteAddress object____ =
+    Object.selectionForCompositeField "deleteAddress" [] object____ (Basics.identity >> Decode.nullable)
 
 
 type alias DeleteCategoryRequiredArguments =
@@ -148,8 +148,8 @@ deleteCategory :
     DeleteCategoryRequiredArguments
     -> SelectionSet decodesTo Cambiatus.Object.DeleteStatus
     -> SelectionSet (Maybe decodesTo) RootMutation
-deleteCategory requiredArgs object_ =
-    Object.selectionForCompositeField "deleteCategory" [ Argument.required "id" requiredArgs.id Encode.int ] object_ (identity >> Decode.nullable)
+deleteCategory requiredArgs____ object____ =
+    Object.selectionForCompositeField "deleteCategory" [ Argument.required "id" requiredArgs____.id Encode.int ] object____ (Basics.identity >> Decode.nullable)
 
 
 {-| [Auth required] A mutation to delete user's kyc data
@@ -157,8 +157,8 @@ deleteCategory requiredArgs object_ =
 deleteKyc :
     SelectionSet decodesTo Cambiatus.Object.DeleteStatus
     -> SelectionSet (Maybe decodesTo) RootMutation
-deleteKyc object_ =
-    Object.selectionForCompositeField "deleteKyc" [] object_ (identity >> Decode.nullable)
+deleteKyc object____ =
+    Object.selectionForCompositeField "deleteKyc" [] object____ (Basics.identity >> Decode.nullable)
 
 
 type alias DeleteNewsRequiredArguments =
@@ -171,8 +171,8 @@ deleteNews :
     DeleteNewsRequiredArguments
     -> SelectionSet decodesTo Cambiatus.Object.DeleteStatus
     -> SelectionSet (Maybe decodesTo) RootMutation
-deleteNews requiredArgs object_ =
-    Object.selectionForCompositeField "deleteNews" [ Argument.required "newsId" requiredArgs.newsId Encode.int ] object_ (identity >> Decode.nullable)
+deleteNews requiredArgs____ object____ =
+    Object.selectionForCompositeField "deleteNews" [ Argument.required "newsId" requiredArgs____.newsId Encode.int ] object____ (Basics.identity >> Decode.nullable)
 
 
 type alias DeleteProductRequiredArguments =
@@ -185,8 +185,8 @@ deleteProduct :
     DeleteProductRequiredArguments
     -> SelectionSet decodesTo Cambiatus.Object.DeleteStatus
     -> SelectionSet (Maybe decodesTo) RootMutation
-deleteProduct requiredArgs object_ =
-    Object.selectionForCompositeField "deleteProduct" [ Argument.required "id" requiredArgs.id Encode.int ] object_ (identity >> Decode.nullable)
+deleteProduct requiredArgs____ object____ =
+    Object.selectionForCompositeField "deleteProduct" [ Argument.required "id" requiredArgs____.id Encode.int ] object____ (Basics.identity >> Decode.nullable)
 
 
 type alias GenAuthRequiredArguments =
@@ -199,8 +199,8 @@ genAuth :
     GenAuthRequiredArguments
     -> SelectionSet decodesTo Cambiatus.Object.Request
     -> SelectionSet decodesTo RootMutation
-genAuth requiredArgs object_ =
-    Object.selectionForCompositeField "genAuth" [ Argument.required "account" requiredArgs.account Encode.string ] object_ identity
+genAuth requiredArgs____ object____ =
+    Object.selectionForCompositeField "genAuth" [ Argument.required "account" requiredArgs____.account Encode.string ] object____ Basics.identity
 
 
 type alias HighlightedNewsOptionalArguments =
@@ -213,16 +213,16 @@ highlightedNews :
     (HighlightedNewsOptionalArguments -> HighlightedNewsOptionalArguments)
     -> SelectionSet decodesTo Cambiatus.Object.Community
     -> SelectionSet (Maybe decodesTo) RootMutation
-highlightedNews fillInOptionals object_ =
+highlightedNews fillInOptionals____ object____ =
     let
-        filledInOptionals =
-            fillInOptionals { newsId = Absent }
+        filledInOptionals____ =
+            fillInOptionals____ { newsId = Absent }
 
-        optionalArgs =
-            [ Argument.optional "newsId" filledInOptionals.newsId Encode.int ]
-                |> List.filterMap identity
+        optionalArgs____ =
+            [ Argument.optional "newsId" filledInOptionals____.newsId Encode.int ]
+                |> List.filterMap Basics.identity
     in
-    Object.selectionForCompositeField "highlightedNews" optionalArgs object_ (identity >> Decode.nullable)
+    Object.selectionForCompositeField "highlightedNews" optionalArgs____ object____ (Basics.identity >> Decode.nullable)
 
 
 type alias NewsOptionalArguments =
@@ -244,16 +244,96 @@ news :
     -> NewsRequiredArguments
     -> SelectionSet decodesTo Cambiatus.Object.News
     -> SelectionSet (Maybe decodesTo) RootMutation
-news fillInOptionals requiredArgs object_ =
+news fillInOptionals____ requiredArgs____ object____ =
     let
-        filledInOptionals =
-            fillInOptionals { id = Absent, scheduling = Absent }
+        filledInOptionals____ =
+            fillInOptionals____ { id = Absent, scheduling = Absent }
 
-        optionalArgs =
-            [ Argument.optional "id" filledInOptionals.id Encode.int, Argument.optional "scheduling" filledInOptionals.scheduling (Cambiatus.ScalarCodecs.codecs |> Cambiatus.Scalar.unwrapEncoder .codecDateTime) ]
-                |> List.filterMap identity
+        optionalArgs____ =
+            [ Argument.optional "id" filledInOptionals____.id Encode.int, Argument.optional "scheduling" filledInOptionals____.scheduling (Cambiatus.ScalarCodecs.codecs |> Cambiatus.Scalar.unwrapEncoder .codecDateTime) ]
+                |> List.filterMap Basics.identity
     in
-    Object.selectionForCompositeField "news" (optionalArgs ++ [ Argument.required "description" requiredArgs.description Encode.string, Argument.required "title" requiredArgs.title Encode.string ]) object_ (identity >> Decode.nullable)
+    Object.selectionForCompositeField "news" (optionalArgs____ ++ [ Argument.required "description" requiredArgs____.description Encode.string, Argument.required "title" requiredArgs____.title Encode.string ]) object____ (Basics.identity >> Decode.nullable)
+
+
+type alias PasskeyRegisterBeginRequiredArguments =
+    { account : String }
+
+
+{-| Begin passkey registration — returns a challenge and existing credential IDs to exclude
+-}
+passkeyRegisterBegin :
+    PasskeyRegisterBeginRequiredArguments
+    -> SelectionSet decodesTo Cambiatus.Object.PasskeyRegistrationChallenge
+    -> SelectionSet decodesTo RootMutation
+passkeyRegisterBegin requiredArgs____ object____ =
+    Object.selectionForCompositeField "passkeyRegisterBegin" [ Argument.required "account" requiredArgs____.account Encode.string ] object____ Basics.identity
+
+
+type alias PasskeyRegisterCompleteOptionalArguments =
+    { authenticatorAttachment : OptionalArgument String
+    , label : OptionalArgument String
+    }
+
+
+type alias PasskeyRegisterCompleteRequiredArguments =
+    { account : String
+    , attestationObject : String
+    , clientDataJson : String
+    , credentialId : String
+    }
+
+
+{-| Complete passkey registration — stores the credential as pending\_encryption
+-}
+passkeyRegisterComplete :
+    (PasskeyRegisterCompleteOptionalArguments -> PasskeyRegisterCompleteOptionalArguments)
+    -> PasskeyRegisterCompleteRequiredArguments
+    -> SelectionSet decodesTo Cambiatus.Object.PasskeyCredential
+    -> SelectionSet decodesTo RootMutation
+passkeyRegisterComplete fillInOptionals____ requiredArgs____ object____ =
+    let
+        filledInOptionals____ =
+            fillInOptionals____ { authenticatorAttachment = Absent, label = Absent }
+
+        optionalArgs____ =
+            [ Argument.optional "authenticatorAttachment" filledInOptionals____.authenticatorAttachment Encode.string, Argument.optional "label" filledInOptionals____.label Encode.string ]
+                |> List.filterMap Basics.identity
+    in
+    Object.selectionForCompositeField "passkeyRegisterComplete" (optionalArgs____ ++ [ Argument.required "account" requiredArgs____.account Encode.string, Argument.required "attestationObject" requiredArgs____.attestationObject Encode.string, Argument.required "clientDataJson" requiredArgs____.clientDataJson Encode.string, Argument.required "credentialId" requiredArgs____.credentialId Encode.string ]) object____ Basics.identity
+
+
+type alias PasskeySignInBeginRequiredArguments =
+    { account : String }
+
+
+{-| Begin passkey sign-in — returns a challenge and the account's active credential IDs
+-}
+passkeySignInBegin :
+    PasskeySignInBeginRequiredArguments
+    -> SelectionSet decodesTo Cambiatus.Object.PasskeyAssertionChallenge
+    -> SelectionSet decodesTo RootMutation
+passkeySignInBegin requiredArgs____ object____ =
+    Object.selectionForCompositeField "passkeySignInBegin" [ Argument.required "account" requiredArgs____.account Encode.string ] object____ Basics.identity
+
+
+type alias PasskeySignInCompleteRequiredArguments =
+    { account : String
+    , authenticatorData : String
+    , clientDataJson : String
+    , credentialId : String
+    , signature : String
+    }
+
+
+{-| Complete passkey sign-in — verifies assertion and returns a session token
+-}
+passkeySignInComplete :
+    PasskeySignInCompleteRequiredArguments
+    -> SelectionSet decodesTo Cambiatus.Object.Session
+    -> SelectionSet decodesTo RootMutation
+passkeySignInComplete requiredArgs____ object____ =
+    Object.selectionForCompositeField "passkeySignInComplete" [ Argument.required "account" requiredArgs____.account Encode.string, Argument.required "authenticatorData" requiredArgs____.authenticatorData Encode.string, Argument.required "clientDataJson" requiredArgs____.clientDataJson Encode.string, Argument.required "credentialId" requiredArgs____.credentialId Encode.string, Argument.required "signature" requiredArgs____.signature Encode.string ] object____ Basics.identity
 
 
 type alias PreferenceOptionalArguments =
@@ -270,16 +350,16 @@ preference :
     (PreferenceOptionalArguments -> PreferenceOptionalArguments)
     -> SelectionSet decodesTo Cambiatus.Object.User
     -> SelectionSet (Maybe decodesTo) RootMutation
-preference fillInOptionals object_ =
+preference fillInOptionals____ object____ =
     let
-        filledInOptionals =
-            fillInOptionals { claimNotification = Absent, digest = Absent, language = Absent, transferNotification = Absent }
+        filledInOptionals____ =
+            fillInOptionals____ { claimNotification = Absent, digest = Absent, language = Absent, transferNotification = Absent }
 
-        optionalArgs =
-            [ Argument.optional "claimNotification" filledInOptionals.claimNotification Encode.bool, Argument.optional "digest" filledInOptionals.digest Encode.bool, Argument.optional "language" filledInOptionals.language (Encode.enum Cambiatus.Enum.Language.toString), Argument.optional "transferNotification" filledInOptionals.transferNotification Encode.bool ]
-                |> List.filterMap identity
+        optionalArgs____ =
+            [ Argument.optional "claimNotification" filledInOptionals____.claimNotification Encode.bool, Argument.optional "digest" filledInOptionals____.digest Encode.bool, Argument.optional "language" filledInOptionals____.language (Encode.enum Cambiatus.Enum.Language.toString), Argument.optional "transferNotification" filledInOptionals____.transferNotification Encode.bool ]
+                |> List.filterMap Basics.identity
     in
-    Object.selectionForCompositeField "preference" optionalArgs object_ (identity >> Decode.nullable)
+    Object.selectionForCompositeField "preference" optionalArgs____ object____ (Basics.identity >> Decode.nullable)
 
 
 type alias ProductOptionalArguments =
@@ -303,16 +383,16 @@ product :
     (ProductOptionalArguments -> ProductOptionalArguments)
     -> SelectionSet decodesTo Cambiatus.Object.Product
     -> SelectionSet (Maybe decodesTo) RootMutation
-product fillInOptionals object_ =
+product fillInOptionals____ object____ =
     let
-        filledInOptionals =
-            fillInOptionals { categories = Absent, description = Absent, id = Absent, images = Absent, price = Absent, title = Absent, trackStock = Absent, units = Absent }
+        filledInOptionals____ =
+            fillInOptionals____ { categories = Absent, description = Absent, id = Absent, images = Absent, price = Absent, title = Absent, trackStock = Absent, units = Absent }
 
-        optionalArgs =
-            [ Argument.optional "categories" filledInOptionals.categories (Encode.int |> Encode.list), Argument.optional "description" filledInOptionals.description Encode.string, Argument.optional "id" filledInOptionals.id Encode.int, Argument.optional "images" filledInOptionals.images (Encode.string |> Encode.list), Argument.optional "price" filledInOptionals.price Encode.float, Argument.optional "title" filledInOptionals.title Encode.string, Argument.optional "trackStock" filledInOptionals.trackStock Encode.bool, Argument.optional "units" filledInOptionals.units Encode.int ]
-                |> List.filterMap identity
+        optionalArgs____ =
+            [ Argument.optional "categories" filledInOptionals____.categories (Encode.int |> Encode.list), Argument.optional "description" filledInOptionals____.description Encode.string, Argument.optional "id" filledInOptionals____.id Encode.int, Argument.optional "images" filledInOptionals____.images (Encode.string |> Encode.list), Argument.optional "price" filledInOptionals____.price Encode.float, Argument.optional "title" filledInOptionals____.title Encode.string, Argument.optional "trackStock" filledInOptionals____.trackStock Encode.bool, Argument.optional "units" filledInOptionals____.units Encode.int ]
+                |> List.filterMap Basics.identity
     in
-    Object.selectionForCompositeField "product" optionalArgs object_ (identity >> Decode.nullable)
+    Object.selectionForCompositeField "product" optionalArgs____ object____ (Basics.identity >> Decode.nullable)
 
 
 type alias ReactToNewsRequiredArguments =
@@ -327,8 +407,8 @@ reactToNews :
     ReactToNewsRequiredArguments
     -> SelectionSet decodesTo Cambiatus.Object.NewsReceipt
     -> SelectionSet (Maybe decodesTo) RootMutation
-reactToNews requiredArgs object_ =
-    Object.selectionForCompositeField "reactToNews" [ Argument.required "newsId" requiredArgs.newsId Encode.int, Argument.required "reactions" requiredArgs.reactions (Encode.enum Cambiatus.Enum.ReactionEnum.toString |> Encode.list) ] object_ (identity >> Decode.nullable)
+reactToNews requiredArgs____ object____ =
+    Object.selectionForCompositeField "reactToNews" [ Argument.required "newsId" requiredArgs____.newsId Encode.int, Argument.required "reactions" requiredArgs____.reactions (Encode.enum Cambiatus.Enum.ReactionEnum.toString |> Encode.list) ] object____ (Basics.identity >> Decode.nullable)
 
 
 type alias ReadRequiredArguments =
@@ -341,8 +421,8 @@ read :
     ReadRequiredArguments
     -> SelectionSet decodesTo Cambiatus.Object.NewsReceipt
     -> SelectionSet (Maybe decodesTo) RootMutation
-read requiredArgs object_ =
-    Object.selectionForCompositeField "read" [ Argument.required "newsId" requiredArgs.newsId Encode.int ] object_ (identity >> Decode.nullable)
+read requiredArgs____ object____ =
+    Object.selectionForCompositeField "read" [ Argument.required "newsId" requiredArgs____.newsId Encode.int ] object____ (Basics.identity >> Decode.nullable)
 
 
 type alias ReadNotificationRequiredArguments =
@@ -355,8 +435,8 @@ readNotification :
     ReadNotificationRequiredArguments
     -> SelectionSet decodesTo Cambiatus.Object.NotificationHistory
     -> SelectionSet decodesTo RootMutation
-readNotification requiredArgs object_ =
-    Object.selectionForCompositeField "readNotification" [ Argument.required "input" requiredArgs.input Cambiatus.InputObject.encodeReadNotificationInput ] object_ identity
+readNotification requiredArgs____ object____ =
+    Object.selectionForCompositeField "readNotification" [ Argument.required "input" requiredArgs____.input Cambiatus.InputObject.encodeReadNotificationInput ] object____ Basics.identity
 
 
 type alias RegisterPushRequiredArguments =
@@ -369,8 +449,8 @@ registerPush :
     RegisterPushRequiredArguments
     -> SelectionSet decodesTo Cambiatus.Object.PushSubscription
     -> SelectionSet decodesTo RootMutation
-registerPush requiredArgs object_ =
-    Object.selectionForCompositeField "registerPush" [ Argument.required "input" requiredArgs.input Cambiatus.InputObject.encodePushSubscriptionInput ] object_ identity
+registerPush requiredArgs____ object____ =
+    Object.selectionForCompositeField "registerPush" [ Argument.required "input" requiredArgs____.input Cambiatus.InputObject.encodePushSubscriptionInput ] object____ Basics.identity
 
 
 type alias SignInOptionalArguments =
@@ -393,16 +473,16 @@ signIn :
     -> SignInRequiredArguments
     -> SelectionSet decodesTo Cambiatus.Object.Session
     -> SelectionSet decodesTo RootMutation
-signIn fillInOptionals requiredArgs object_ =
+signIn fillInOptionals____ requiredArgs____ object____ =
     let
-        filledInOptionals =
-            fillInOptionals { invitationId = Absent }
+        filledInOptionals____ =
+            fillInOptionals____ { invitationId = Absent }
 
-        optionalArgs =
-            [ Argument.optional "invitationId" filledInOptionals.invitationId Encode.string ]
-                |> List.filterMap identity
+        optionalArgs____ =
+            [ Argument.optional "invitationId" filledInOptionals____.invitationId Encode.string ]
+                |> List.filterMap Basics.identity
     in
-    Object.selectionForCompositeField "signIn" (optionalArgs ++ [ Argument.required "account" requiredArgs.account Encode.string, Argument.required "password" requiredArgs.password Encode.string ]) object_ identity
+    Object.selectionForCompositeField "signIn" (optionalArgs____ ++ [ Argument.required "account" requiredArgs____.account Encode.string, Argument.required "password" requiredArgs____.password Encode.string ]) object____ Basics.identity
 
 
 type alias SignUpOptionalArguments =
@@ -438,16 +518,33 @@ signUp :
     -> SignUpRequiredArguments
     -> SelectionSet decodesTo Cambiatus.Object.Session
     -> SelectionSet decodesTo RootMutation
-signUp fillInOptionals requiredArgs object_ =
+signUp fillInOptionals____ requiredArgs____ object____ =
     let
-        filledInOptionals =
-            fillInOptionals { address = Absent, invitationId = Absent, kyc = Absent }
+        filledInOptionals____ =
+            fillInOptionals____ { address = Absent, invitationId = Absent, kyc = Absent }
 
-        optionalArgs =
-            [ Argument.optional "address" filledInOptionals.address Cambiatus.InputObject.encodeAddressUpdateInput, Argument.optional "invitationId" filledInOptionals.invitationId Encode.string, Argument.optional "kyc" filledInOptionals.kyc Cambiatus.InputObject.encodeKycDataUpdateInput ]
-                |> List.filterMap identity
+        optionalArgs____ =
+            [ Argument.optional "address" filledInOptionals____.address Cambiatus.InputObject.encodeAddressUpdateInput, Argument.optional "invitationId" filledInOptionals____.invitationId Encode.string, Argument.optional "kyc" filledInOptionals____.kyc Cambiatus.InputObject.encodeKycDataUpdateInput ]
+                |> List.filterMap Basics.identity
     in
-    Object.selectionForCompositeField "signUp" (optionalArgs ++ [ Argument.required "account" requiredArgs.account Encode.string, Argument.required "email" requiredArgs.email Encode.string, Argument.required "name" requiredArgs.name Encode.string, Argument.required "publicKey" requiredArgs.publicKey Encode.string, Argument.required "userType" requiredArgs.userType Encode.string ]) object_ identity
+    Object.selectionForCompositeField "signUp" (optionalArgs____ ++ [ Argument.required "account" requiredArgs____.account Encode.string, Argument.required "email" requiredArgs____.email Encode.string, Argument.required "name" requiredArgs____.name Encode.string, Argument.required "publicKey" requiredArgs____.publicKey Encode.string, Argument.required "userType" requiredArgs____.userType Encode.string ]) object____ Basics.identity
+
+
+type alias StoreEncryptedMnemonicRequiredArguments =
+    { credentialId : Cambiatus.ScalarCodecs.Id
+    , encryptedMnemonic : String
+    , mnemonicNonce : String
+    }
+
+
+{-| [Auth required] Store the encrypted mnemonic blob for a credential — transitions it to active
+-}
+storeEncryptedMnemonic :
+    StoreEncryptedMnemonicRequiredArguments
+    -> SelectionSet decodesTo Cambiatus.Object.PasskeyCredential
+    -> SelectionSet decodesTo RootMutation
+storeEncryptedMnemonic requiredArgs____ object____ =
+    Object.selectionForCompositeField "storeEncryptedMnemonic" [ Argument.required "credentialId" requiredArgs____.credentialId (Cambiatus.ScalarCodecs.codecs |> Cambiatus.Scalar.unwrapEncoder .codecId), Argument.required "encryptedMnemonic" requiredArgs____.encryptedMnemonic Encode.string, Argument.required "mnemonicNonce" requiredArgs____.mnemonicNonce Encode.string ] object____ Basics.identity
 
 
 type alias UpsertAddressRequiredArguments =
@@ -460,8 +557,8 @@ upsertAddress :
     UpsertAddressRequiredArguments
     -> SelectionSet decodesTo Cambiatus.Object.Address
     -> SelectionSet (Maybe decodesTo) RootMutation
-upsertAddress requiredArgs object_ =
-    Object.selectionForCompositeField "upsertAddress" [ Argument.required "input" requiredArgs.input Cambiatus.InputObject.encodeAddressUpdateInput ] object_ (identity >> Decode.nullable)
+upsertAddress requiredArgs____ object____ =
+    Object.selectionForCompositeField "upsertAddress" [ Argument.required "input" requiredArgs____.input Cambiatus.InputObject.encodeAddressUpdateInput ] object____ (Basics.identity >> Decode.nullable)
 
 
 type alias UpsertKycRequiredArguments =
@@ -474,8 +571,8 @@ upsertKyc :
     UpsertKycRequiredArguments
     -> SelectionSet decodesTo Cambiatus.Object.KycData
     -> SelectionSet (Maybe decodesTo) RootMutation
-upsertKyc requiredArgs object_ =
-    Object.selectionForCompositeField "upsertKyc" [ Argument.required "input" requiredArgs.input Cambiatus.InputObject.encodeKycDataUpdateInput ] object_ (identity >> Decode.nullable)
+upsertKyc requiredArgs____ object____ =
+    Object.selectionForCompositeField "upsertKyc" [ Argument.required "input" requiredArgs____.input Cambiatus.InputObject.encodeKycDataUpdateInput ] object____ (Basics.identity >> Decode.nullable)
 
 
 type alias UserRequiredArguments =
@@ -488,5 +585,5 @@ user :
     UserRequiredArguments
     -> SelectionSet decodesTo Cambiatus.Object.User
     -> SelectionSet (Maybe decodesTo) RootMutation
-user requiredArgs object_ =
-    Object.selectionForCompositeField "user" [ Argument.required "input" requiredArgs.input Cambiatus.InputObject.encodeUserUpdateInput ] object_ (identity >> Decode.nullable)
+user requiredArgs____ object____ =
+    Object.selectionForCompositeField "user" [ Argument.required "input" requiredArgs____.input Cambiatus.InputObject.encodeUserUpdateInput ] object____ (Basics.identity >> Decode.nullable)

--- a/src/elm/Cambiatus/Object.elm
+++ b/src/elm/Cambiatus/Object.elm
@@ -65,6 +65,10 @@ type DeleteStatus
     = DeleteStatus
 
 
+type EncryptedMnemonicResult
+    = EncryptedMnemonicResult
+
+
 type Exists
     = Exists
 
@@ -115,6 +119,18 @@ type Order
 
 type PageInfo
     = PageInfo
+
+
+type PasskeyAssertionChallenge
+    = PasskeyAssertionChallenge
+
+
+type PasskeyCredential
+    = PasskeyCredential
+
+
+type PasskeyRegistrationChallenge
+    = PasskeyRegistrationChallenge
 
 
 type Product

--- a/src/elm/Cambiatus/Object/Action.elm
+++ b/src/elm/Cambiatus/Object/Action.elm
@@ -28,23 +28,23 @@ type alias ClaimCountOptionalArguments =
 claimCount :
     (ClaimCountOptionalArguments -> ClaimCountOptionalArguments)
     -> SelectionSet Int Cambiatus.Object.Action
-claimCount fillInOptionals =
+claimCount fillInOptionals____ =
     let
-        filledInOptionals =
-            fillInOptionals { status = Absent }
+        filledInOptionals____ =
+            fillInOptionals____ { status = Absent }
 
-        optionalArgs =
-            [ Argument.optional "status" filledInOptionals.status (Encode.enum Cambiatus.Enum.ClaimStatus.toString) ]
-                |> List.filterMap identity
+        optionalArgs____ =
+            [ Argument.optional "status" filledInOptionals____.status (Encode.enum Cambiatus.Enum.ClaimStatus.toString) ]
+                |> List.filterMap Basics.identity
     in
-    Object.selectionForField "Int" "claimCount" optionalArgs Decode.int
+    Object.selectionForField "Int" "claimCount" optionalArgs____ Decode.int
 
 
 claims :
     SelectionSet decodesTo Cambiatus.Object.Claim
     -> SelectionSet (List decodesTo) Cambiatus.Object.Action
-claims object_ =
-    Object.selectionForCompositeField "claims" [] object_ (identity >> Decode.list)
+claims object____ =
+    Object.selectionForCompositeField "claims" [] object____ (Basics.identity >> Decode.list)
 
 
 createdAt : SelectionSet Cambiatus.ScalarCodecs.DateTime Cambiatus.Object.Action
@@ -70,8 +70,8 @@ createdTx =
 creator :
     SelectionSet decodesTo Cambiatus.Object.User
     -> SelectionSet decodesTo Cambiatus.Object.Action
-creator object_ =
-    Object.selectionForCompositeField "creator" [] object_ identity
+creator object____ =
+    Object.selectionForCompositeField "creator" [] object____ Basics.identity
 
 
 creatorId : SelectionSet String Cambiatus.Object.Action
@@ -117,8 +117,8 @@ isCompleted =
 objective :
     SelectionSet decodesTo Cambiatus.Object.Objective
     -> SelectionSet decodesTo Cambiatus.Object.Action
-objective object_ =
-    Object.selectionForCompositeField "objective" [] object_ identity
+objective object____ =
+    Object.selectionForCompositeField "objective" [] object____ Basics.identity
 
 
 photoProofInstructions : SelectionSet (Maybe String) Cambiatus.Object.Action
@@ -149,8 +149,8 @@ usagesLeft =
 validators :
     SelectionSet decodesTo Cambiatus.Object.User
     -> SelectionSet (List decodesTo) Cambiatus.Object.Action
-validators object_ =
-    Object.selectionForCompositeField "validators" [] object_ (identity >> Decode.list)
+validators object____ =
+    Object.selectionForCompositeField "validators" [] object____ (Basics.identity >> Decode.list)
 
 
 verificationType : SelectionSet Cambiatus.Enum.VerificationType.VerificationType Cambiatus.Object.Action

--- a/src/elm/Cambiatus/Object/Address.elm
+++ b/src/elm/Cambiatus/Object/Address.elm
@@ -22,22 +22,22 @@ import Json.Decode as Decode
 city :
     SelectionSet decodesTo Cambiatus.Object.City
     -> SelectionSet decodesTo Cambiatus.Object.Address
-city object_ =
-    Object.selectionForCompositeField "city" [] object_ identity
+city object____ =
+    Object.selectionForCompositeField "city" [] object____ Basics.identity
 
 
 country :
     SelectionSet decodesTo Cambiatus.Object.Country
     -> SelectionSet decodesTo Cambiatus.Object.Address
-country object_ =
-    Object.selectionForCompositeField "country" [] object_ identity
+country object____ =
+    Object.selectionForCompositeField "country" [] object____ Basics.identity
 
 
 neighborhood :
     SelectionSet decodesTo Cambiatus.Object.Neighborhood
     -> SelectionSet decodesTo Cambiatus.Object.Address
-neighborhood object_ =
-    Object.selectionForCompositeField "neighborhood" [] object_ identity
+neighborhood object____ =
+    Object.selectionForCompositeField "neighborhood" [] object____ Basics.identity
 
 
 number : SelectionSet (Maybe String) Cambiatus.Object.Address
@@ -48,8 +48,8 @@ number =
 state :
     SelectionSet decodesTo Cambiatus.Object.State
     -> SelectionSet decodesTo Cambiatus.Object.Address
-state object_ =
-    Object.selectionForCompositeField "state" [] object_ identity
+state object____ =
+    Object.selectionForCompositeField "state" [] object____ Basics.identity
 
 
 street : SelectionSet String Cambiatus.Object.Address

--- a/src/elm/Cambiatus/Object/Category.elm
+++ b/src/elm/Cambiatus/Object/Category.elm
@@ -22,8 +22,8 @@ import Json.Decode as Decode
 categories :
     SelectionSet decodesTo Cambiatus.Object.Category
     -> SelectionSet (Maybe (List decodesTo)) Cambiatus.Object.Category
-categories object_ =
-    Object.selectionForCompositeField "categories" [] object_ (identity >> Decode.list >> Decode.nullable)
+categories object____ =
+    Object.selectionForCompositeField "categories" [] object____ (Basics.identity >> Decode.list >> Decode.nullable)
 
 
 description : SelectionSet String Cambiatus.Object.Category
@@ -74,8 +74,8 @@ name =
 parent :
     SelectionSet decodesTo Cambiatus.Object.Category
     -> SelectionSet (Maybe decodesTo) Cambiatus.Object.Category
-parent object_ =
-    Object.selectionForCompositeField "parent" [] object_ (identity >> Decode.nullable)
+parent object____ =
+    Object.selectionForCompositeField "parent" [] object____ (Basics.identity >> Decode.nullable)
 
 
 position : SelectionSet Int Cambiatus.Object.Category
@@ -86,8 +86,8 @@ position =
 products :
     SelectionSet decodesTo Cambiatus.Object.Product
     -> SelectionSet (Maybe (List decodesTo)) Cambiatus.Object.Category
-products object_ =
-    Object.selectionForCompositeField "products" [] object_ (identity >> Decode.list >> Decode.nullable)
+products object____ =
+    Object.selectionForCompositeField "products" [] object____ (Basics.identity >> Decode.list >> Decode.nullable)
 
 
 slug : SelectionSet (Maybe String) Cambiatus.Object.Category

--- a/src/elm/Cambiatus/Object/Check.elm
+++ b/src/elm/Cambiatus/Object/Check.elm
@@ -22,8 +22,8 @@ import Json.Decode as Decode
 claim :
     SelectionSet decodesTo Cambiatus.Object.Claim
     -> SelectionSet decodesTo Cambiatus.Object.Check
-claim object_ =
-    Object.selectionForCompositeField "claim" [] object_ identity
+claim object____ =
+    Object.selectionForCompositeField "claim" [] object____ Basics.identity
 
 
 createdAt : SelectionSet Cambiatus.ScalarCodecs.DateTime Cambiatus.Object.Check
@@ -54,5 +54,5 @@ isVerified =
 validator :
     SelectionSet decodesTo Cambiatus.Object.User
     -> SelectionSet decodesTo Cambiatus.Object.Check
-validator object_ =
-    Object.selectionForCompositeField "validator" [] object_ identity
+validator object____ =
+    Object.selectionForCompositeField "validator" [] object____ Basics.identity

--- a/src/elm/Cambiatus/Object/City.elm
+++ b/src/elm/Cambiatus/Object/City.elm
@@ -32,5 +32,5 @@ name =
 neighborhoods :
     SelectionSet decodesTo Cambiatus.Object.Neighborhood
     -> SelectionSet (List decodesTo) Cambiatus.Object.City
-neighborhoods object_ =
-    Object.selectionForCompositeField "neighborhoods" [] object_ (identity >> Decode.list)
+neighborhoods object____ =
+    Object.selectionForCompositeField "neighborhoods" [] object____ (Basics.identity >> Decode.list)

--- a/src/elm/Cambiatus/Object/Claim.elm
+++ b/src/elm/Cambiatus/Object/Claim.elm
@@ -23,8 +23,8 @@ import Json.Decode as Decode
 action :
     SelectionSet decodesTo Cambiatus.Object.Action
     -> SelectionSet decodesTo Cambiatus.Object.Claim
-action object_ =
-    Object.selectionForCompositeField "action" [] object_ identity
+action object____ =
+    Object.selectionForCompositeField "action" [] object____ Basics.identity
 
 
 type alias ChecksOptionalArguments =
@@ -35,23 +35,23 @@ checks :
     (ChecksOptionalArguments -> ChecksOptionalArguments)
     -> SelectionSet decodesTo Cambiatus.Object.Check
     -> SelectionSet (List decodesTo) Cambiatus.Object.Claim
-checks fillInOptionals object_ =
+checks fillInOptionals____ object____ =
     let
-        filledInOptionals =
-            fillInOptionals { input = Absent }
+        filledInOptionals____ =
+            fillInOptionals____ { input = Absent }
 
-        optionalArgs =
-            [ Argument.optional "input" filledInOptionals.input Cambiatus.InputObject.encodeChecksInput ]
-                |> List.filterMap identity
+        optionalArgs____ =
+            [ Argument.optional "input" filledInOptionals____.input Cambiatus.InputObject.encodeChecksInput ]
+                |> List.filterMap Basics.identity
     in
-    Object.selectionForCompositeField "checks" optionalArgs object_ (identity >> Decode.list)
+    Object.selectionForCompositeField "checks" optionalArgs____ object____ (Basics.identity >> Decode.list)
 
 
 claimer :
     SelectionSet decodesTo Cambiatus.Object.User
     -> SelectionSet decodesTo Cambiatus.Object.Claim
-claimer object_ =
-    Object.selectionForCompositeField "claimer" [] object_ identity
+claimer object____ =
+    Object.selectionForCompositeField "claimer" [] object____ Basics.identity
 
 
 createdAt : SelectionSet Cambiatus.ScalarCodecs.DateTime Cambiatus.Object.Claim

--- a/src/elm/Cambiatus/Object/ClaimConnection.elm
+++ b/src/elm/Cambiatus/Object/ClaimConnection.elm
@@ -27,12 +27,12 @@ count =
 edges :
     SelectionSet decodesTo Cambiatus.Object.ClaimEdge
     -> SelectionSet (Maybe (List (Maybe decodesTo))) Cambiatus.Object.ClaimConnection
-edges object_ =
-    Object.selectionForCompositeField "edges" [] object_ (identity >> Decode.nullable >> Decode.list >> Decode.nullable)
+edges object____ =
+    Object.selectionForCompositeField "edges" [] object____ (Basics.identity >> Decode.nullable >> Decode.list >> Decode.nullable)
 
 
 pageInfo :
     SelectionSet decodesTo Cambiatus.Object.PageInfo
     -> SelectionSet decodesTo Cambiatus.Object.ClaimConnection
-pageInfo object_ =
-    Object.selectionForCompositeField "pageInfo" [] object_ identity
+pageInfo object____ =
+    Object.selectionForCompositeField "pageInfo" [] object____ Basics.identity

--- a/src/elm/Cambiatus/Object/ClaimEdge.elm
+++ b/src/elm/Cambiatus/Object/ClaimEdge.elm
@@ -27,5 +27,5 @@ cursor =
 node :
     SelectionSet decodesTo Cambiatus.Object.Claim
     -> SelectionSet (Maybe decodesTo) Cambiatus.Object.ClaimEdge
-node object_ =
-    Object.selectionForCompositeField "node" [] object_ (identity >> Decode.nullable)
+node object____ =
+    Object.selectionForCompositeField "node" [] object____ (Basics.identity >> Decode.nullable)

--- a/src/elm/Cambiatus/Object/Community.elm
+++ b/src/elm/Cambiatus/Object/Community.elm
@@ -33,8 +33,8 @@ autoInvite =
 categories :
     SelectionSet decodesTo Cambiatus.Object.Category
     -> SelectionSet (List decodesTo) Cambiatus.Object.Community
-categories object_ =
-    Object.selectionForCompositeField "categories" [] object_ (identity >> Decode.list)
+categories object____ =
+    Object.selectionForCompositeField "categories" [] object____ (Basics.identity >> Decode.list)
 
 
 claimCount : SelectionSet Int Cambiatus.Object.Community
@@ -45,15 +45,15 @@ claimCount =
 contacts :
     SelectionSet decodesTo Cambiatus.Object.Contact
     -> SelectionSet (List decodesTo) Cambiatus.Object.Community
-contacts object_ =
-    Object.selectionForCompositeField "contacts" [] object_ (identity >> Decode.list)
+contacts object____ =
+    Object.selectionForCompositeField "contacts" [] object____ (Basics.identity >> Decode.list)
 
 
 contributionConfiguration :
     SelectionSet decodesTo Cambiatus.Object.ContributionConfig
     -> SelectionSet (Maybe decodesTo) Cambiatus.Object.Community
-contributionConfiguration object_ =
-    Object.selectionForCompositeField "contributionConfiguration" [] object_ (identity >> Decode.nullable)
+contributionConfiguration object____ =
+    Object.selectionForCompositeField "contributionConfiguration" [] object____ (Basics.identity >> Decode.nullable)
 
 
 type alias ContributionsOptionalArguments =
@@ -66,16 +66,16 @@ contributions :
     (ContributionsOptionalArguments -> ContributionsOptionalArguments)
     -> SelectionSet decodesTo Cambiatus.Object.Contribution
     -> SelectionSet (List decodesTo) Cambiatus.Object.Community
-contributions fillInOptionals object_ =
+contributions fillInOptionals____ object____ =
     let
-        filledInOptionals =
-            fillInOptionals { status = Absent }
+        filledInOptionals____ =
+            fillInOptionals____ { status = Absent }
 
-        optionalArgs =
-            [ Argument.optional "status" filledInOptionals.status (Encode.enum Cambiatus.Enum.ContributionStatusType.toString) ]
-                |> List.filterMap identity
+        optionalArgs____ =
+            [ Argument.optional "status" filledInOptionals____.status (Encode.enum Cambiatus.Enum.ContributionStatusType.toString) ]
+                |> List.filterMap Basics.identity
     in
-    Object.selectionForCompositeField "contributions" optionalArgs object_ (identity >> Decode.list)
+    Object.selectionForCompositeField "contributions" optionalArgs____ object____ (Basics.identity >> Decode.list)
 
 
 createdAt : SelectionSet Cambiatus.ScalarCodecs.DateTime Cambiatus.Object.Community
@@ -131,8 +131,8 @@ hasShop =
 highlightedNews :
     SelectionSet decodesTo Cambiatus.Object.News
     -> SelectionSet (Maybe decodesTo) Cambiatus.Object.Community
-highlightedNews object_ =
-    Object.selectionForCompositeField "highlightedNews" [] object_ (identity >> Decode.nullable)
+highlightedNews object____ =
+    Object.selectionForCompositeField "highlightedNews" [] object____ (Basics.identity >> Decode.nullable)
 
 
 invitedReward : SelectionSet Float Cambiatus.Object.Community
@@ -168,8 +168,8 @@ memberCount =
 members :
     SelectionSet decodesTo Cambiatus.Object.User
     -> SelectionSet (List decodesTo) Cambiatus.Object.Community
-members object_ =
-    Object.selectionForCompositeField "members" [] object_ (identity >> Decode.list)
+members object____ =
+    Object.selectionForCompositeField "members" [] object____ (Basics.identity >> Decode.list)
 
 
 minBalance : SelectionSet (Maybe Float) Cambiatus.Object.Community
@@ -180,8 +180,8 @@ minBalance =
 mints :
     SelectionSet decodesTo Cambiatus.Object.Mint
     -> SelectionSet (List decodesTo) Cambiatus.Object.Community
-mints object_ =
-    Object.selectionForCompositeField "mints" [] object_ (identity >> Decode.list)
+mints object____ =
+    Object.selectionForCompositeField "mints" [] object____ (Basics.identity >> Decode.list)
 
 
 name : SelectionSet String Cambiatus.Object.Community
@@ -192,15 +192,15 @@ name =
 news :
     SelectionSet decodesTo Cambiatus.Object.News
     -> SelectionSet (List decodesTo) Cambiatus.Object.Community
-news object_ =
-    Object.selectionForCompositeField "news" [] object_ (identity >> Decode.list)
+news object____ =
+    Object.selectionForCompositeField "news" [] object____ (Basics.identity >> Decode.list)
 
 
 objectives :
     SelectionSet decodesTo Cambiatus.Object.Objective
     -> SelectionSet (List decodesTo) Cambiatus.Object.Community
-objectives object_ =
-    Object.selectionForCompositeField "objectives" [] object_ (identity >> Decode.list)
+objectives object____ =
+    Object.selectionForCompositeField "objectives" [] object____ (Basics.identity >> Decode.list)
 
 
 orderCount : SelectionSet Int Cambiatus.Object.Community
@@ -211,8 +211,8 @@ orderCount =
 orders :
     SelectionSet decodesTo Cambiatus.Object.Order
     -> SelectionSet (List decodesTo) Cambiatus.Object.Community
-orders object_ =
-    Object.selectionForCompositeField "orders" [] object_ (identity >> Decode.list)
+orders object____ =
+    Object.selectionForCompositeField "orders" [] object____ (Basics.identity >> Decode.list)
 
 
 productCount : SelectionSet Int Cambiatus.Object.Community
@@ -223,15 +223,22 @@ productCount =
 rewards :
     SelectionSet decodesTo Cambiatus.Object.Reward
     -> SelectionSet (List decodesTo) Cambiatus.Object.Community
-rewards object_ =
-    Object.selectionForCompositeField "rewards" [] object_ (identity >> Decode.list)
+rewards object____ =
+    Object.selectionForCompositeField "rewards" [] object____ (Basics.identity >> Decode.list)
+
+
+roles :
+    SelectionSet decodesTo Cambiatus.Object.Role
+    -> SelectionSet (List decodesTo) Cambiatus.Object.Community
+roles object____ =
+    Object.selectionForCompositeField "roles" [] object____ (Basics.identity >> Decode.list)
 
 
 subdomain :
     SelectionSet decodesTo Cambiatus.Object.Subdomain
     -> SelectionSet (Maybe decodesTo) Cambiatus.Object.Community
-subdomain object_ =
-    Object.selectionForCompositeField "subdomain" [] object_ (identity >> Decode.nullable)
+subdomain object____ =
+    Object.selectionForCompositeField "subdomain" [] object____ (Basics.identity >> Decode.nullable)
 
 
 supply : SelectionSet (Maybe Float) Cambiatus.Object.Community
@@ -261,16 +268,16 @@ transfers :
     (TransfersOptionalArguments -> TransfersOptionalArguments)
     -> SelectionSet decodesTo Cambiatus.Object.TransferConnection
     -> SelectionSet (Maybe decodesTo) Cambiatus.Object.Community
-transfers fillInOptionals object_ =
+transfers fillInOptionals____ object____ =
     let
-        filledInOptionals =
-            fillInOptionals { after = Absent, before = Absent, first = Absent, last = Absent }
+        filledInOptionals____ =
+            fillInOptionals____ { after = Absent, before = Absent, first = Absent, last = Absent }
 
-        optionalArgs =
-            [ Argument.optional "after" filledInOptionals.after Encode.string, Argument.optional "before" filledInOptionals.before Encode.string, Argument.optional "first" filledInOptionals.first Encode.int, Argument.optional "last" filledInOptionals.last Encode.int ]
-                |> List.filterMap identity
+        optionalArgs____ =
+            [ Argument.optional "after" filledInOptionals____.after Encode.string, Argument.optional "before" filledInOptionals____.before Encode.string, Argument.optional "first" filledInOptionals____.first Encode.int, Argument.optional "last" filledInOptionals____.last Encode.int ]
+                |> List.filterMap Basics.identity
     in
-    Object.selectionForCompositeField "transfers" optionalArgs object_ (identity >> Decode.nullable)
+    Object.selectionForCompositeField "transfers" optionalArgs____ object____ (Basics.identity >> Decode.nullable)
 
 
 type_ : SelectionSet (Maybe String) Cambiatus.Object.Community
@@ -281,8 +288,8 @@ type_ =
 uploads :
     SelectionSet decodesTo Cambiatus.Object.Upload
     -> SelectionSet (List decodesTo) Cambiatus.Object.Community
-uploads object_ =
-    Object.selectionForCompositeField "uploads" [] object_ (identity >> Decode.list)
+uploads object____ =
+    Object.selectionForCompositeField "uploads" [] object____ (Basics.identity >> Decode.list)
 
 
 {-| List of users that are claim validators
@@ -290,8 +297,8 @@ uploads object_ =
 validators :
     SelectionSet decodesTo Cambiatus.Object.User
     -> SelectionSet (List decodesTo) Cambiatus.Object.Community
-validators object_ =
-    Object.selectionForCompositeField "validators" [] object_ (identity >> Decode.list)
+validators object____ =
+    Object.selectionForCompositeField "validators" [] object____ (Basics.identity >> Decode.list)
 
 
 website : SelectionSet (Maybe String) Cambiatus.Object.Community

--- a/src/elm/Cambiatus/Object/CommunityPreview.elm
+++ b/src/elm/Cambiatus/Object/CommunityPreview.elm
@@ -62,8 +62,8 @@ name =
 subdomain :
     SelectionSet decodesTo Cambiatus.Object.Subdomain
     -> SelectionSet (Maybe decodesTo) Cambiatus.Object.CommunityPreview
-subdomain object_ =
-    Object.selectionForCompositeField "subdomain" [] object_ (identity >> Decode.nullable)
+subdomain object____ =
+    Object.selectionForCompositeField "subdomain" [] object____ (Basics.identity >> Decode.nullable)
 
 
 symbol : SelectionSet String Cambiatus.Object.CommunityPreview
@@ -74,8 +74,8 @@ symbol =
 uploads :
     SelectionSet decodesTo Cambiatus.Object.Upload
     -> SelectionSet (List decodesTo) Cambiatus.Object.CommunityPreview
-uploads object_ =
-    Object.selectionForCompositeField "uploads" [] object_ (identity >> Decode.list)
+uploads object____ =
+    Object.selectionForCompositeField "uploads" [] object____ (Basics.identity >> Decode.list)
 
 
 website : SelectionSet (Maybe String) Cambiatus.Object.CommunityPreview

--- a/src/elm/Cambiatus/Object/Contribution.elm
+++ b/src/elm/Cambiatus/Object/Contribution.elm
@@ -30,8 +30,8 @@ amount =
 community :
     SelectionSet decodesTo Cambiatus.Object.Community
     -> SelectionSet decodesTo Cambiatus.Object.Contribution
-community object_ =
-    Object.selectionForCompositeField "community" [] object_ identity
+community object____ =
+    Object.selectionForCompositeField "community" [] object____ Basics.identity
 
 
 currency : SelectionSet Cambiatus.Enum.CurrencyType.CurrencyType Cambiatus.Object.Contribution
@@ -67,5 +67,5 @@ updatedAt =
 user :
     SelectionSet decodesTo Cambiatus.Object.User
     -> SelectionSet decodesTo Cambiatus.Object.Contribution
-user object_ =
-    Object.selectionForCompositeField "user" [] object_ identity
+user object____ =
+    Object.selectionForCompositeField "user" [] object____ Basics.identity

--- a/src/elm/Cambiatus/Object/Country.elm
+++ b/src/elm/Cambiatus/Object/Country.elm
@@ -32,5 +32,5 @@ name =
 states :
     SelectionSet decodesTo Cambiatus.Object.State
     -> SelectionSet (List decodesTo) Cambiatus.Object.Country
-states object_ =
-    Object.selectionForCompositeField "states" [] object_ (identity >> Decode.list)
+states object____ =
+    Object.selectionForCompositeField "states" [] object____ (Basics.identity >> Decode.list)

--- a/src/elm/Cambiatus/Object/EncryptedMnemonicResult.elm
+++ b/src/elm/Cambiatus/Object/EncryptedMnemonicResult.elm
@@ -2,7 +2,7 @@
 -- https://github.com/dillonkearns/elm-graphql
 
 
-module Cambiatus.Object.State exposing (..)
+module Cambiatus.Object.EncryptedMnemonicResult exposing (..)
 
 import Cambiatus.InputObject
 import Cambiatus.Interface
@@ -19,18 +19,11 @@ import Graphql.SelectionSet exposing (SelectionSet)
 import Json.Decode as Decode
 
 
-cities :
-    SelectionSet decodesTo Cambiatus.Object.City
-    -> SelectionSet (List decodesTo) Cambiatus.Object.State
-cities object____ =
-    Object.selectionForCompositeField "cities" [] object____ (Basics.identity >> Decode.list)
+encryptedMnemonic : SelectionSet String Cambiatus.Object.EncryptedMnemonicResult
+encryptedMnemonic =
+    Object.selectionForField "String" "encryptedMnemonic" [] Decode.string
 
 
-id : SelectionSet Cambiatus.ScalarCodecs.Id Cambiatus.Object.State
-id =
-    Object.selectionForField "ScalarCodecs.Id" "id" [] (Cambiatus.ScalarCodecs.codecs |> Cambiatus.Scalar.unwrapCodecs |> .codecId |> .decoder)
-
-
-name : SelectionSet String Cambiatus.Object.State
-name =
-    Object.selectionForField "String" "name" [] Decode.string
+mnemonicNonce : SelectionSet String Cambiatus.Object.EncryptedMnemonicResult
+mnemonicNonce =
+    Object.selectionForField "String" "mnemonicNonce" [] Decode.string

--- a/src/elm/Cambiatus/Object/Invite.elm
+++ b/src/elm/Cambiatus/Object/Invite.elm
@@ -22,12 +22,12 @@ import Json.Decode as Decode
 communityPreview :
     SelectionSet decodesTo Cambiatus.Object.CommunityPreview
     -> SelectionSet decodesTo Cambiatus.Object.Invite
-communityPreview object_ =
-    Object.selectionForCompositeField "communityPreview" [] object_ identity
+communityPreview object____ =
+    Object.selectionForCompositeField "communityPreview" [] object____ Basics.identity
 
 
 creator :
     SelectionSet decodesTo Cambiatus.Object.User
     -> SelectionSet decodesTo Cambiatus.Object.Invite
-creator object_ =
-    Object.selectionForCompositeField "creator" [] object_ identity
+creator object____ =
+    Object.selectionForCompositeField "creator" [] object____ Basics.identity

--- a/src/elm/Cambiatus/Object/KycData.elm
+++ b/src/elm/Cambiatus/Object/KycData.elm
@@ -22,8 +22,8 @@ import Json.Decode as Decode
 country :
     SelectionSet decodesTo Cambiatus.Object.Country
     -> SelectionSet (Maybe decodesTo) Cambiatus.Object.KycData
-country object_ =
-    Object.selectionForCompositeField "country" [] object_ (identity >> Decode.nullable)
+country object____ =
+    Object.selectionForCompositeField "country" [] object____ (Basics.identity >> Decode.nullable)
 
 
 document : SelectionSet String Cambiatus.Object.KycData

--- a/src/elm/Cambiatus/Object/Mint.elm
+++ b/src/elm/Cambiatus/Object/Mint.elm
@@ -22,8 +22,8 @@ import Json.Decode as Decode
 community :
     SelectionSet decodesTo Cambiatus.Object.Community
     -> SelectionSet decodesTo Cambiatus.Object.Mint
-community object_ =
-    Object.selectionForCompositeField "community" [] object_ identity
+community object____ =
+    Object.selectionForCompositeField "community" [] object____ Basics.identity
 
 
 createdAt : SelectionSet Cambiatus.ScalarCodecs.DateTime Cambiatus.Object.Mint
@@ -59,5 +59,5 @@ quantity =
 to :
     SelectionSet decodesTo Cambiatus.Object.User
     -> SelectionSet decodesTo Cambiatus.Object.Mint
-to object_ =
-    Object.selectionForCompositeField "to" [] object_ identity
+to object____ =
+    Object.selectionForCompositeField "to" [] object____ Basics.identity

--- a/src/elm/Cambiatus/Object/Network.elm
+++ b/src/elm/Cambiatus/Object/Network.elm
@@ -22,15 +22,15 @@ import Json.Decode as Decode
 account :
     SelectionSet decodesTo Cambiatus.Object.User
     -> SelectionSet (Maybe decodesTo) Cambiatus.Object.Network
-account object_ =
-    Object.selectionForCompositeField "account" [] object_ (identity >> Decode.nullable)
+account object____ =
+    Object.selectionForCompositeField "account" [] object____ (Basics.identity >> Decode.nullable)
 
 
 community :
     SelectionSet decodesTo Cambiatus.Object.Community
     -> SelectionSet decodesTo Cambiatus.Object.Network
-community object_ =
-    Object.selectionForCompositeField "community" [] object_ identity
+community object____ =
+    Object.selectionForCompositeField "community" [] object____ Basics.identity
 
 
 communityId : SelectionSet String Cambiatus.Object.Network

--- a/src/elm/Cambiatus/Object/News.elm
+++ b/src/elm/Cambiatus/Object/News.elm
@@ -37,15 +37,15 @@ insertedAt =
 reactions :
     SelectionSet decodesTo Cambiatus.Object.ReactionType
     -> SelectionSet (List decodesTo) Cambiatus.Object.News
-reactions object_ =
-    Object.selectionForCompositeField "reactions" [] object_ (identity >> Decode.list)
+reactions object____ =
+    Object.selectionForCompositeField "reactions" [] object____ (Basics.identity >> Decode.list)
 
 
 receipt :
     SelectionSet decodesTo Cambiatus.Object.NewsReceipt
     -> SelectionSet (Maybe decodesTo) Cambiatus.Object.News
-receipt object_ =
-    Object.selectionForCompositeField "receipt" [] object_ (identity >> Decode.nullable)
+receipt object____ =
+    Object.selectionForCompositeField "receipt" [] object____ (Basics.identity >> Decode.nullable)
 
 
 scheduling : SelectionSet (Maybe Cambiatus.ScalarCodecs.DateTime) Cambiatus.Object.News
@@ -66,12 +66,12 @@ updatedAt =
 user :
     SelectionSet decodesTo Cambiatus.Object.User
     -> SelectionSet decodesTo Cambiatus.Object.News
-user object_ =
-    Object.selectionForCompositeField "user" [] object_ identity
+user object____ =
+    Object.selectionForCompositeField "user" [] object____ Basics.identity
 
 
 versions :
     SelectionSet decodesTo Cambiatus.Object.NewsVersion
     -> SelectionSet (List decodesTo) Cambiatus.Object.News
-versions object_ =
-    Object.selectionForCompositeField "versions" [] object_ (identity >> Decode.list)
+versions object____ =
+    Object.selectionForCompositeField "versions" [] object____ (Basics.identity >> Decode.list)

--- a/src/elm/Cambiatus/Object/NewsReceipt.elm
+++ b/src/elm/Cambiatus/Object/NewsReceipt.elm
@@ -38,5 +38,5 @@ updatedAt =
 user :
     SelectionSet decodesTo Cambiatus.Object.User
     -> SelectionSet decodesTo Cambiatus.Object.NewsReceipt
-user object_ =
-    Object.selectionForCompositeField "user" [] object_ identity
+user object____ =
+    Object.selectionForCompositeField "user" [] object____ Basics.identity

--- a/src/elm/Cambiatus/Object/NewsVersion.elm
+++ b/src/elm/Cambiatus/Object/NewsVersion.elm
@@ -37,5 +37,5 @@ title =
 user :
     SelectionSet decodesTo Cambiatus.Object.User
     -> SelectionSet decodesTo Cambiatus.Object.NewsVersion
-user object_ =
-    Object.selectionForCompositeField "user" [] object_ identity
+user object____ =
+    Object.selectionForCompositeField "user" [] object____ Basics.identity

--- a/src/elm/Cambiatus/Object/NotificationHistory.elm
+++ b/src/elm/Cambiatus/Object/NotificationHistory.elm
@@ -37,15 +37,15 @@ isRead =
 payload :
     SelectionSet decodesTo Cambiatus.Union.NotificationType
     -> SelectionSet decodesTo Cambiatus.Object.NotificationHistory
-payload object_ =
-    Object.selectionForCompositeField "payload" [] object_ identity
+payload object____ =
+    Object.selectionForCompositeField "payload" [] object____ Basics.identity
 
 
 recipient :
     SelectionSet decodesTo Cambiatus.Object.User
     -> SelectionSet decodesTo Cambiatus.Object.NotificationHistory
-recipient object_ =
-    Object.selectionForCompositeField "recipient" [] object_ identity
+recipient object____ =
+    Object.selectionForCompositeField "recipient" [] object____ Basics.identity
 
 
 recipientId : SelectionSet String Cambiatus.Object.NotificationHistory

--- a/src/elm/Cambiatus/Object/Objective.elm
+++ b/src/elm/Cambiatus/Object/Objective.elm
@@ -27,23 +27,23 @@ actions :
     (ActionsOptionalArguments -> ActionsOptionalArguments)
     -> SelectionSet decodesTo Cambiatus.Object.Action
     -> SelectionSet (List decodesTo) Cambiatus.Object.Objective
-actions fillInOptionals object_ =
+actions fillInOptionals____ object____ =
     let
-        filledInOptionals =
-            fillInOptionals { input = Absent }
+        filledInOptionals____ =
+            fillInOptionals____ { input = Absent }
 
-        optionalArgs =
-            [ Argument.optional "input" filledInOptionals.input Cambiatus.InputObject.encodeActionsInput ]
-                |> List.filterMap identity
+        optionalArgs____ =
+            [ Argument.optional "input" filledInOptionals____.input Cambiatus.InputObject.encodeActionsInput ]
+                |> List.filterMap Basics.identity
     in
-    Object.selectionForCompositeField "actions" optionalArgs object_ (identity >> Decode.list)
+    Object.selectionForCompositeField "actions" optionalArgs____ object____ (Basics.identity >> Decode.list)
 
 
 community :
     SelectionSet decodesTo Cambiatus.Object.Community
     -> SelectionSet decodesTo Cambiatus.Object.Objective
-community object_ =
-    Object.selectionForCompositeField "community" [] object_ identity
+community object____ =
+    Object.selectionForCompositeField "community" [] object____ Basics.identity
 
 
 completedAt : SelectionSet (Maybe Cambiatus.ScalarCodecs.NaiveDateTime) Cambiatus.Object.Objective
@@ -74,8 +74,8 @@ createdTx =
 creator :
     SelectionSet decodesTo Cambiatus.Object.User
     -> SelectionSet decodesTo Cambiatus.Object.Objective
-creator object_ =
-    Object.selectionForCompositeField "creator" [] object_ identity
+creator object____ =
+    Object.selectionForCompositeField "creator" [] object____ Basics.identity
 
 
 creatorId : SelectionSet String Cambiatus.Object.Objective

--- a/src/elm/Cambiatus/Object/Order.elm
+++ b/src/elm/Cambiatus/Object/Order.elm
@@ -47,8 +47,8 @@ createdTx =
 from :
     SelectionSet decodesTo Cambiatus.Object.User
     -> SelectionSet decodesTo Cambiatus.Object.Order
-from object_ =
-    Object.selectionForCompositeField "from" [] object_ identity
+from object____ =
+    Object.selectionForCompositeField "from" [] object____ Basics.identity
 
 
 fromId : SelectionSet String Cambiatus.Object.Order
@@ -64,8 +64,8 @@ id =
 product :
     SelectionSet decodesTo Cambiatus.Object.Product
     -> SelectionSet decodesTo Cambiatus.Object.Order
-product object_ =
-    Object.selectionForCompositeField "product" [] object_ identity
+product object____ =
+    Object.selectionForCompositeField "product" [] object____ Basics.identity
 
 
 productId : SelectionSet Int Cambiatus.Object.Order
@@ -76,8 +76,8 @@ productId =
 to :
     SelectionSet decodesTo Cambiatus.Object.User
     -> SelectionSet decodesTo Cambiatus.Object.Order
-to object_ =
-    Object.selectionForCompositeField "to" [] object_ identity
+to object____ =
+    Object.selectionForCompositeField "to" [] object____ Basics.identity
 
 
 toId : SelectionSet String Cambiatus.Object.Order

--- a/src/elm/Cambiatus/Object/PasskeyAssertionChallenge.elm
+++ b/src/elm/Cambiatus/Object/PasskeyAssertionChallenge.elm
@@ -2,7 +2,7 @@
 -- https://github.com/dillonkearns/elm-graphql
 
 
-module Cambiatus.Object.State exposing (..)
+module Cambiatus.Object.PasskeyAssertionChallenge exposing (..)
 
 import Cambiatus.InputObject
 import Cambiatus.Interface
@@ -19,18 +19,11 @@ import Graphql.SelectionSet exposing (SelectionSet)
 import Json.Decode as Decode
 
 
-cities :
-    SelectionSet decodesTo Cambiatus.Object.City
-    -> SelectionSet (List decodesTo) Cambiatus.Object.State
-cities object____ =
-    Object.selectionForCompositeField "cities" [] object____ (Basics.identity >> Decode.list)
+challenge : SelectionSet String Cambiatus.Object.PasskeyAssertionChallenge
+challenge =
+    Object.selectionForField "String" "challenge" [] Decode.string
 
 
-id : SelectionSet Cambiatus.ScalarCodecs.Id Cambiatus.Object.State
-id =
-    Object.selectionForField "ScalarCodecs.Id" "id" [] (Cambiatus.ScalarCodecs.codecs |> Cambiatus.Scalar.unwrapCodecs |> .codecId |> .decoder)
-
-
-name : SelectionSet String Cambiatus.Object.State
-name =
-    Object.selectionForField "String" "name" [] Decode.string
+credentialIds : SelectionSet (List String) Cambiatus.Object.PasskeyAssertionChallenge
+credentialIds =
+    Object.selectionForField "(List String)" "credentialIds" [] (Decode.string |> Decode.list)

--- a/src/elm/Cambiatus/Object/PasskeyCredential.elm
+++ b/src/elm/Cambiatus/Object/PasskeyCredential.elm
@@ -2,7 +2,7 @@
 -- https://github.com/dillonkearns/elm-graphql
 
 
-module Cambiatus.Object.State exposing (..)
+module Cambiatus.Object.PasskeyCredential exposing (..)
 
 import Cambiatus.InputObject
 import Cambiatus.Interface
@@ -19,18 +19,21 @@ import Graphql.SelectionSet exposing (SelectionSet)
 import Json.Decode as Decode
 
 
-cities :
-    SelectionSet decodesTo Cambiatus.Object.City
-    -> SelectionSet (List decodesTo) Cambiatus.Object.State
-cities object____ =
-    Object.selectionForCompositeField "cities" [] object____ (Basics.identity >> Decode.list)
-
-
-id : SelectionSet Cambiatus.ScalarCodecs.Id Cambiatus.Object.State
+id : SelectionSet Cambiatus.ScalarCodecs.Id Cambiatus.Object.PasskeyCredential
 id =
     Object.selectionForField "ScalarCodecs.Id" "id" [] (Cambiatus.ScalarCodecs.codecs |> Cambiatus.Scalar.unwrapCodecs |> .codecId |> .decoder)
 
 
-name : SelectionSet String Cambiatus.Object.State
-name =
-    Object.selectionForField "String" "name" [] Decode.string
+insertedAt : SelectionSet Cambiatus.ScalarCodecs.NaiveDateTime Cambiatus.Object.PasskeyCredential
+insertedAt =
+    Object.selectionForField "ScalarCodecs.NaiveDateTime" "insertedAt" [] (Cambiatus.ScalarCodecs.codecs |> Cambiatus.Scalar.unwrapCodecs |> .codecNaiveDateTime |> .decoder)
+
+
+label : SelectionSet (Maybe String) Cambiatus.Object.PasskeyCredential
+label =
+    Object.selectionForField "(Maybe String)" "label" [] (Decode.string |> Decode.nullable)
+
+
+status : SelectionSet String Cambiatus.Object.PasskeyCredential
+status =
+    Object.selectionForField "String" "status" [] Decode.string

--- a/src/elm/Cambiatus/Object/PasskeyRegistrationChallenge.elm
+++ b/src/elm/Cambiatus/Object/PasskeyRegistrationChallenge.elm
@@ -2,7 +2,7 @@
 -- https://github.com/dillonkearns/elm-graphql
 
 
-module Cambiatus.Object.State exposing (..)
+module Cambiatus.Object.PasskeyRegistrationChallenge exposing (..)
 
 import Cambiatus.InputObject
 import Cambiatus.Interface
@@ -19,18 +19,11 @@ import Graphql.SelectionSet exposing (SelectionSet)
 import Json.Decode as Decode
 
 
-cities :
-    SelectionSet decodesTo Cambiatus.Object.City
-    -> SelectionSet (List decodesTo) Cambiatus.Object.State
-cities object____ =
-    Object.selectionForCompositeField "cities" [] object____ (Basics.identity >> Decode.list)
+challenge : SelectionSet String Cambiatus.Object.PasskeyRegistrationChallenge
+challenge =
+    Object.selectionForField "String" "challenge" [] Decode.string
 
 
-id : SelectionSet Cambiatus.ScalarCodecs.Id Cambiatus.Object.State
-id =
-    Object.selectionForField "ScalarCodecs.Id" "id" [] (Cambiatus.ScalarCodecs.codecs |> Cambiatus.Scalar.unwrapCodecs |> .codecId |> .decoder)
-
-
-name : SelectionSet String Cambiatus.Object.State
-name =
-    Object.selectionForField "String" "name" [] Decode.string
+excludeCredentialIds : SelectionSet (List String) Cambiatus.Object.PasskeyRegistrationChallenge
+excludeCredentialIds =
+    Object.selectionForField "(List String)" "excludeCredentialIds" [] (Decode.string |> Decode.list)

--- a/src/elm/Cambiatus/Object/Product.elm
+++ b/src/elm/Cambiatus/Object/Product.elm
@@ -22,15 +22,15 @@ import Json.Decode as Decode
 categories :
     SelectionSet decodesTo Cambiatus.Object.Category
     -> SelectionSet (List decodesTo) Cambiatus.Object.Product
-categories object_ =
-    Object.selectionForCompositeField "categories" [] object_ (identity >> Decode.list)
+categories object____ =
+    Object.selectionForCompositeField "categories" [] object____ (Basics.identity >> Decode.list)
 
 
 community :
     SelectionSet decodesTo Cambiatus.Object.Community
     -> SelectionSet decodesTo Cambiatus.Object.Product
-community object_ =
-    Object.selectionForCompositeField "community" [] object_ identity
+community object____ =
+    Object.selectionForCompositeField "community" [] object____ Basics.identity
 
 
 communityId : SelectionSet String Cambiatus.Object.Product
@@ -41,8 +41,8 @@ communityId =
 creator :
     SelectionSet decodesTo Cambiatus.Object.User
     -> SelectionSet decodesTo Cambiatus.Object.Product
-creator object_ =
-    Object.selectionForCompositeField "creator" [] object_ identity
+creator object____ =
+    Object.selectionForCompositeField "creator" [] object____ Basics.identity
 
 
 creatorId : SelectionSet String Cambiatus.Object.Product
@@ -63,8 +63,8 @@ id =
 images :
     SelectionSet decodesTo Cambiatus.Object.ProductImage
     -> SelectionSet (List decodesTo) Cambiatus.Object.Product
-images object_ =
-    Object.selectionForCompositeField "images" [] object_ (identity >> Decode.list)
+images object____ =
+    Object.selectionForCompositeField "images" [] object____ (Basics.identity >> Decode.list)
 
 
 insertedAt : SelectionSet Cambiatus.ScalarCodecs.NaiveDateTime Cambiatus.Object.Product
@@ -75,8 +75,8 @@ insertedAt =
 orders :
     SelectionSet decodesTo Cambiatus.Object.Order
     -> SelectionSet (List decodesTo) Cambiatus.Object.Product
-orders object_ =
-    Object.selectionForCompositeField "orders" [] object_ (identity >> Decode.list)
+orders object____ =
+    Object.selectionForCompositeField "orders" [] object____ (Basics.identity >> Decode.list)
 
 
 price : SelectionSet Float Cambiatus.Object.Product

--- a/src/elm/Cambiatus/Object/ProductPreview.elm
+++ b/src/elm/Cambiatus/Object/ProductPreview.elm
@@ -22,8 +22,8 @@ import Json.Decode as Decode
 community :
     SelectionSet decodesTo Cambiatus.Object.CommunityPreview
     -> SelectionSet decodesTo Cambiatus.Object.ProductPreview
-community object_ =
-    Object.selectionForCompositeField "community" [] object_ identity
+community object____ =
+    Object.selectionForCompositeField "community" [] object____ Basics.identity
 
 
 communityId : SelectionSet String Cambiatus.Object.ProductPreview
@@ -49,8 +49,8 @@ id =
 images :
     SelectionSet decodesTo Cambiatus.Object.ProductImage
     -> SelectionSet (List decodesTo) Cambiatus.Object.ProductPreview
-images object_ =
-    Object.selectionForCompositeField "images" [] object_ (identity >> Decode.list)
+images object____ =
+    Object.selectionForCompositeField "images" [] object____ (Basics.identity >> Decode.list)
 
 
 price : SelectionSet Float Cambiatus.Object.ProductPreview

--- a/src/elm/Cambiatus/Object/Reward.elm
+++ b/src/elm/Cambiatus/Object/Reward.elm
@@ -22,12 +22,12 @@ import Json.Decode as Decode
 action :
     SelectionSet decodesTo Cambiatus.Object.Action
     -> SelectionSet decodesTo Cambiatus.Object.Reward
-action object_ =
-    Object.selectionForCompositeField "action" [] object_ identity
+action object____ =
+    Object.selectionForCompositeField "action" [] object____ Basics.identity
 
 
 receiver :
     SelectionSet decodesTo Cambiatus.Object.User
     -> SelectionSet decodesTo Cambiatus.Object.Reward
-receiver object_ =
-    Object.selectionForCompositeField "receiver" [] object_ identity
+receiver object____ =
+    Object.selectionForCompositeField "receiver" [] object____ Basics.identity

--- a/src/elm/Cambiatus/Object/SearchResult.elm
+++ b/src/elm/Cambiatus/Object/SearchResult.elm
@@ -27,16 +27,16 @@ actions :
     (ActionsOptionalArguments -> ActionsOptionalArguments)
     -> SelectionSet decodesTo Cambiatus.Object.Action
     -> SelectionSet (List decodesTo) Cambiatus.Object.SearchResult
-actions fillInOptionals object_ =
+actions fillInOptionals____ object____ =
     let
-        filledInOptionals =
-            fillInOptionals { query = Absent }
+        filledInOptionals____ =
+            fillInOptionals____ { query = Absent }
 
-        optionalArgs =
-            [ Argument.optional "query" filledInOptionals.query Encode.string ]
-                |> List.filterMap identity
+        optionalArgs____ =
+            [ Argument.optional "query" filledInOptionals____.query Encode.string ]
+                |> List.filterMap Basics.identity
     in
-    Object.selectionForCompositeField "actions" optionalArgs object_ (identity >> Decode.list)
+    Object.selectionForCompositeField "actions" optionalArgs____ object____ (Basics.identity >> Decode.list)
 
 
 type alias MembersOptionalArguments =
@@ -47,16 +47,16 @@ members :
     (MembersOptionalArguments -> MembersOptionalArguments)
     -> SelectionSet decodesTo Cambiatus.Object.User
     -> SelectionSet (List decodesTo) Cambiatus.Object.SearchResult
-members fillInOptionals object_ =
+members fillInOptionals____ object____ =
     let
-        filledInOptionals =
-            fillInOptionals { filters = Absent }
+        filledInOptionals____ =
+            fillInOptionals____ { filters = Absent }
 
-        optionalArgs =
-            [ Argument.optional "filters" filledInOptionals.filters Cambiatus.InputObject.encodeMembersFilterInput ]
-                |> List.filterMap identity
+        optionalArgs____ =
+            [ Argument.optional "filters" filledInOptionals____.filters Cambiatus.InputObject.encodeMembersFilterInput ]
+                |> List.filterMap Basics.identity
     in
-    Object.selectionForCompositeField "members" optionalArgs object_ (identity >> Decode.list)
+    Object.selectionForCompositeField "members" optionalArgs____ object____ (Basics.identity >> Decode.list)
 
 
 type alias ProductsOptionalArguments =
@@ -67,13 +67,13 @@ products :
     (ProductsOptionalArguments -> ProductsOptionalArguments)
     -> SelectionSet decodesTo Cambiatus.Object.Product
     -> SelectionSet (List decodesTo) Cambiatus.Object.SearchResult
-products fillInOptionals object_ =
+products fillInOptionals____ object____ =
     let
-        filledInOptionals =
-            fillInOptionals { query = Absent }
+        filledInOptionals____ =
+            fillInOptionals____ { query = Absent }
 
-        optionalArgs =
-            [ Argument.optional "query" filledInOptionals.query Encode.string ]
-                |> List.filterMap identity
+        optionalArgs____ =
+            [ Argument.optional "query" filledInOptionals____.query Encode.string ]
+                |> List.filterMap Basics.identity
     in
-    Object.selectionForCompositeField "products" optionalArgs object_ (identity >> Decode.list)
+    Object.selectionForCompositeField "products" optionalArgs____ object____ (Basics.identity >> Decode.list)

--- a/src/elm/Cambiatus/Object/Session.elm
+++ b/src/elm/Cambiatus/Object/Session.elm
@@ -27,5 +27,5 @@ token =
 user :
     SelectionSet decodesTo Cambiatus.Object.User
     -> SelectionSet decodesTo Cambiatus.Object.Session
-user object_ =
-    Object.selectionForCompositeField "user" [] object_ identity
+user object____ =
+    Object.selectionForCompositeField "user" [] object____ Basics.identity

--- a/src/elm/Cambiatus/Object/Transfer.elm
+++ b/src/elm/Cambiatus/Object/Transfer.elm
@@ -27,8 +27,8 @@ amount =
 community :
     SelectionSet decodesTo Cambiatus.Object.Community
     -> SelectionSet decodesTo Cambiatus.Object.Transfer
-community object_ =
-    Object.selectionForCompositeField "community" [] object_ identity
+community object____ =
+    Object.selectionForCompositeField "community" [] object____ Basics.identity
 
 
 communityId : SelectionSet String Cambiatus.Object.Transfer
@@ -59,8 +59,8 @@ createdTx =
 from :
     SelectionSet decodesTo Cambiatus.Object.User
     -> SelectionSet decodesTo Cambiatus.Object.Transfer
-from object_ =
-    Object.selectionForCompositeField "from" [] object_ identity
+from object____ =
+    Object.selectionForCompositeField "from" [] object____ Basics.identity
 
 
 fromId : SelectionSet String Cambiatus.Object.Transfer
@@ -81,8 +81,8 @@ memo =
 to :
     SelectionSet decodesTo Cambiatus.Object.User
     -> SelectionSet decodesTo Cambiatus.Object.Transfer
-to object_ =
-    Object.selectionForCompositeField "to" [] object_ identity
+to object____ =
+    Object.selectionForCompositeField "to" [] object____ Basics.identity
 
 
 toId : SelectionSet String Cambiatus.Object.Transfer

--- a/src/elm/Cambiatus/Object/TransferConnection.elm
+++ b/src/elm/Cambiatus/Object/TransferConnection.elm
@@ -27,12 +27,12 @@ count =
 edges :
     SelectionSet decodesTo Cambiatus.Object.TransferEdge
     -> SelectionSet (Maybe (List (Maybe decodesTo))) Cambiatus.Object.TransferConnection
-edges object_ =
-    Object.selectionForCompositeField "edges" [] object_ (identity >> Decode.nullable >> Decode.list >> Decode.nullable)
+edges object____ =
+    Object.selectionForCompositeField "edges" [] object____ (Basics.identity >> Decode.nullable >> Decode.list >> Decode.nullable)
 
 
 pageInfo :
     SelectionSet decodesTo Cambiatus.Object.PageInfo
     -> SelectionSet decodesTo Cambiatus.Object.TransferConnection
-pageInfo object_ =
-    Object.selectionForCompositeField "pageInfo" [] object_ identity
+pageInfo object____ =
+    Object.selectionForCompositeField "pageInfo" [] object____ Basics.identity

--- a/src/elm/Cambiatus/Object/TransferEdge.elm
+++ b/src/elm/Cambiatus/Object/TransferEdge.elm
@@ -27,5 +27,5 @@ cursor =
 node :
     SelectionSet decodesTo Cambiatus.Object.Transfer
     -> SelectionSet (Maybe decodesTo) Cambiatus.Object.TransferEdge
-node object_ =
-    Object.selectionForCompositeField "node" [] object_ (identity >> Decode.nullable)
+node object____ =
+    Object.selectionForCompositeField "node" [] object____ (Basics.identity >> Decode.nullable)

--- a/src/elm/Cambiatus/Object/User.elm
+++ b/src/elm/Cambiatus/Object/User.elm
@@ -29,8 +29,8 @@ account =
 address :
     SelectionSet decodesTo Cambiatus.Object.Address
     -> SelectionSet (Maybe decodesTo) Cambiatus.Object.User
-address object_ =
-    Object.selectionForCompositeField "address" [] object_ (identity >> Decode.nullable)
+address object____ =
+    Object.selectionForCompositeField "address" [] object____ (Basics.identity >> Decode.nullable)
 
 
 analysisCount : SelectionSet Int Cambiatus.Object.User
@@ -76,30 +76,30 @@ claims :
     (ClaimsOptionalArguments -> ClaimsOptionalArguments)
     -> SelectionSet decodesTo Cambiatus.Object.Claim
     -> SelectionSet (List decodesTo) Cambiatus.Object.User
-claims fillInOptionals object_ =
+claims fillInOptionals____ object____ =
     let
-        filledInOptionals =
-            fillInOptionals { communityId = Absent }
+        filledInOptionals____ =
+            fillInOptionals____ { communityId = Absent }
 
-        optionalArgs =
-            [ Argument.optional "communityId" filledInOptionals.communityId Encode.string ]
-                |> List.filterMap identity
+        optionalArgs____ =
+            [ Argument.optional "communityId" filledInOptionals____.communityId Encode.string ]
+                |> List.filterMap Basics.identity
     in
-    Object.selectionForCompositeField "claims" optionalArgs object_ (identity >> Decode.list)
+    Object.selectionForCompositeField "claims" optionalArgs____ object____ (Basics.identity >> Decode.list)
 
 
 communities :
     SelectionSet decodesTo Cambiatus.Object.Community
     -> SelectionSet (List decodesTo) Cambiatus.Object.User
-communities object_ =
-    Object.selectionForCompositeField "communities" [] object_ (identity >> Decode.list)
+communities object____ =
+    Object.selectionForCompositeField "communities" [] object____ (Basics.identity >> Decode.list)
 
 
 contacts :
     SelectionSet decodesTo Cambiatus.Object.Contact
     -> SelectionSet (List decodesTo) Cambiatus.Object.User
-contacts object_ =
-    Object.selectionForCompositeField "contacts" [] object_ (identity >> Decode.list)
+contacts object____ =
+    Object.selectionForCompositeField "contacts" [] object____ (Basics.identity >> Decode.list)
 
 
 type alias ContributionCountOptionalArguments =
@@ -114,16 +114,16 @@ type alias ContributionCountOptionalArguments =
 contributionCount :
     (ContributionCountOptionalArguments -> ContributionCountOptionalArguments)
     -> SelectionSet Int Cambiatus.Object.User
-contributionCount fillInOptionals =
+contributionCount fillInOptionals____ =
     let
-        filledInOptionals =
-            fillInOptionals { communityId = Absent }
+        filledInOptionals____ =
+            fillInOptionals____ { communityId = Absent }
 
-        optionalArgs =
-            [ Argument.optional "communityId" filledInOptionals.communityId Encode.string ]
-                |> List.filterMap identity
+        optionalArgs____ =
+            [ Argument.optional "communityId" filledInOptionals____.communityId Encode.string ]
+                |> List.filterMap Basics.identity
     in
-    Object.selectionForField "Int" "contributionCount" optionalArgs Decode.int
+    Object.selectionForField "Int" "contributionCount" optionalArgs____ Decode.int
 
 
 type alias ContributionsOptionalArguments =
@@ -136,16 +136,16 @@ contributions :
     (ContributionsOptionalArguments -> ContributionsOptionalArguments)
     -> SelectionSet decodesTo Cambiatus.Object.Contribution
     -> SelectionSet (List decodesTo) Cambiatus.Object.User
-contributions fillInOptionals object_ =
+contributions fillInOptionals____ object____ =
     let
-        filledInOptionals =
-            fillInOptionals { communityId = Absent, status = Absent }
+        filledInOptionals____ =
+            fillInOptionals____ { communityId = Absent, status = Absent }
 
-        optionalArgs =
-            [ Argument.optional "communityId" filledInOptionals.communityId Encode.string, Argument.optional "status" filledInOptionals.status (Encode.enum Cambiatus.Enum.ContributionStatusType.toString) ]
-                |> List.filterMap identity
+        optionalArgs____ =
+            [ Argument.optional "communityId" filledInOptionals____.communityId Encode.string, Argument.optional "status" filledInOptionals____.status (Encode.enum Cambiatus.Enum.ContributionStatusType.toString) ]
+                |> List.filterMap Basics.identity
     in
-    Object.selectionForCompositeField "contributions" optionalArgs object_ (identity >> Decode.list)
+    Object.selectionForCompositeField "contributions" optionalArgs____ object____ (Basics.identity >> Decode.list)
 
 
 createdAt : SelectionSet (Maybe String) Cambiatus.Object.User
@@ -183,8 +183,8 @@ getPayersByAccount :
     GetPayersByAccountRequiredArguments
     -> SelectionSet decodesTo Cambiatus.Object.User
     -> SelectionSet (Maybe (List (Maybe decodesTo))) Cambiatus.Object.User
-getPayersByAccount requiredArgs object_ =
-    Object.selectionForCompositeField "getPayersByAccount" [ Argument.required "account" requiredArgs.account Encode.string ] object_ (identity >> Decode.nullable >> Decode.list >> Decode.nullable)
+getPayersByAccount requiredArgs____ object____ =
+    Object.selectionForCompositeField "getPayersByAccount" [ Argument.required "account" requiredArgs____.account Encode.string ] object____ (Basics.identity >> Decode.nullable >> Decode.list >> Decode.nullable)
 
 
 interests : SelectionSet (Maybe String) Cambiatus.Object.User
@@ -195,13 +195,18 @@ interests =
 kyc :
     SelectionSet decodesTo Cambiatus.Object.KycData
     -> SelectionSet (Maybe decodesTo) Cambiatus.Object.User
-kyc object_ =
-    Object.selectionForCompositeField "kyc" [] object_ (identity >> Decode.nullable)
+kyc object____ =
+    Object.selectionForCompositeField "kyc" [] object____ (Basics.identity >> Decode.nullable)
 
 
 language : SelectionSet (Maybe Cambiatus.Enum.Language.Language) Cambiatus.Object.User
 language =
     Object.selectionForField "(Maybe Enum.Language.Language)" "language" [] (Cambiatus.Enum.Language.decoder |> Decode.nullable)
+
+
+lastSeen : SelectionSet (Maybe Cambiatus.ScalarCodecs.DateTime) Cambiatus.Object.User
+lastSeen =
+    Object.selectionForField "(Maybe ScalarCodecs.DateTime)" "lastSeen" [] (Cambiatus.ScalarCodecs.codecs |> Cambiatus.Scalar.unwrapCodecs |> .codecDateTime |> .decoder |> Decode.nullable)
 
 
 latestAcceptedTerms : SelectionSet (Maybe Cambiatus.ScalarCodecs.NaiveDateTime) Cambiatus.Object.User
@@ -227,22 +232,22 @@ name =
 network :
     SelectionSet decodesTo Cambiatus.Object.Network
     -> SelectionSet (Maybe (List (Maybe decodesTo))) Cambiatus.Object.User
-network object_ =
-    Object.selectionForCompositeField "network" [] object_ (identity >> Decode.nullable >> Decode.list >> Decode.nullable)
+network object____ =
+    Object.selectionForCompositeField "network" [] object____ (Basics.identity >> Decode.nullable >> Decode.list >> Decode.nullable)
 
 
 products :
     SelectionSet decodesTo Cambiatus.Object.Product
     -> SelectionSet (List (Maybe decodesTo)) Cambiatus.Object.User
-products object_ =
-    Object.selectionForCompositeField "products" [] object_ (identity >> Decode.nullable >> Decode.list)
+products object____ =
+    Object.selectionForCompositeField "products" [] object____ (Basics.identity >> Decode.nullable >> Decode.list)
 
 
 roles :
     SelectionSet decodesTo Cambiatus.Object.Role
     -> SelectionSet (List decodesTo) Cambiatus.Object.User
-roles object_ =
-    Object.selectionForCompositeField "roles" [] object_ (identity >> Decode.list)
+roles object____ =
+    Object.selectionForCompositeField "roles" [] object____ (Basics.identity >> Decode.list)
 
 
 transferNotification : SelectionSet Bool Cambiatus.Object.User
@@ -268,13 +273,13 @@ transfers :
     (TransfersOptionalArguments -> TransfersOptionalArguments)
     -> SelectionSet decodesTo Cambiatus.Object.TransferConnection
     -> SelectionSet (Maybe decodesTo) Cambiatus.Object.User
-transfers fillInOptionals object_ =
+transfers fillInOptionals____ object____ =
     let
-        filledInOptionals =
-            fillInOptionals { after = Absent, before = Absent, filter = Absent, first = Absent, last = Absent }
+        filledInOptionals____ =
+            fillInOptionals____ { after = Absent, before = Absent, filter = Absent, first = Absent, last = Absent }
 
-        optionalArgs =
-            [ Argument.optional "after" filledInOptionals.after Encode.string, Argument.optional "before" filledInOptionals.before Encode.string, Argument.optional "filter" filledInOptionals.filter Cambiatus.InputObject.encodeTransferFilter, Argument.optional "first" filledInOptionals.first Encode.int, Argument.optional "last" filledInOptionals.last Encode.int ]
-                |> List.filterMap identity
+        optionalArgs____ =
+            [ Argument.optional "after" filledInOptionals____.after Encode.string, Argument.optional "before" filledInOptionals____.before Encode.string, Argument.optional "filter" filledInOptionals____.filter Cambiatus.InputObject.encodeTransferFilter, Argument.optional "first" filledInOptionals____.first Encode.int, Argument.optional "last" filledInOptionals____.last Encode.int ]
+                |> List.filterMap Basics.identity
     in
-    Object.selectionForCompositeField "transfers" optionalArgs object_ (identity >> Decode.nullable)
+    Object.selectionForCompositeField "transfers" optionalArgs____ object____ (Basics.identity >> Decode.nullable)

--- a/src/elm/Cambiatus/Query.elm
+++ b/src/elm/Cambiatus/Query.elm
@@ -32,16 +32,16 @@ analyzedClaims :
     (AnalyzedClaimsOptionalArguments -> AnalyzedClaimsOptionalArguments)
     -> SelectionSet decodesTo Cambiatus.Object.ClaimConnection
     -> SelectionSet (Maybe decodesTo) RootQuery
-analyzedClaims fillInOptionals object_ =
+analyzedClaims fillInOptionals____ object____ =
     let
-        filledInOptionals =
-            fillInOptionals { after = Absent, before = Absent, filter = Absent, first = Absent, last = Absent }
+        filledInOptionals____ =
+            fillInOptionals____ { after = Absent, before = Absent, filter = Absent, first = Absent, last = Absent }
 
-        optionalArgs =
-            [ Argument.optional "after" filledInOptionals.after Encode.string, Argument.optional "before" filledInOptionals.before Encode.string, Argument.optional "filter" filledInOptionals.filter Cambiatus.InputObject.encodeClaimsFilter, Argument.optional "first" filledInOptionals.first Encode.int, Argument.optional "last" filledInOptionals.last Encode.int ]
-                |> List.filterMap identity
+        optionalArgs____ =
+            [ Argument.optional "after" filledInOptionals____.after Encode.string, Argument.optional "before" filledInOptionals____.before Encode.string, Argument.optional "filter" filledInOptionals____.filter Cambiatus.InputObject.encodeClaimsFilter, Argument.optional "first" filledInOptionals____.first Encode.int, Argument.optional "last" filledInOptionals____.last Encode.int ]
+                |> List.filterMap Basics.identity
     in
-    Object.selectionForCompositeField "analyzedClaims" optionalArgs object_ (identity >> Decode.nullable)
+    Object.selectionForCompositeField "analyzedClaims" optionalArgs____ object____ (Basics.identity >> Decode.nullable)
 
 
 type alias ClaimRequiredArguments =
@@ -54,8 +54,8 @@ claim :
     ClaimRequiredArguments
     -> SelectionSet decodesTo Cambiatus.Object.Claim
     -> SelectionSet decodesTo RootQuery
-claim requiredArgs object_ =
-    Object.selectionForCompositeField "claim" [ Argument.required "id" requiredArgs.id Encode.int ] object_ identity
+claim requiredArgs____ object____ =
+    Object.selectionForCompositeField "claim" [ Argument.required "id" requiredArgs____.id Encode.int ] object____ Basics.identity
 
 
 {-| [Auth required] A list of communities in Cambiatus
@@ -63,8 +63,8 @@ claim requiredArgs object_ =
 communities :
     SelectionSet decodesTo Cambiatus.Object.Community
     -> SelectionSet (List decodesTo) RootQuery
-communities object_ =
-    Object.selectionForCompositeField "communities" [] object_ (identity >> Decode.list)
+communities object____ =
+    Object.selectionForCompositeField "communities" [] object____ (Basics.identity >> Decode.list)
 
 
 type alias CommunityOptionalArguments =
@@ -79,16 +79,16 @@ community :
     (CommunityOptionalArguments -> CommunityOptionalArguments)
     -> SelectionSet decodesTo Cambiatus.Object.Community
     -> SelectionSet (Maybe decodesTo) RootQuery
-community fillInOptionals object_ =
+community fillInOptionals____ object____ =
     let
-        filledInOptionals =
-            fillInOptionals { subdomain = Absent, symbol = Absent }
+        filledInOptionals____ =
+            fillInOptionals____ { subdomain = Absent, symbol = Absent }
 
-        optionalArgs =
-            [ Argument.optional "subdomain" filledInOptionals.subdomain Encode.string, Argument.optional "symbol" filledInOptionals.symbol Encode.string ]
-                |> List.filterMap identity
+        optionalArgs____ =
+            [ Argument.optional "subdomain" filledInOptionals____.subdomain Encode.string, Argument.optional "symbol" filledInOptionals____.symbol Encode.string ]
+                |> List.filterMap Basics.identity
     in
-    Object.selectionForCompositeField "community" optionalArgs object_ (identity >> Decode.nullable)
+    Object.selectionForCompositeField "community" optionalArgs____ object____ (Basics.identity >> Decode.nullable)
 
 
 type alias CommunityPreviewOptionalArguments =
@@ -103,16 +103,16 @@ communityPreview :
     (CommunityPreviewOptionalArguments -> CommunityPreviewOptionalArguments)
     -> SelectionSet decodesTo Cambiatus.Object.CommunityPreview
     -> SelectionSet (Maybe decodesTo) RootQuery
-communityPreview fillInOptionals object_ =
+communityPreview fillInOptionals____ object____ =
     let
-        filledInOptionals =
-            fillInOptionals { subdomain = Absent, symbol = Absent }
+        filledInOptionals____ =
+            fillInOptionals____ { subdomain = Absent, symbol = Absent }
 
-        optionalArgs =
-            [ Argument.optional "subdomain" filledInOptionals.subdomain Encode.string, Argument.optional "symbol" filledInOptionals.symbol Encode.string ]
-                |> List.filterMap identity
+        optionalArgs____ =
+            [ Argument.optional "subdomain" filledInOptionals____.subdomain Encode.string, Argument.optional "symbol" filledInOptionals____.symbol Encode.string ]
+                |> List.filterMap Basics.identity
     in
-    Object.selectionForCompositeField "communityPreview" optionalArgs object_ (identity >> Decode.nullable)
+    Object.selectionForCompositeField "communityPreview" optionalArgs____ object____ (Basics.identity >> Decode.nullable)
 
 
 type alias CountryRequiredArguments =
@@ -125,8 +125,8 @@ country :
     CountryRequiredArguments
     -> SelectionSet decodesTo Cambiatus.Object.Country
     -> SelectionSet (Maybe decodesTo) RootQuery
-country requiredArgs object_ =
-    Object.selectionForCompositeField "country" [ Argument.required "input" requiredArgs.input Cambiatus.InputObject.encodeCountryInput ] object_ (identity >> Decode.nullable)
+country requiredArgs____ object____ =
+    Object.selectionForCompositeField "country" [ Argument.required "input" requiredArgs____.input Cambiatus.InputObject.encodeCountryInput ] object____ (Basics.identity >> Decode.nullable)
 
 
 type alias DomainAvailableRequiredArguments =
@@ -139,8 +139,24 @@ domainAvailable :
     DomainAvailableRequiredArguments
     -> SelectionSet decodesTo Cambiatus.Object.Exists
     -> SelectionSet (Maybe decodesTo) RootQuery
-domainAvailable requiredArgs object_ =
-    Object.selectionForCompositeField "domainAvailable" [ Argument.required "domain" requiredArgs.domain Encode.string ] object_ (identity >> Decode.nullable)
+domainAvailable requiredArgs____ object____ =
+    Object.selectionForCompositeField "domainAvailable" [ Argument.required "domain" requiredArgs____.domain Encode.string ] object____ (Basics.identity >> Decode.nullable)
+
+
+type alias FetchEncryptedMnemonicRequiredArguments =
+    { account : String
+    , credentialId : Cambiatus.ScalarCodecs.Id
+    }
+
+
+{-| [Auth required] Fetch the encrypted mnemonic blob for a specific passkey credential
+-}
+fetchEncryptedMnemonic :
+    FetchEncryptedMnemonicRequiredArguments
+    -> SelectionSet decodesTo Cambiatus.Object.EncryptedMnemonicResult
+    -> SelectionSet (Maybe decodesTo) RootQuery
+fetchEncryptedMnemonic requiredArgs____ object____ =
+    Object.selectionForCompositeField "fetchEncryptedMnemonic" [ Argument.required "account" requiredArgs____.account Encode.string, Argument.required "credentialId" requiredArgs____.credentialId (Cambiatus.ScalarCodecs.codecs |> Cambiatus.Scalar.unwrapEncoder .codecId) ] object____ (Basics.identity >> Decode.nullable)
 
 
 type alias InviteRequiredArguments =
@@ -153,8 +169,8 @@ invite :
     InviteRequiredArguments
     -> SelectionSet decodesTo Cambiatus.Object.Invite
     -> SelectionSet (Maybe decodesTo) RootQuery
-invite requiredArgs object_ =
-    Object.selectionForCompositeField "invite" [ Argument.required "id" requiredArgs.id Encode.string ] object_ (identity >> Decode.nullable)
+invite requiredArgs____ object____ =
+    Object.selectionForCompositeField "invite" [ Argument.required "id" requiredArgs____.id Encode.string ] object____ (Basics.identity >> Decode.nullable)
 
 
 type alias NewsRequiredArguments =
@@ -167,8 +183,8 @@ news :
     NewsRequiredArguments
     -> SelectionSet decodesTo Cambiatus.Object.News
     -> SelectionSet (Maybe decodesTo) RootQuery
-news requiredArgs object_ =
-    Object.selectionForCompositeField "news" [ Argument.required "newsId" requiredArgs.newsId Encode.int ] object_ (identity >> Decode.nullable)
+news requiredArgs____ object____ =
+    Object.selectionForCompositeField "news" [ Argument.required "newsId" requiredArgs____.newsId Encode.int ] object____ (Basics.identity >> Decode.nullable)
 
 
 {-| [Auth required] User's notifications
@@ -176,8 +192,8 @@ news requiredArgs object_ =
 notificationHistory :
     SelectionSet decodesTo Cambiatus.Object.NotificationHistory
     -> SelectionSet (List decodesTo) RootQuery
-notificationHistory object_ =
-    Object.selectionForCompositeField "notificationHistory" [] object_ (identity >> Decode.list)
+notificationHistory object____ =
+    Object.selectionForCompositeField "notificationHistory" [] object____ (Basics.identity >> Decode.list)
 
 
 type alias ObjectiveRequiredArguments =
@@ -190,8 +206,8 @@ objective :
     ObjectiveRequiredArguments
     -> SelectionSet decodesTo Cambiatus.Object.Objective
     -> SelectionSet (Maybe decodesTo) RootQuery
-objective requiredArgs object_ =
-    Object.selectionForCompositeField "objective" [ Argument.required "id" requiredArgs.id Encode.int ] object_ (identity >> Decode.nullable)
+objective requiredArgs____ object____ =
+    Object.selectionForCompositeField "objective" [ Argument.required "id" requiredArgs____.id Encode.int ] object____ (Basics.identity >> Decode.nullable)
 
 
 type alias PendingClaimsOptionalArguments =
@@ -209,16 +225,16 @@ pendingClaims :
     (PendingClaimsOptionalArguments -> PendingClaimsOptionalArguments)
     -> SelectionSet decodesTo Cambiatus.Object.ClaimConnection
     -> SelectionSet (Maybe decodesTo) RootQuery
-pendingClaims fillInOptionals object_ =
+pendingClaims fillInOptionals____ object____ =
     let
-        filledInOptionals =
-            fillInOptionals { after = Absent, before = Absent, filter = Absent, first = Absent, last = Absent }
+        filledInOptionals____ =
+            fillInOptionals____ { after = Absent, before = Absent, filter = Absent, first = Absent, last = Absent }
 
-        optionalArgs =
-            [ Argument.optional "after" filledInOptionals.after Encode.string, Argument.optional "before" filledInOptionals.before Encode.string, Argument.optional "filter" filledInOptionals.filter Cambiatus.InputObject.encodeClaimsFilter, Argument.optional "first" filledInOptionals.first Encode.int, Argument.optional "last" filledInOptionals.last Encode.int ]
-                |> List.filterMap identity
+        optionalArgs____ =
+            [ Argument.optional "after" filledInOptionals____.after Encode.string, Argument.optional "before" filledInOptionals____.before Encode.string, Argument.optional "filter" filledInOptionals____.filter Cambiatus.InputObject.encodeClaimsFilter, Argument.optional "first" filledInOptionals____.first Encode.int, Argument.optional "last" filledInOptionals____.last Encode.int ]
+                |> List.filterMap Basics.identity
     in
-    Object.selectionForCompositeField "pendingClaims" optionalArgs object_ (identity >> Decode.nullable)
+    Object.selectionForCompositeField "pendingClaims" optionalArgs____ object____ (Basics.identity >> Decode.nullable)
 
 
 type alias ProductRequiredArguments =
@@ -231,8 +247,8 @@ product :
     ProductRequiredArguments
     -> SelectionSet decodesTo Cambiatus.Object.Product
     -> SelectionSet (Maybe decodesTo) RootQuery
-product requiredArgs object_ =
-    Object.selectionForCompositeField "product" [ Argument.required "id" requiredArgs.id Encode.int ] object_ (identity >> Decode.nullable)
+product requiredArgs____ object____ =
+    Object.selectionForCompositeField "product" [ Argument.required "id" requiredArgs____.id Encode.int ] object____ (Basics.identity >> Decode.nullable)
 
 
 type alias ProductPreviewRequiredArguments =
@@ -245,8 +261,8 @@ productPreview :
     ProductPreviewRequiredArguments
     -> SelectionSet decodesTo Cambiatus.Object.ProductPreview
     -> SelectionSet decodesTo RootQuery
-productPreview requiredArgs object_ =
-    Object.selectionForCompositeField "productPreview" [ Argument.required "id" requiredArgs.id Encode.int ] object_ identity
+productPreview requiredArgs____ object____ =
+    Object.selectionForCompositeField "productPreview" [ Argument.required "id" requiredArgs____.id Encode.int ] object____ Basics.identity
 
 
 type alias ProductsOptionalArguments =
@@ -259,16 +275,16 @@ products :
     (ProductsOptionalArguments -> ProductsOptionalArguments)
     -> SelectionSet decodesTo Cambiatus.Object.Product
     -> SelectionSet (List decodesTo) RootQuery
-products fillInOptionals object_ =
+products fillInOptionals____ object____ =
     let
-        filledInOptionals =
-            fillInOptionals { filters = Absent }
+        filledInOptionals____ =
+            fillInOptionals____ { filters = Absent }
 
-        optionalArgs =
-            [ Argument.optional "filters" filledInOptionals.filters Cambiatus.InputObject.encodeProductsFilterInput ]
-                |> List.filterMap identity
+        optionalArgs____ =
+            [ Argument.optional "filters" filledInOptionals____.filters Cambiatus.InputObject.encodeProductsFilterInput ]
+                |> List.filterMap Basics.identity
     in
-    Object.selectionForCompositeField "products" optionalArgs object_ (identity >> Decode.list)
+    Object.selectionForCompositeField "products" optionalArgs____ object____ (Basics.identity >> Decode.list)
 
 
 {-| [Auth required] Searches the community for a product or action
@@ -276,8 +292,8 @@ products fillInOptionals object_ =
 search :
     SelectionSet decodesTo Cambiatus.Object.SearchResult
     -> SelectionSet decodesTo RootQuery
-search object_ =
-    Object.selectionForCompositeField "search" [] object_ identity
+search object____ =
+    Object.selectionForCompositeField "search" [] object____ Basics.identity
 
 
 type alias TransferRequiredArguments =
@@ -290,8 +306,8 @@ transfer :
     TransferRequiredArguments
     -> SelectionSet decodesTo Cambiatus.Object.Transfer
     -> SelectionSet (Maybe decodesTo) RootQuery
-transfer requiredArgs object_ =
-    Object.selectionForCompositeField "transfer" [ Argument.required "id" requiredArgs.id Encode.int ] object_ (identity >> Decode.nullable)
+transfer requiredArgs____ object____ =
+    Object.selectionForCompositeField "transfer" [ Argument.required "id" requiredArgs____.id Encode.int ] object____ (Basics.identity >> Decode.nullable)
 
 
 type alias UserRequiredArguments =
@@ -304,5 +320,5 @@ user :
     UserRequiredArguments
     -> SelectionSet decodesTo Cambiatus.Object.User
     -> SelectionSet (Maybe decodesTo) RootQuery
-user requiredArgs object_ =
-    Object.selectionForCompositeField "user" [ Argument.required "account" requiredArgs.account Encode.string ] object_ (identity >> Decode.nullable)
+user requiredArgs____ object____ =
+    Object.selectionForCompositeField "user" [ Argument.required "account" requiredArgs____.account Encode.string ] object____ (Basics.identity >> Decode.nullable)

--- a/src/elm/Cambiatus/Scalar.elm
+++ b/src/elm/Cambiatus/Scalar.elm
@@ -50,6 +50,11 @@ unwrapCodecs (Codecs unwrappedCodecs) =
     unwrappedCodecs
 
 
+unwrapEncoder :
+    (RawCodecs valueDate valueDateTime valueId valueNaiveDateTime -> Codec getterValue)
+    -> Codecs valueDate valueDateTime valueId valueNaiveDateTime
+    -> getterValue
+    -> Graphql.Internal.Encode.Value
 unwrapEncoder getter (Codecs unwrappedCodecs) =
     (unwrappedCodecs |> getter |> .encoder) >> Graphql.Internal.Encode.fromJson
 

--- a/src/elm/Cambiatus/Subscription.elm
+++ b/src/elm/Cambiatus/Subscription.elm
@@ -24,8 +24,8 @@ import Json.Decode as Decode exposing (Decoder)
 highlightedNews :
     SelectionSet decodesTo Cambiatus.Object.News
     -> SelectionSet (Maybe decodesTo) RootSubscription
-highlightedNews object_ =
-    Object.selectionForCompositeField "highlightedNews" [] object_ (identity >> Decode.nullable)
+highlightedNews object____ =
+    Object.selectionForCompositeField "highlightedNews" [] object____ (Basics.identity >> Decode.nullable)
 
 
 type alias NewcommunityRequiredArguments =
@@ -38,8 +38,8 @@ newcommunity :
     NewcommunityRequiredArguments
     -> SelectionSet decodesTo Cambiatus.Object.Community
     -> SelectionSet decodesTo RootSubscription
-newcommunity requiredArgs object_ =
-    Object.selectionForCompositeField "newcommunity" [ Argument.required "input" requiredArgs.input Cambiatus.InputObject.encodeNewCommunityInput ] object_ identity
+newcommunity requiredArgs____ object____ =
+    Object.selectionForCompositeField "newcommunity" [ Argument.required "input" requiredArgs____.input Cambiatus.InputObject.encodeNewCommunityInput ] object____ Basics.identity
 
 
 type alias TransfersucceedRequiredArguments =
@@ -50,8 +50,8 @@ transfersucceed :
     TransfersucceedRequiredArguments
     -> SelectionSet decodesTo Cambiatus.Object.Transfer
     -> SelectionSet decodesTo RootSubscription
-transfersucceed requiredArgs object_ =
-    Object.selectionForCompositeField "transfersucceed" [ Argument.required "input" requiredArgs.input Cambiatus.InputObject.encodeTransferSucceedInput ] object_ identity
+transfersucceed requiredArgs____ object____ =
+    Object.selectionForCompositeField "transfersucceed" [ Argument.required "input" requiredArgs____.input Cambiatus.InputObject.encodeTransferSucceedInput ] object____ Basics.identity
 
 
 type alias UnreadsRequiredArguments =
@@ -64,5 +64,5 @@ unreads :
     UnreadsRequiredArguments
     -> SelectionSet decodesTo Cambiatus.Object.UnreadNotifications
     -> SelectionSet decodesTo RootSubscription
-unreads requiredArgs object_ =
-    Object.selectionForCompositeField "unreads" [ Argument.required "input" requiredArgs.input Cambiatus.InputObject.encodeUnreadNotificationsSubscriptionInput ] object_ identity
+unreads requiredArgs____ object____ =
+    Object.selectionForCompositeField "unreads" [ Argument.required "input" requiredArgs____.input Cambiatus.InputObject.encodeUnreadNotificationsSubscriptionInput ] object____ Basics.identity

--- a/src/elm/Cambiatus/Union/NotificationType.elm
+++ b/src/elm/Cambiatus/Union/NotificationType.elm
@@ -31,11 +31,11 @@ type alias Fragments decodesTo =
 fragments :
     Fragments decodesTo
     -> SelectionSet decodesTo Cambiatus.Union.NotificationType
-fragments selections =
+fragments selections____ =
     Object.exhaustiveFragmentSelection
-        [ Object.buildFragment "Mint" selections.onMint
-        , Object.buildFragment "Order" selections.onOrder
-        , Object.buildFragment "Transfer" selections.onTransfer
+        [ Object.buildFragment "Mint" selections____.onMint
+        , Object.buildFragment "Order" selections____.onOrder
+        , Object.buildFragment "Transfer" selections____.onTransfer
         ]
 
 

--- a/src/elm/Cambiatus/elm-graphql-metadata.json
+++ b/src/elm/Cambiatus/elm-graphql-metadata.json
@@ -1,1 +1,1 @@
-{"targetElmPackageVersion": "5.0.0", "generatedByNpmPackageVersion": "4.0.3"}
+{"targetElmPackageVersion": "5.0.12", "generatedByNpmPackageVersion": "4.3.2"}


### PR DESCRIPTION
## What

Regenerate `src/elm/Cambiatus/` with `@dillonkearns/elm-graphql`. The types were last refreshed in 2022 (#786) and had drifted from the live backend.

Regenerated against **prod** (`app.cambiatus.io/api/graph`) because the staging graph endpoint was unreachable at the time.

## Why

Schema drift broke runtime decoding — most visibly the `Permission` enum missing `ADMIN`, which failed signIn decoding for admin users (hotfixed in #984; this supersedes that patch with the generated version).

## Scope / safety

- 53 modified + 4 new files (`EncryptedMnemonicResult`, `PasskeyAssertionChallenge`, `PasskeyCredential`, `PasskeyRegistrationChallenge`).
- Additive/compatible: **`yarn build` compiles clean** (no selection-set breakage), `elm-format --validate` passes.
- elm-test not run locally (`elmi-to-json` has no darwin-arm64 binary); CI covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)