### PR TITLE
fix(sw): self-heal stale service worker caches

### DIFF
--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,32 +1,41 @@
-var CACHE_NAME = 'bes-site-cache-v1-hotfix'
+/* global self, caches */
 
-// See https://github.com/cambiatus/frontend/issues/252 for the details
-var urlsToCache = []
-self.caches.delete('bes-site-cache-v1')
+// Self-healing service worker. See https://github.com/cambiatus/frontend/issues/252
+//
+// Old versions precached the app shell. After a deploy the hashed asset names
+// change, so a client serving the stale cached index.html requested JS that no
+// longer existed (404) and froze on the splash screen — most visibly in Safari.
+// This SW caches nothing, purges every previous cache, takes control of open
+// tabs immediately, and reloads any window still running the stale bundle, so
+// users recover automatically without clearing site data by hand.
 
-// install event handler here setup our local landscape
 self.addEventListener('install', function (event) {
+  // Replace the old SW as soon as this one installs.
   self.skipWaiting()
+})
+
+self.addEventListener('activate', function (event) {
   event.waitUntil(
-    caches.open(CACHE_NAME)
-      .then(function (cache) {
-        return cache.addAll(urlsToCache)
+    (async function () {
+      // Drop every cache left behind by any previous SW version.
+      const names = await caches.keys()
+      await Promise.all(names.map(function (name) { return caches.delete(name) }))
+
+      // Control already-open tabs without waiting for a reload.
+      await self.clients.claim()
+
+      // Reload any window still showing the stale, frozen bundle so it fetches
+      // the live assets from the network.
+      const windows = await self.clients.matchAll({ type: 'window' })
+      windows.forEach(function (client) {
+        if ('navigate' in client) { client.navigate(client.url) }
       })
+    })()
   )
 })
 
-/* global self, caches, fetch  */
-// fetch handler
-self.addEventListener('fetch', function (event) {
-  event.respondWith(
-    caches.match(event.request).then(function (response) {
-      if (response) {
-        return response
-      }
-      return fetch(event.request)
-    })
-  )
-})
+// No fetch handler: never serve app assets from cache. Requests go straight to
+// the network (HTTP caching still applies); the SW exists only for push.
 
 // Configure push eventListener to handle C2DM messages
 self.addEventListener('push', function (event) {


### PR DESCRIPTION
## Problem

User on Safari stuck on the splash screen — Cambiatus logo rendered oversized (CSS never applied), app never boots. Not an auth issue.

Root cause: older service worker versions precached the app shell. After a frontend deploy the hashed asset filenames change, so a client still serving the **cached** `index.html` requests JS chunks that no longer exist (404). Elm never boots → splash frozen, logo unstyled. Safari is especially sticky about picking up SW updates, so affected users would otherwise have to manually clear site data (Settings → Safari → … → Website Data) to recover.

The current live SW already caches nothing + `skipWaiting()`, but it lacks `clients.claim()`, doesn't purge *all* old caches, and never reloads the already-frozen tab — so a wedged client only recovers on a manual reload.

## Fix

`public/service-worker.js`:
- **install** → `skipWaiting()`
- **activate** → delete *every* existing cache, `clients.claim()`, and reload any open window via `client.navigate(client.url)` so a frozen tab self-recovers
- **removed** the cache-first `fetch` handler — requests go straight to the network (HTTP caching still applies); the SW remains only for push notifications

## How it reaches affected users

Browsers re-fetch `service-worker.js` from the network (bypassing the SW cache) on navigation. After deploy, the next time a user opens/reloads the app, the new SW installs → activates → purges old cache, claims the tab, auto-reloads → app boots on live assets. No manual cache clearing.

## Validation

- Build + checks via GHA on this PR.
- Push handlers (`push`, `notificationclick`) left unchanged.

Refs #252

🤖 Generated with [Claude Code](https://claude.com/claude-code)